### PR TITLE
fix the build to use cmake everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-#add_subdirectory(src/common/wflign/deps/WFA2-lib EXCLUDE_FROM_ALL)
-#add_subdirectory(src/common/wflign/deps/wflambda EXCLUDE_FROM_ALL)
 add_subdirectory(src/common/wflign EXCLUDE_FROM_ALL)
-#add_subdirectory(src/common/abseil-cpp)
 
 add_executable(wfmash
   src/common/utils.cpp
@@ -57,7 +54,6 @@ target_include_directories(wfmash PRIVATE
   src/common
   src/common/wflign/deps
   src/common/wflign/deps/WFA2-lib
-  #src/common/wflign/abseil-cpp
   )
 target_link_directories(wfmash PRIVATE
   src/common/wflign/deps/WFA2-lib/lib)
@@ -72,7 +68,6 @@ target_link_libraries(wfmash
   wfacpp
   jemalloc
   z
-  #absl::flat_hash_map
 )
 
 install(TARGETS wfmash DESTINATION bin)

--- a/src/common/wflign/CMakeLists.txt
+++ b/src/common/wflign/CMakeLists.txt
@@ -46,12 +46,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 #
 # WFA2-lib Build
-#
-add_custom_target(
-        wfa_lib
-        COMMAND make clean all
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deps/WFA2-lib
-)
+# use CMakelists to build rather than Makefile
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/WFA2-lib)
 
 #
 # WFling
@@ -94,4 +90,3 @@ target_include_directories(
         deps/PicoSHA2
         deps/robin-hood-hashing
         deps/WFA2-lib)
-add_dependencies(libwflign_static wfa_lib)


### PR DESCRIPTION
This avoids build issues we were having because we were mixing Make and CMake when building WFA2-lib.