### PR TITLE
disable middle patching when standard WFA is performed

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -12,8 +12,8 @@ namespace wavefront {
 /*
 * Configuration
 */
-#define MAX_LEN_FOR_PURE_WFA    25000 // == default --block-length. Only for low-divergence, otherwise disabled
-#define MIN_WF_LENGTH           256
+#define MAX_LEN_FOR_STANDARD_WFA 25000 // default --block-length. Only for low-divergence, otherwise disabled
+#define MIN_WF_LENGTH            256
 
 /*
 * Utils
@@ -391,10 +391,8 @@ void WFlign::wflign_affine_wavefront(
     if (
             (query_length <= segment_length * 8 || target_length <= segment_length * 8) ||
             (mashmap_estimated_identity >= 0.99
-             && query_length <= MAX_LEN_FOR_PURE_WFA && target_length <= MAX_LEN_FOR_PURE_WFA)
+             && query_length <= MAX_LEN_FOR_STANDARD_WFA && target_length <= MAX_LEN_FOR_STANDARD_WFA)
             ) {
-        uint64_t num_alignments = 0;
-        uint64_t num_alignments_performed = 0;
         wfa::WFAlignerGapAffine* wf_aligner =
                 new wfa::WFAlignerGapAffine(
                         wfa_affine_penalties.mismatch,
@@ -446,9 +444,6 @@ void WFlign::wflign_affine_wavefront(
     #endif
         }
 
-        ++num_alignments;
-        ++num_alignments_performed;
-
         trace.push_back(aln);
 
         const long elapsed_time_wflambda_ms =
@@ -487,15 +482,15 @@ void WFlign::wflign_affine_wavefront(
                 target_total_length,
                 target_offset,
                 target_length,
-                MAX_LEN_FOR_PURE_WFA,
+                MAX_LEN_FOR_STANDARD_WFA,
                 min_identity,
                 elapsed_time_wflambda_ms,
-                num_alignments,
-                num_alignments_performed,
+                1,
+                1,
                 mashmap_estimated_identity,
                 wflign_max_len_major,
                 wflign_max_len_minor,
-                0, // Erosion is disabled, because standard WFA was performed on the whole mapping
+                0, // Erosion and middle patching are disabled, because standard WFA was performed on the whole mapping
                 MIN_WF_LENGTH,
                 wf_max_dist_threshold
 #ifdef WFA_PNG_AND_TSV

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -371,6 +371,7 @@ void write_merged_alignment(
                 &segment_length,
                 &wflign_max_len_major,
                 &wflign_max_len_minor,
+                &erode_k,
                 &distance_close_big_enough_indels, &min_wf_length,
                 &max_dist_threshold, &wf_aligner,
                 &affine_penalties](std::vector<char> &unpatched,
@@ -588,389 +589,373 @@ void write_merged_alignment(
             }
 
             // Patching in the middle
-            // get to the first match ... we'll not yet try to patch the
-            // alignment tips
-            while (q != unpatched.end()) {
-                while (q != unpatched.end() && (*q == 'M' || *q == 'X')) {
-                    /*
-                    std::cerr << "q: " << query[query_pos] << " "
-                    << "t: " << target[target_pos - target_pointer_shift] <<
-                    std::endl;
-                    */
-                    if (query_pos >= query_length ||
-                        target_pos >= target_length_mut) {
-                        std::cerr << "[wflign::wflign_affine_wavefront] "
-                                     "corrupted traceback (out of bounds) for "
-                                  << query_name << " " << query_offset << " "
-                                  << target_name << " " << target_offset
-                                  << std::endl;
-                        exit(1);
-                    }
-
-                    if (*q == 'M') {
-                        if (query[query_pos] !=
-                            target[target_pos - target_pointer_shift]) {
-                            std::cerr << "[wflign::wflign_affine_wavefront] "
-                                         "corrupted traceback (M, but there is "
-                                         "a mismatch) for "
-                                      << query_name << " " << query_offset
-                                      << " " << target_name << " "
-                                      << target_offset << std::endl;
-                            exit(1);
-                        }
-                    } else {
-                        if (query[query_pos] ==
-                            target[target_pos - target_pointer_shift]) {
-                            std::cerr << "[wflign::wflign_affine_wavefront] "
-                                         "corrupted traceback (X, but there is "
-                                         "a match) for "
-                                      << query_name << " " << query_offset
-                                      << " " << target_name << " "
-                                      << target_offset << std::endl;
-                            exit(1);
-                        }
-                    }
-
-                    patched.push_back(*q);
-                    ++query_pos;
-                    ++target_pos;
-                    ++q;
-                }
-
-                // how long a gap?
-                while (q != unpatched.end() && *q == 'I') {
-                    ++query_delta;
-                    ++q;
-                }
-                while (q != unpatched.end() && *q == 'D') {
-                    ++target_delta;
-                    ++q;
-                }
-
-                // how long was our last gap?
-                // if it's long enough, patch it
-                int32_t size_region_to_repatch = 0;
-
-                do {
-                    got_alignment = false;
-
-                    if ((size_region_to_repatch > 0 ||
-                        (query_delta > 0 && target_delta > 0) ||
-                        (query_delta > 2 || target_delta > 2) &&
-                        (query_delta < wflign_max_len_major &&
-                         target_delta < wflign_max_len_major) &&
-                        (query_delta < wflign_max_len_minor ||
-                         target_delta < wflign_max_len_minor))) {
-
-                        // TODO this should only happen if we're at >99% identity
-                        int32_t distance_close_indels = -1;
+            if (erode_k > 0) {
+                while (q != unpatched.end()) {
+                    // get to the first match
+                    while (q != unpatched.end() && (*q == 'M' || *q == 'X')) {
                         /*
-                        int32_t distance_close_indels = (query_delta > 3 || target_delta > 3) ?
-                                                        distance_close_big_enough_indels(std::max(query_delta, target_delta), q, unpatched) :
-                                                        -1;
-                        */
-
-                        // std::cerr << "distance_close_indels " <<
-                        // distance_close_indels << std::endl;
-                        // Trigger the patching if there is a dropout
-                        // (consecutive Is and Ds) or if there is a close and
-                        // big enough indel forward
-                        if (size_region_to_repatch > 0 ||
-                            (query_delta > 0 && target_delta > 0) ||
-                            (distance_close_indels > 0)) {
-#ifdef WFLIGN_DEBUG
-                            // std::cerr << "query_delta " << query_delta <<
-                            // "\n"; std::cerr << "target_delta " << target_delta
-                            // << "\n"; std::cerr << "distance_close_indel " <<
-                            // distance_close_indel << "\n";
-
-                            std::cerr << "[wflign::wflign_affine_wavefront] "
-                                         "patching in "
-                                      << query_name << " " << query_offset
-                                      << " @ " << query_pos << " - "
-                                      << query_delta << " " << target_name
-                                      << " " << target_offset << " @ "
-                                      << target_pos << " - " << target_delta
-                                      << std::endl;
-#endif
-                            /*
-                              std::cerr << "A patching in "
-                              << query_name << " " << query_offset << " @ " << query_pos << " - " << query_delta << " "
-                              << target_name << " " << target_offset << " @ " << target_pos << " - " << target_delta
+                    std::cerr << "q: " << query[query_pos] << " "
+                              << "t: " << target[target_pos - target_pointer_shift]
                               << std::endl;
-                            */
-
-                            // if we are continuing a patch, we can't nibble
-                            // backward too much to avoid the risk of going in
-                            // endless loop
-                            if (size_region_to_repatch > 0) {
-                                // nibble backward
-                                while (!patched.empty() &&
-                                       size_region_to_repatch > 0) {
-                                    const auto &c = patched.back();
-                                    switch (c) {
-                                        case 'M':
-                                        case 'X':
-                                            --query_pos;
-                                            --target_pos;
-                                            ++query_delta;
-                                            ++target_delta;
-                                            break;
-                                        case 'I':
-                                            ++query_delta;
-                                            --query_pos;
-                                            break;
-                                        case 'D':
-                                            ++target_delta;
-                                            --target_pos;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    patched.pop_back();
-                                    --size_region_to_repatch;
-                                }
-
-                                //distance_close_indels = distance_close_big_enough_indels(std::max(query_delta, target_delta), q, unpatched);
-                            } else {
-                                // nibble backward if we're below the correct
-                                // length
-                                while (
-                                        !patched.empty() &&
-                                        (query_delta < (min_wfa_patch_length / 2) ||
-                                         target_delta <
-                                         (min_wfa_patch_length / 2))) {
-                                    const auto &c = patched.back();
-                                    switch (c) {
-                                        case 'M':
-                                        case 'X':
-                                            --query_pos;
-                                            --target_pos;
-                                            ++query_delta;
-                                            ++target_delta;
-                                            break;
-                                        case 'I':
-                                            ++query_delta;
-                                            --query_pos;
-                                            break;
-                                        case 'D':
-                                            ++target_delta;
-                                            --target_pos;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    patched.pop_back();
-                                }
-                            }
-
-                            // nibble forward if we're below the correct length
-                            while (q != unpatched.end() &&
-                                   (query_delta < min_wfa_patch_length ||
-                                    target_delta < min_wfa_patch_length)) {
-                                const auto &c = *q++;
-                                switch (c) {
-                                    case 'M':
-                                    case 'X':
-                                        ++query_delta;
-                                        ++target_delta;
-                                        break;
-                                    case 'I':
-                                        ++query_delta;
-                                        break;
-                                    case 'D':
-                                        ++target_delta;
-                                        break;
-                                    default:
-                                        break;
-                                }
-
-                                --distance_close_indels;
-                            }
-
-                            /*
-                            std::cerr
-                                << "B patching in "
-                                << query_name << " " << query_offset << " @ " << query_pos << " - " << query_delta << " "
-                                << target_name << " " << target_offset << " @ " << target_pos << " - " << target_delta
-                                << std::endl;
-                            */
-
-                            // Nibble until the close, big enough indel is
-                            // reached Important when the patching can't be
-                            // computed correctly without including the next
-                            // indel
-                            while (q != unpatched.end() &&
-                                   distance_close_indels > 0) {
-                                const auto &c = *q++;
-                                switch (c) {
-                                    case 'M':
-                                    case 'X':
-                                        ++query_delta;
-                                        ++target_delta;
-                                        break;
-                                    case 'I':
-                                        ++query_delta;
-                                        break;
-                                    case 'D':
-                                        ++target_delta;
-                                        break;
-                                    default:
-                                        break;
-                                }
-
-                                --distance_close_indels;
-                            }
-
-
-                            /*
-                            std::cerr << "C patching in "
-                                      << query_name << " " << query_offset << " @ " << query_pos << " - " << query_delta << " "
-                                      << target_name << " " << target_offset << " @ " << target_pos << " - " << target_delta
+                    */
+                        if (query_pos >= query_length ||
+                            target_pos >= target_length_mut) {
+                            std::cerr << "[wflign::wflign_affine_wavefront] "
+                                         "corrupted traceback (out of bounds) for "
+                                      << query_name << " " << query_offset << " "
+                                      << target_name << " " << target_offset
                                       << std::endl;
-                            */
+                            exit(1);
+                        }
 
-                            // check forward if there are other Is/Ds to merge
-                            // in the current patch
-                            while (q != unpatched.end() &&
-                                   (*q == 'I' || *q == 'D') &&
-                                   ((query_delta < wflign_max_len_major &&
-                                     target_delta < wflign_max_len_major) &&
-                                    (query_delta < wflign_max_len_minor ||
-                                     target_delta < wflign_max_len_minor))) {
-                                const auto &c = *q++;
-                                if (c == 'I') {
-                                    ++query_delta;
-                                } else {
-                                    ++target_delta;
-                                }
+                        if (*q == 'M') {
+                            if (query[query_pos] !=
+                                target[target_pos - target_pointer_shift]) {
+                                std::cerr << "[wflign::wflign_affine_wavefront] "
+                                             "corrupted traceback (M, but there is "
+                                             "a mismatch) for "
+                                          << query_name << " " << query_offset
+                                          << " " << target_name << " "
+                                          << target_offset << std::endl;
+                                exit(1);
                             }
-
-                            /*
-                            std::cerr << "D patching in "
-                                      << query_name << " " << query_offset << " @ " << query_pos << " - " << query_delta << " "
-                                      << target_name << " " << target_offset << " @ " << target_pos << " - " << target_delta
-                                      << std::endl;
-                            */
-
-                            // check backward if there are other Is/Ds to merge
-                            // in the current patch it will eventually nibble
-                            // the Is/Ds left from the last patch
-                            while (!patched.empty() &&
-                                   (patched.back() == 'I' ||
-                                    patched.back() == 'D') &&
-                                   ((query_delta < wflign_max_len_major &&
-                                     target_delta < wflign_max_len_major) &&
-                                    (query_delta < wflign_max_len_minor ||
-                                     target_delta < wflign_max_len_minor))) {
-                                const auto &c = patched.back();
-                                if (c == 'I') {
-                                    ++query_delta;
-                                    --query_pos;
-                                } else {
-                                    ++target_delta;
-                                    --target_pos;
-                                }
-                                patched.pop_back();
+                        } else {
+                            if (query[query_pos] ==
+                                target[target_pos - target_pointer_shift]) {
+                                std::cerr << "[wflign::wflign_affine_wavefront] "
+                                             "corrupted traceback (X, but there is "
+                                             "a match) for "
+                                          << query_name << " " << query_offset
+                                          << " " << target_name << " "
+                                          << target_offset << std::endl;
+                                exit(1);
                             }
+                        }
 
+                        patched.push_back(*q);
+                        ++query_pos;
+                        ++target_pos;
+                        ++q;
+                    }
+
+                    // how long a gap?
+                    while (q != unpatched.end() && *q == 'I') {
+                        ++query_delta;
+                        ++q;
+                    }
+                    while (q != unpatched.end() && *q == 'D') {
+                        ++target_delta;
+                        ++q;
+                    }
+
+                    // how long was our last gap?
+                    // if it's long enough, patch it
+                    int32_t size_region_to_repatch = 0;
+
+                    do {
+                        got_alignment = false;
+
+                        if ((size_region_to_repatch > 0 ||
+                             (query_delta > 0 && target_delta > 0) ||
+                             (query_delta > 2 || target_delta > 2) &&
+                                     (query_delta < wflign_max_len_major &&
+                                      target_delta < wflign_max_len_major) &&
+                                     (query_delta < wflign_max_len_minor ||
+                                      target_delta < wflign_max_len_minor))) {
+
+                            // this should only happen if we're at >99% identity
+                            int32_t distance_close_indels = -1;
                             /*
-                            std::cerr << "E patching in "
-                                      << query_name << " " << query_offset << " @ " << query_pos << " - " << query_delta << " "
-                                      << target_name << " " << target_offset << " @ " << target_pos << " - " << target_delta
-                                      << std::endl;
+                            int32_t distance_close_indels = (query_delta > 3 || target_delta > 3) ?
+                                                            distance_close_big_enough_indels(std::max(query_delta, target_delta), q, unpatched) :
+                                                            -1;
                             */
 
-                            size_region_to_repatch = 0;
-                            // we need to be sure that our nibble made the
-                            // problem long enough For affine WFA to be correct
-                            // (to avoid trace-back errors), it must be at least
-                            // 10 nt
-                            { //if (query_delta >= 10 && target_delta >= 10) {
-                                alignment_t patch_aln;
-                                // WFA is only global
-                                do_wfa_patch_alignment(
-                                        query, query_pos, query_delta,
-                                        target - target_pointer_shift, target_pos,
-                                        target_delta, segment_length,
-                                        wf_aligner, affine_penalties, patch_aln);
-                                if (patch_aln.ok) {
-                                    // std::cerr << "got an ok patch aln" <<
-                                    // std::endl;
-                                    got_alignment = true;
-                                    const int start_idx =
-                                            patch_aln.edit_cigar.begin_offset;
-                                    const int end_idx =
-                                            patch_aln.edit_cigar.end_offset;
-                                    for (int i = start_idx; i < end_idx; i++) {
-                                        // std::cerr <<
-                                        // patch_aln.edit_cigar.operations[i];
-                                        patched.push_back(patch_aln.edit_cigar.cigar_ops[i]);
-                                    }
-                                    // std::cerr << "\n";
+                            // std::cerr << "distance_close_indels "
+                            //           <<  distance_close_indels << std::endl;
+                            // Trigger the patching if there is a dropout
+                            // (consecutive Is and Ds) or if there is a close and
+                            // big enough indel forward
+                            if (size_region_to_repatch > 0 ||
+                                (query_delta > 0 && target_delta > 0) ||
+                                (distance_close_indels > 0)) {
+#ifdef WFLIGN_DEBUG
+                                // std::cerr << "query_delta " << query_delta <<
+                                // "\n"; std::cerr << "target_delta " << target_delta
+                                // << "\n"; std::cerr << "distance_close_indel " <<
+                                // distance_close_indel << "\n";
 
-                                    // Check if there are too many indels in the
-                                    // patch
-                                    uint32_t size_indel = 0;
-                                    for (int i = end_idx - 1; i >= start_idx;
-                                         --i) {
-                                        // std::cerr <<
-                                        // patch_aln.edit_cigar.operations[i];
-                                        if (patch_aln.edit_cigar.cigar_ops[i] == 'I' ||
-                                            patch_aln.edit_cigar.cigar_ops[i] == 'D') {
-                                            ++size_indel;
-                                            ++size_region_to_repatch;
-                                        } else {
-                                            // Not too big, to avoid repatching
-                                            // structural variants boundaries
-                                            if (size_indel > 7 &&
-                                                size_indel <= 4096 &&
-                                                size_indel <
-                                                (end_idx - start_idx)) {
+                                std::cerr << "[wflign::wflign_affine_wavefront] "
+                                             "patching in "
+                                          << query_name << " " << query_offset
+                                          << " @ " << query_pos << " - "
+                                          << query_delta << " " << target_name
+                                          << " " << target_offset << " @ "
+                                          << target_pos << " - " << target_delta
+                                          << std::endl;
+#endif
+
+                                // if we are continuing a patch, we can't nibble
+                                // backward too much to avoid the risk of going in
+                                // endless loop
+                                if (size_region_to_repatch > 0) {
+                                    // nibble backward
+                                    while (!patched.empty() &&
+                                           size_region_to_repatch > 0) {
+                                        const auto &c = patched.back();
+                                        switch (c) {
+                                            case 'M':
+                                            case 'X':
+                                                --query_pos;
+                                                --target_pos;
+                                                ++query_delta;
+                                                ++target_delta;
                                                 break;
-                                            }
+                                            case 'I':
+                                                ++query_delta;
+                                                --query_pos;
+                                                break;
+                                            case 'D':
+                                                ++target_delta;
+                                                --target_pos;
+                                                break;
+                                            default:
+                                                break;
+                                        }
+                                        patched.pop_back();
+                                        --size_region_to_repatch;
+                                    }
 
-                                            ++size_region_to_repatch;
-                                            size_indel = 0;
+                                    //distance_close_indels = distance_close_big_enough_indels(std::max(query_delta, target_delta), q, unpatched);
+                                } else {
+                                    // nibble backward if we're below the correct
+                                    // length
+                                    while (
+                                            !patched.empty() &&
+                                            (query_delta < (min_wfa_patch_length / 2) ||
+                                             target_delta <
+                                                     (min_wfa_patch_length / 2))) {
+                                        const auto &c = patched.back();
+                                        switch (c) {
+                                            case 'M':
+                                            case 'X':
+                                                --query_pos;
+                                                --target_pos;
+                                                ++query_delta;
+                                                ++target_delta;
+                                                break;
+                                            case 'I':
+                                                ++query_delta;
+                                                --query_pos;
+                                                break;
+                                            case 'D':
+                                                ++target_delta;
+                                                --target_pos;
+                                                break;
+                                            default:
+                                                break;
+                                        }
+                                        patched.pop_back();
+                                    }
+                                }
+
+                                // nibble forward if we're below the correct length
+                                while (q != unpatched.end() &&
+                                       (query_delta < min_wfa_patch_length ||
+                                        target_delta < min_wfa_patch_length)) {
+                                    const auto &c = *q++;
+                                    switch (c) {
+                                        case 'M':
+                                        case 'X':
+                                            ++query_delta;
+                                            ++target_delta;
+                                            break;
+                                        case 'I':
+                                            ++query_delta;
+                                            break;
+                                        case 'D':
+                                            ++target_delta;
+                                            break;
+                                        default:
+                                            break;
+                                    }
+
+                                    --distance_close_indels;
+                                }
+
+                                // Nibble until the close, big enough indel is
+                                // reached Important when the patching can't be
+                                // computed correctly without including the next
+                                // indel
+                                while (q != unpatched.end() &&
+                                       distance_close_indels > 0) {
+                                    const auto &c = *q++;
+                                    switch (c) {
+                                        case 'M':
+                                        case 'X':
+                                            ++query_delta;
+                                            ++target_delta;
+                                            break;
+                                        case 'I':
+                                            ++query_delta;
+                                            break;
+                                        case 'D':
+                                            ++target_delta;
+                                            break;
+                                        default:
+                                            break;
+                                    }
+
+                                    --distance_close_indels;
+                                }
+
+                                // check forward if there are other Is/Ds to merge
+                                // in the current patch
+                                while (q != unpatched.end() &&
+                                       (*q == 'I' || *q == 'D') &&
+                                       ((query_delta < wflign_max_len_major &&
+                                         target_delta < wflign_max_len_major) &&
+                                        (query_delta < wflign_max_len_minor ||
+                                         target_delta < wflign_max_len_minor))) {
+                                    const auto &c = *q++;
+                                    if (c == 'I') {
+                                        ++query_delta;
+                                    } else {
+                                        ++target_delta;
+                                    }
+                                }
+
+                                // check backward if there are other Is/Ds to merge
+                                // in the current patch it will eventually nibble
+                                // the Is/Ds left from the last patch
+                                while (!patched.empty() &&
+                                       (patched.back() == 'I' ||
+                                        patched.back() == 'D') &&
+                                       ((query_delta < wflign_max_len_major &&
+                                         target_delta < wflign_max_len_major) &&
+                                        (query_delta < wflign_max_len_minor ||
+                                         target_delta < wflign_max_len_minor))) {
+                                    const auto &c = patched.back();
+                                    if (c == 'I') {
+                                        ++query_delta;
+                                        --query_pos;
+                                    } else {
+                                        ++target_delta;
+                                        --target_pos;
+                                    }
+                                    patched.pop_back();
+                                }
+
+                                size_region_to_repatch = 0;
+                                {
+                                    alignment_t patch_aln;
+                                    // WFA is only global
+                                    do_wfa_patch_alignment(
+                                            query, query_pos, query_delta,
+                                            target - target_pointer_shift, target_pos,
+                                            target_delta, segment_length,
+                                            wf_aligner, affine_penalties, patch_aln);
+                                    if (patch_aln.ok) {
+                                        // std::cerr << "got an ok patch aln" <<
+                                        // std::endl;
+                                        got_alignment = true;
+                                        const int start_idx =
+                                                patch_aln.edit_cigar.begin_offset;
+                                        const int end_idx =
+                                                patch_aln.edit_cigar.end_offset;
+                                        for (int i = start_idx; i < end_idx; i++) {
+                                            // std::cerr <<
+                                            // patch_aln.edit_cigar.operations[i];
+                                            patched.push_back(patch_aln.edit_cigar.cigar_ops[i]);
+                                        }
+                                        // std::cerr << "\n";
+
+                                        // Check if there are too many indels in the
+                                        // patch
+                                        uint32_t size_indel = 0;
+                                        for (int i = end_idx - 1; i >= start_idx;
+                                             --i) {
+                                            // std::cerr <<
+                                            // patch_aln.edit_cigar.operations[i];
+                                            if (patch_aln.edit_cigar.cigar_ops[i] == 'I' ||
+                                                patch_aln.edit_cigar.cigar_ops[i] == 'D') {
+                                                ++size_indel;
+                                                ++size_region_to_repatch;
+                                            } else {
+                                                // Not too big, to avoid repatching
+                                                // structural variants boundaries
+                                                if (size_indel > 7 &&
+                                                    size_indel <= 4096 &&
+                                                    size_indel <
+                                                            (end_idx - start_idx)) {
+                                                    break;
+                                                }
+
+                                                ++size_region_to_repatch;
+                                                size_indel = 0;
+                                            }
+                                        }
+                                        // std::cerr << std::endl;
+
+                                        // Not too big, to avoid repatching
+                                        // structural variants boundaries
+                                        //std::cerr << "size_region_to_repatch " << size_region_to_repatch << std::endl;
+                                        //std::cerr << "end_idx - start_idx " << end_idx - start_idx << std::endl;
+                                        if (size_indel > 7 && size_indel <= 4096 &&
+                                            size_region_to_repatch <
+                                                    (end_idx - start_idx)) {
+                                            //std::cerr << "REPATCH " << std::endl;
+                                        } else {
+                                            size_region_to_repatch = 0;
                                         }
                                     }
-                                    // std::cerr << std::endl;
-
-                                    // Not too big, to avoid repatching
-                                    // structural variants boundaries
-                                    //std::cerr << "size_region_to_repatch " << size_region_to_repatch << std::endl;
-                                    //std::cerr << "end_idx - start_idx " << end_idx - start_idx << std::endl;
-                                    if (size_indel > 7 && size_indel <= 4096 &&
-                                        size_region_to_repatch <
-                                        (end_idx - start_idx)) {
-                                        //std::cerr << "REPATCH " << std::endl;
-                                    } else {
-                                        size_region_to_repatch = 0;
-                                    }
                                 }
                             }
                         }
+
+                        // add in stuff if we didn't align
+                        if (!got_alignment) {
+                            for (uint64_t i = 0; i < query_delta; ++i) {
+                                patched.push_back('I');
+                            }
+                            for (uint64_t i = 0; i < target_delta; ++i) {
+                                patched.push_back('D');
+                            }
+                        }
+
+                        // std::cerr << "query_delta " << query_delta << std::endl;
+                        // std::cerr << "target_delta " << target_delta <<
+                        // std::endl;
+                        query_pos += query_delta;
+                        target_pos += target_delta;
+
+                        query_delta = 0;
+                        target_delta = 0;
+                    } while (size_region_to_repatch > 0);
+                }
+            } else {
+                // If erosion is disabled, disable also the patching in the middle
+                while (q != unpatched.end()) {
+                    patched.push_back(*q);
+
+                    switch (*q) {
+                        case 'M':
+                        case 'X':
+                            ++query_pos;
+                            ++target_pos;
+                            break;
+                        case 'I':
+                            ++query_pos;
+                            break;
+                        case 'D':
+                            ++target_pos;
+                            break;
+                        default:
+                            break;
                     }
 
-                    // add in stuff if we didn't align
-                    if (!got_alignment) {
-                        for (uint64_t i = 0; i < query_delta; ++i) {
-                            patched.push_back('I');
-                        }
-                        for (uint64_t i = 0; i < target_delta; ++i) {
-                            patched.push_back('D');
-                        }
-                    }
-
-                    // std::cerr << "query_delta " << query_delta << std::endl;
-                    // std::cerr << "target_delta " << target_delta <<
-                    // std::endl;
-                    query_pos += query_delta;
-                    target_pos += target_delta;
-
-                    query_delta = 0;
-                    target_delta = 0;
-                } while (size_region_to_repatch > 0);
+                    ++q;
+                }
             }
 
             // Tail patching
@@ -1016,16 +1001,16 @@ void write_merged_alignment(
                 got_alignment = false;
 
                 if (query_delta > 0 && query_delta < wflign_max_len_minor) {
-//                                            std::cerr << "A TAIL patching in "
-//                                                      << query_name << " " <<
-//                                                      query_offset << " @ " <<
-//                                                      query_pos << " - " <<
-//                                                      query_delta << " "
-//                                                      << target_name << " " <<
-//                                                      target_offset << " @ "
-//                                                      << target_pos - target_pointer_shift << " - "
-//                                                      << target_delta
-//                                                      << std::endl;
+//                    std::cerr << "A TAIL patching in "
+//                              << query_name << " " <<
+//                              query_offset << " @ " <<
+//                              query_pos << " - " <<
+//                              query_delta << " "
+//                              << target_name << " " <<
+//                              target_offset << " @ "
+//                              << target_pos - target_pointer_shift << " - "
+//                              << target_delta
+//                              << std::endl;
 
                     // min_wfa_patch_length-bps of margins to manage insertions in the query
                     const uint64_t delta_to_ask = query_delta + min_wfa_patch_length <= target_delta ? 0 : query_delta + min_wfa_patch_length - target_delta;


### PR DESCRIPTION
Other useless, and potentially error-prone, operations when standard WFA is performed.