### PR TITLE
Limit size of DP filter

### DIFF
--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -92,6 +92,7 @@ namespace fixed
 //int max_best_mappings_per_position = 25;          // At a particular position, if algorithm finds more than a certain best
 //mappings, it doesn't mark them as best anymore
 
+double ss_table_max = 1000.0;                       // Maximum size of dp table for filtering
 double pval_cutoff = 1e-3;                          // p-value cutoff for determining window size
 float confidence_interval = 0.95;                   // Confidence interval to relax jaccard cutoff for mapping (0-1)
 float percentage_identity = 0.85;                   // Percent identity in the mapping step


### PR DESCRIPTION
* Limits the size of the DP filter to a sketch size of 1000. When the sketch size is larger than 1000, a DP table of size 1000 will be used to approximate the results. 