### PR TITLE
set chain gap to 20k

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -82,7 +82,7 @@ void parse_args(int argc,
 	args::ValueFlag<std::string> target_list(mapping_opts, "FILE", "file containing list of target sequence names to use", {'A', "target-list"});
     args::Flag approx_mapping(mapping_opts, "approx-map", "skip base-level alignment, producing an approximate mapping in PAF", {'m',"approx-map"});
     args::Flag no_split(mapping_opts, "no-split", "disable splitting of input sequences during mapping [default: enabled]", {'N',"no-split"});
-    args::ValueFlag<std::string> chain_gap(mapping_opts, "N", "chain mappings closer than this distance in query and target, retaining mappings in best chain [default: 50k]", {'c', "chain-gap"});
+    args::ValueFlag<std::string> chain_gap(mapping_opts, "N", "chain mappings closer than this distance in query and target, sets approximate maximum variant length detectable in alignment [default: 20k]", {'c', "chain-gap"});
     args::Flag drop_low_map_pct_identity(mapping_opts, "K", "drop mappings with estimated identity below --map-pct-id=%", {'K', "drop-low-map-id"});
     args::Flag no_filter(mapping_opts, "MODE", "disable mapping filtering", {'f', "no-filter"});
     args::ValueFlag<double> map_sparsification(mapping_opts, "FACTOR", "keep this fraction of mappings", {'x', "sparsify-mappings"});
@@ -400,7 +400,7 @@ void parse_args(int argc,
         }
         map_parameters.chain_gap = l;
     } else {
-        map_parameters.chain_gap = 50000;
+        map_parameters.chain_gap = 20000;
     }
 
     if (drop_low_map_pct_identity) {


### PR DESCRIPTION
The code changes in this PR modify the `chain_gap` parameter in `parse_args.hpp` of the source code. It alters the default chain gap from 50k to 20k and updates the associated description. The chain gap is the distance in the query and target where mappings are bound together. This changes the maximum length indel that we can directly align across.