### PR TITLE
make `gcc` 11.4.0 and 13.1.0 happy

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <string>
+#include <cstdint>
 
 namespace wfmash {
     bool is_a_number(const std::string& s);

--- a/src/common/wflign/deps/WFA2-lib/Makefile
+++ b/src/common/wflign/deps/WFA2-lib/Makefile
@@ -12,7 +12,7 @@ UNAME=$(shell uname)
 CC:=$(CC)
 CPP:=$(CXX)
 
-CC_FLAGS=-Wall -g
+CC_FLAGS=-Wall -g -fPIE
 
 AR=ar
 AR_FLAGS=-rsc

--- a/src/common/wflign/deps/WFA2-lib/bindings/cpp/WFAligner.hpp
+++ b/src/common/wflign/deps/WFA2-lib/bindings/cpp/WFAligner.hpp
@@ -33,6 +33,7 @@
 #define BINDINGS_CPP_WFALIGNER_HPP_
 
 #include <string>
+#include <cstdint>
 
 #include "../../wavefront/wfa.hpp"
 


### PR DESCRIPTION
To fix https://github.com/waveygang/wfmash/issues/175. Mirrored at https://github.com/smarco/WFA2-lib/pull/70.