### PR TITLE
subset targets by list or prefix

### DIFF
--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -214,7 +214,7 @@ namespace align
                       MappingBoundaryRow currentRecord;
 
                       seqiter::for_each_seq_in_file(
-                          fileName,
+                          fileName, {}, "", 
                           [&](const std::string& qSeqId,
                               const std::string& _seq) {
                               ++total_seqs;

--- a/src/interface/main.cpp
+++ b/src/interface/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
                 for(const auto &fileName : map_parameters.querySequences)
                 {
                     seqiter::for_each_seq_in_file(
-                            fileName,
+						    fileName, {}, "", 
                             [&](const std::string& seq_name,
                                     const std::string& seq) {
                                 seqName_to_seqCounterAndLen[seq_name] = std::make_pair(seqCounter++,  seq.length());
@@ -178,7 +178,7 @@ int main(int argc, char** argv) {
                 // if not, warn that this is expensive
                 std::cerr << "[wfmash::align] WARNING, no .fai index found for " << fileName << ", reading the file to prepare SAM header (slow)" << std::endl;
                 seqiter::for_each_seq_in_file(
-                        fileName,
+					    fileName, {}, "",
                         [&](const std::string& seq_name,
                                 const std::string& seq) {
                             outstrm << "@SQ\tSN:" << seq_name << "\tLN:" << seq.length() << "\n";

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -77,6 +77,8 @@ void parse_args(int argc,
     args::ValueFlag<float> kmer_pct_threshold(mapping_opts, "%", "ignore the top % most-frequent kmers [default: 0.001]", {'H', "kmer-threshold"});
     args::Flag skip_self(mapping_opts, "", "skip self mappings when the query and target name is the same (for all-vs-all mode)", {'X', "skip-self"});
     args::ValueFlag<char> skip_prefix(mapping_opts, "C", "skip mappings when the query and target have the same prefix before the last occurrence of the given character C", {'Y', "skip-prefix"});
+	args::ValueFlag<std::string> target_prefix(mandatory_opts, "PREFIX", "prefix to filter target sequences by", {'P', "target-prefix"});
+	args::ValueFlag<std::string> target_list(mapping_opts, "FILE", "file containing list of target sequence names to allow", {'A', "target-list"});
     args::Flag approx_mapping(mapping_opts, "approx-map", "skip base-level alignment, producing an approximate mapping in PAF", {'m',"approx-map"});
     args::Flag no_split(mapping_opts, "no-split", "disable splitting of input sequences during mapping [default: enabled]", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "N", "chain mappings closer than this distance in query and target, retaining mappings in best chain [default: 50k]", {'c', "chain-gap"});
@@ -174,6 +176,14 @@ void parse_args(int argc,
         map_parameters.prefix_delim = '\0';
     }
 
+	if (target_list) {
+		map_parameters.target_list = args::get(target_list);
+	}
+
+	if (target_prefix) {
+		map_parameters.target_prefix = args::get(target_prefix);
+	}
+	
     if (target_sequence_file) {
         map_parameters.refSequences.push_back(args::get(target_sequence_file));
         align_parameters.refSequences.push_back(args::get(target_sequence_file));

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -145,7 +145,7 @@ namespace skch
                 // if not, warn that this is expensive
                 std::cerr << "[wfmash::skch::Map::mapQuery] WARNING, no .fai index found for " << fileName << ", reading the file to sum sequence length (slow)" << std::endl;
                 seqiter::for_each_seq_in_file(
-                    fileName,
+                    fileName, {}, "",
                     [&](const std::string& seq_name,
                         const std::string& seq) {
                         ++total_seqs;
@@ -164,7 +164,7 @@ namespace skch
 #endif
 
             seqiter::for_each_seq_in_file(
-                fileName,
+                fileName, {}, "",
                 [&](const std::string& seq_name,
                     const std::string& seq) {
                     // todo: offset_t is an 32-bit integer, which could cause problems

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -49,6 +49,8 @@ struct Parameters
     bool skip_self;                                   //skip self mappings
     bool skip_prefix;                                 //skip mappings to sequences with the same prefix
     char prefix_delim;                                //the prefix delimiter
+	std::string target_list;  					      //file containing list of target sequences
+	std::string target_prefix; 					      //prefix for target sequences to use
     bool mergeMappings;                               //if we should merge consecutive segment mappings
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
 

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -125,6 +125,17 @@ namespace skch
        */
       void build()
       {
+
+		// allowed set of targets
+		std::unordered_set<std::string> allowed_target_names;
+		if (!param.target_list.empty()) {
+			std::ifstream filter_list(param.target_list);
+			std::string name;
+			while (getline(filter_list, name)) {
+				allowed_target_names.insert(name); 
+			}
+		}
+
         //sequence counter while parsing file
         seqno_t seqCounter = 0;
 
@@ -140,6 +151,8 @@ namespace skch
 
         seqiter::for_each_seq_in_file(
             fileName,
+			allowed_target_names,
+			param.target_prefix,
             [&](const std::string& seq_name,
                 const std::string& seq) {
                 // todo: offset_t is an 32-bit integer, which could cause problems


### PR DESCRIPTION
By setting a set of targets on the command line, we open up divide and conquer mapping strategies based on the same underlying sequence file, which is convenient in some contexts.

The changes in this PR involve modifications in several files, primarily focusing on filtering target sequences.

- In `computeAlignments.hpp`, `seqiter.hpp`, `main.cpp`, `computeMap.hpp` files, `for_each_seq_in_file` function is updated to include two new parameters i.e.,
 `keep_seq` and `keep_prefix`. These parameters are expected to control which sequences are kept based on their content and prefix.

- In `seqiter.hpp`, inside the `for_each_seq_in_file` function, the logic has been added to append the line to the sequence only if the sequence qualifies the 
`keep` condition. Function functionality will be executed based on `keep` condition.

- In `parse_args.hpp`, new command-line arguments `target_prefix` and `target_list` are added allowing users to specify a prefix to filter target sequences by 
and provide a file which contains a list of target sequence names to allow.

- In `map_parameters.hpp`, the new options `target_list` and `target_prefix` are added to the Parameters structure.

- In `winSketch.hpp`, a new block of code is added to read the target sequence names from the user-provided file and store it in an unordered set of allowed ta
rget sequence names. This unordered set and the target prefix are passed to the `for_each_seq_in_file` function.

### Potential improvements

We might want to use the list to just iterate through the indexed FASTA/FASTQ. That really could save us a lot of time. This is currently set up so that we have to read the entire file even if we just need a few sequences. That's fine for cases when there isn't an index but current use discourages running on files without sequence indexes.