### PR TITLE
totally symmetric by default

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -75,6 +75,7 @@ void parse_args(int argc,
     args::ValueFlag<uint32_t> num_mappings_for_short_seq(mapping_opts, "N", "number of mappings to retain for each sequence shorter than segment length [default: 1]", {'S', "num-mappings-for-short-seq"});
     args::ValueFlag<int> kmer_size(mapping_opts, "N", "kmer size [default: 19]", {'k', "kmer"});
     args::ValueFlag<float> kmer_pct_threshold(mapping_opts, "%", "ignore the top % most-frequent kmers [default: 0.001]", {'H', "kmer-threshold"});
+	args::Flag lower_triangular(mapping_opts, "", "only map shorter sequences against longer in all-vs-all mode", {'L', "lower-triangular"});
     args::Flag skip_self(mapping_opts, "", "skip self mappings when the query and target name is the same (for all-vs-all mode)", {'X', "skip-self"});
     args::ValueFlag<char> skip_prefix(mapping_opts, "C", "skip mappings when the query and target have the same prefix before the last occurrence of the given character C", {'Y', "skip-prefix"});
 	args::ValueFlag<std::string> target_prefix(mapping_opts, "pfx", "use only targets whose name starts with this prefix", {'P', "target-prefix"});
@@ -167,6 +168,12 @@ void parse_args(int argc,
     } else {
         map_parameters.skip_self = false;
     }
+
+	if (lower_triangular) {
+		map_parameters.lower_triangular = true;
+	} else {
+		map_parameters.lower_triangular = false;
+	}
 
     if (skip_prefix) {
         map_parameters.skip_prefix = true;

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -132,7 +132,7 @@ namespace skch
     int n_merged;                                       // how many mappings we've merged into this one
     offset_t splitMappingId;                            // To identify split mappings that are chained
     uint8_t discard;                                    // set to 1 for deletion
-    bool selfMapFilter;                                 // set to true if a long-to-short mapping in all-vs-all mode (we report short as the query)
+    bool lowerTriFilter;                                // set to true if we should filter a long-to-short mapping
 
     offset_t qlen() {                                   //length of this mapping on query axis
       return queryEndPos - queryStartPos + 1;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -257,13 +257,13 @@ namespace skch
        * @param[in]   input   mappings
        * @return              void
        */
-      void filterSelfingLongToShorts(MappingResultsVector_t &readMappings)
+      void filterLongToShorts(MappingResultsVector_t &readMappings)
       {
-          if (param.skip_self || param.skip_prefix) {
+          if (param.lower_triangular) {
               readMappings.erase(
                   std::remove_if(readMappings.begin(),
                                  readMappings.end(),
-                                 [&](MappingResult &e){ return e.selfMapFilter == true; }),
+                                 [&](MappingResult &e){ return e.lowerTriFilter == true; }),
                   readMappings.end());
           }
       }
@@ -443,8 +443,9 @@ namespace skch
             }
         }
 
-        // remove self-mode don't-maps
-        this->filterSelfingLongToShorts(output->readMappings);
+        // if we're in lower triangular mode
+        // remove mappings where the query is longer than the target
+        this->filterLongToShorts(output->readMappings);
 
         // remove alignments where the ratio between query and target length is < our identity threshold
         this->filterFalseHighIdentity(output->readMappings);
@@ -721,9 +722,7 @@ namespace skch
                 res.conservedSketches = l2.sharedSketchSize;
                 res.blockLength = std::max(res.refEndPos - res.refStartPos, res.queryEndPos - res.queryStartPos);
                 res.approxMatches = std::round(res.nucIdentity * res.blockLength / 100.0);
-
-                res.selfMapFilter = ((param.skip_self || param.skip_prefix) && Q.fullLen > ref.len);
-
+                res.lowerTriFilter = (param.lower_triangular && Q.fullLen > ref.len);
                 //Compute additional statistics -> strand, reference complexity
                 {
                   SlideMapper<Q_Info> slidemap(Q);

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -46,6 +46,7 @@ struct Parameters
     std::vector<std::string> querySequences;          //query sequence(s)
     std::string outFileName;                          //output file name
     bool split;                                       //Split read mapping (done if this is true)
+	bool lower_triangular;                            //only output lower triangle of the mapping matrix
     bool skip_self;                                   //skip self mappings
     bool skip_prefix;                                 //skip mappings to sequences with the same prefix
     char prefix_delim;                                //the prefix delimiter


### PR DESCRIPTION
This pull request proposes changes to the parsing of mapping arguments and introduces a new flag, `-L, --lower_triangular`.

This flag filters mappings where the query is longer than the target. The purpose is to reduce work during pangenome construction, where the duplicate mappings are redundant, but it is not always useful. On master, this is default behavior when self mapping a single file. However, this PR will make the behavior explicit.

A new condition is added that throws a warning if single file all-vs-all mapping is detected with no other options, and it suggests that -L may be warranted to reduce costs.

Also, some changes in the  mapping parameters object and the naming convention have been made.