### PR TITLE
Better head/tail patching

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -490,7 +490,7 @@ void WFlign::wflign_affine_wavefront(
                 mashmap_estimated_identity,
                 wflign_max_len_major,
                 wflign_max_len_minor,
-                0, // Erosion and middle patching are disabled, because standard WFA was performed on the whole mapping
+                erode_k,
                 MIN_WF_LENGTH,
                 wf_max_dist_threshold
 #ifdef WFA_PNG_AND_TSV


### PR DESCRIPTION
This introduces CIGAR string nibbling at the head/tail before the semi-global alignment. This gives a bit more context for the alignment, improving a little bit the result without destroying the performance.

This also reintroduces the CIGAR erosion and the middle patching for short/medium sequences: with them the alignments make more biological sense.