### PR TITLE
disable erosion when pure WFA is performed

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -495,7 +495,7 @@ void WFlign::wflign_affine_wavefront(
                 mashmap_estimated_identity,
                 wflign_max_len_major,
                 wflign_max_len_minor,
-                erode_k,
+                0, // Erosion is disabled, because standard WFA was performed on the whole mapping
                 MIN_WF_LENGTH,
                 wf_max_dist_threshold
 #ifdef WFA_PNG_AND_TSV


### PR DESCRIPTION
When we perform the standard/exact WFA algorithm, we do not need to erode the CIGAR string, as we already have the exact alignment across the whole mapping.

This improves the accuracy and the runtime for short/medium sequences.