### PR TITLE
Update progress bar w/ each segment 

### DIFF
--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -9,6 +9,7 @@
 
 #include <tuple>
 #include <vector>
+#include "common/progress.hpp"
 
 namespace skch
 {
@@ -186,6 +187,27 @@ namespace skch
           , seqCounter(seqcount) { }
   };
 
+
+  // Same as InputSeqContainer but with shared progress meter
+  struct InputSeqProgContainer : InputSeqContainer
+  {
+    using InputSeqContainer::InputSeqContainer;
+    progress_meter::ProgressMeter& progress;    //progress meter (shared)
+                                                
+
+    /*
+     * @brief               constructor
+     * @param[in] kseq_seq  complete read or reference sequence
+     * @param[in] kseq_id   sequence id name
+     * @param[in] len       length of sequence
+     * @param[in] progress  progress meter
+     */
+      InputSeqProgContainer(const std::string& s, const std::string& id, seqno_t seqcount, progress_meter::ProgressMeter& pm)
+          : InputSeqContainer(s, id, seqcount)
+          , progress(pm) { }
+  };
+
+
   //Output type of map function
   struct MapModuleOutput
   {
@@ -199,6 +221,7 @@ namespace skch
       this->readMappings.clear();
     }
   };
+
 
   //Information about fragment sequence during L1/L2 mapping
   template <typename MinimizerVec>

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -123,7 +123,7 @@ namespace skch
         MappingResultsVector_t allReadMappings;  //Aggregate mapping results for the complete run
 
         //Create the thread pool
-        ThreadPool<InputSeqContainer, MapModuleOutput> threadPool( [this](InputSeqContainer* e){return mapModule(e);}, param.threads);
+        ThreadPool<InputSeqProgContainer, MapModuleOutput> threadPool( [this](InputSeqProgContainer* e){return mapModule(e);}, param.threads);
 
         // kind've expensive if the fasta index is not available for the query sequences,
         // but it can help people know how long we're going to take
@@ -188,14 +188,13 @@ namespace skch
                     {
                         totalReadsPickedForMapping++;
                         //Dispatch input to thread
-                        threadPool.runWhenThreadAvailable(new InputSeqContainer(seq, seq_name, seqCounter));
+                        threadPool.runWhenThreadAvailable(new InputSeqProgContainer(seq, seq_name, seqCounter, progress));
 
                         //Collect output if available
                         while ( threadPool.outputAvailable() ) {
                             mapModuleHandleOutput(threadPool.popOutputWhenAvailable(), allReadMappings, totalReadsMapped, outstrm, progress);
                         }
                     }
-                    progress.increment(seq.size()/2);
                     seqCounter++;
                 }); //Finish reading query input file
 
@@ -334,7 +333,7 @@ namespace skch
        * @param[in]   input   input read details
        * @return              output object containing the mappings
        */
-      MapModuleOutput* mapModule (InputSeqContainer* input)
+      MapModuleOutput* mapModule (InputSeqProgContainer* input)
       {
         MapModuleOutput* output = new MapModuleOutput();
 
@@ -362,6 +361,8 @@ namespace skch
 
           // indicate that we mapped full length
           split_mapping = false;
+
+          input->progress.increment(input->len);
         }
         else  //Split read mapping
         {
@@ -392,6 +393,8 @@ namespace skch
 
             // save the output
             output->readMappings.insert(output->readMappings.end(), l2Mappings.begin(), l2Mappings.end());
+
+            input->progress.increment(param.segLength);
           }
 
           //Map last overlapping fragment to cover the whole read
@@ -417,6 +420,8 @@ namespace skch
                 });
 
             output->readMappings.insert(output->readMappings.end(), l2Mappings.begin(), l2Mappings.end());
+
+            input->progress.increment(input->len % param.segLength);
           }
         }
 
@@ -486,8 +491,6 @@ namespace skch
             //Report mapping
             reportReadMappings(output->readMappings, output->qseqName, outstrm);
           }
-
-          progress.increment(output->qseqLen/2 + (output->qseqLen % 2 != 0));
 
           delete output;
         }


### PR DESCRIPTION
* Added a new type that allows the progress bar to be shared across workers
* Progress bar is updated w/ each segment mapped, as opposed to after each sequence mapped