### PR TITLE
More permissive patching

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Test mapping coverage with 8 yeast genomes (PAF output)
         run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/scerevisiae8.fa.gz -p 95 -n 7 -m -L -Y '#' > scerevisiae8.paf; scripts/test.sh data/scerevisiae8.fa.gz.fai scerevisiae8.paf 0.92
       - name: Test mapping+alignment with a subset of the LPA dataset (PAF output)
-        run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/LPA.subset.fa.gz -n 10 -T wflign_info. -u ./ -L > LPA.subset.paf && head LPA.subset.paf
+        run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/LPA.subset.fa.gz -n 10 -T wflign_info. -u ./ -L --path-patching-tsv x.tsv > LPA.subset.paf && head LPA.subset.paf && head x.tsv
       - name: Test mapping+alignment with a subset of the LPA dataset (SAM output)
         run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/LPA.subset.fa.gz -N -a -T wflign_info. -L > LPA.subset.sam && samtools view LPA.subset.sam -bS | samtools sort > LPA.subset.bam && samtools index LPA.subset.bam && samtools view LPA.subset.bam | head | cut -f 1-9
       - name: Test mapping+alignment with short reads (500 bps) to a reference (SAM output)

--- a/src/align/include/align_parameters.hpp
+++ b/src/align/include/align_parameters.hpp
@@ -56,6 +56,8 @@ struct Parameters {
     std::string tsvOutputPrefix;                  //tsv files with wavefront information for each alignment
     uint64_t wfplot_max_size;                     // Max size (width/height) of the wfplot
     std::string prefix_wavefront_plot_in_png;     // Prefix of PNG files with wavefront plot for each alignment
+
+    std::string path_patching_info_in_tsv;        // TSV file with patching statistics
 #endif
 };
 

--- a/src/align/include/align_parameters.hpp
+++ b/src/align/include/align_parameters.hpp
@@ -39,6 +39,8 @@ struct Parameters {
     uint64_t wflign_max_len_minor;
     int wflign_erode_k;
     int kmerSize;                                 //kmer size for pre-checking before aligning a fragment
+    int64_t chain_gap;                            //max distance for 2d range union-find mapping chaining;
+    int wflign_max_patching_score;                //maximum score allowed for patching
 
     std::vector<std::string> refSequences;        //reference sequence(s)
     std::vector<std::string> querySequences;      //query sequence(s)

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -500,7 +500,9 @@ namespace align
                 param.wflign_max_distance_threshold,
                 param.wflign_max_len_major,
                 param.wflign_max_len_minor,
-                param.wflign_erode_k);
+                param.wflign_erode_k,
+                param.chain_gap,
+                param.wflign_max_patching_score);
         wflign->set_output(
                 &output,
 #ifdef WFA_PNG_AND_TSV

--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -54,7 +54,9 @@ WFlign::WFlign(
     const int wflign_max_distance_threshold,
     const uint64_t wflign_max_len_major,
     const uint64_t wflign_max_len_minor,
-    const int erode_k) {
+    const int erode_k,
+    const int64_t chain_gap,
+    const int max_patching_score) {
     // Parameters
     this->segment_length = segment_length;
     this->min_identity = min_identity;
@@ -71,6 +73,8 @@ WFlign::WFlign(
     this->wflign_max_len_major = wflign_max_len_major;
     this->wflign_max_len_minor = wflign_max_len_minor;
     this->erode_k = erode_k;
+    this->chain_gap = chain_gap;
+    this->max_patching_score = max_patching_score;
     // Query
     this->query_name = nullptr;
     this->query = nullptr;
@@ -492,6 +496,8 @@ void WFlign::wflign_affine_wavefront(
                 wflign_max_len_major,
                 wflign_max_len_minor,
                 erode_k,
+                chain_gap,
+                max_patching_score,
                 MIN_WF_LENGTH,
                 wf_max_dist_threshold
 #ifdef WFA_PNG_AND_TSV
@@ -945,6 +951,8 @@ void WFlign::wflign_affine_wavefront(
                         wflign_max_len_major,
                         wflign_max_len_minor,
                         erode_k,
+                        chain_gap,
+                        max_patching_score,
                         MIN_WF_LENGTH,
                         wf_max_dist_threshold
 #ifdef WFA_PNG_AND_TSV

--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -95,6 +95,8 @@ WFlign::WFlign(
     this->out_tsv = nullptr;
     this->prefix_wavefront_plot_in_png = nullptr;
     this->wfplot_max_size = 0;
+    this->emit_patching_tsv = false;
+    this->out_patching_tsv = nullptr;
 #endif
     this->merge_alignments = false;
     this->emit_md_tag = false;
@@ -111,6 +113,8 @@ void WFlign::set_output(
     std::ostream* const out_tsv,
     const std::string &wfplot_filepath,
     const uint64_t wfplot_max_size,
+    const bool emit_patching_tsv,
+    std::ostream* const out_patching_tsv,
 #endif
     const bool merge_alignments,
     const bool emit_md_tag,
@@ -122,6 +126,8 @@ void WFlign::set_output(
     this->out_tsv = out_tsv;
     this->prefix_wavefront_plot_in_png = &wfplot_filepath;
     this->wfplot_max_size = wfplot_max_size;
+    this->emit_patching_tsv = emit_patching_tsv;
+    this->out_patching_tsv = out_patching_tsv;
 #endif
     this->merge_alignments = merge_alignments;
     this->emit_md_tag = emit_md_tag;
@@ -503,7 +509,9 @@ void WFlign::wflign_affine_wavefront(
 #ifdef WFA_PNG_AND_TSV
                 ,
                 prefix_wavefront_plot_in_png,
-                wfplot_max_size
+                wfplot_max_size,
+                emit_patching_tsv,
+                out_patching_tsv
 #endif
                 );
 
@@ -958,7 +966,9 @@ void WFlign::wflign_affine_wavefront(
 #ifdef WFA_PNG_AND_TSV
                         ,
                         prefix_wavefront_plot_in_png,
-                        wfplot_max_size
+                        wfplot_max_size,
+                        emit_patching_tsv,
+                        out_patching_tsv
 #endif
                         );
             } else {

--- a/src/common/wflign/src/wflign.hpp
+++ b/src/common/wflign/src/wflign.hpp
@@ -54,6 +54,8 @@ namespace wflign {
             uint64_t wflign_max_len_major;
             uint64_t wflign_max_len_minor;
             int erode_k;
+            int64_t chain_gap;
+            int max_patching_score;
             // Query
             const std::string* query_name;
             char* query;
@@ -95,7 +97,9 @@ namespace wflign {
                     const int wflign_max_distance_threshold,
                     const uint64_t wflign_max_len_major,
                     const uint64_t wflign_max_len_minor,
-                    const int erode_k);
+                    const int erode_k,
+                    const int64_t chain_gap,
+                    const int max_patching_score);
             // Set output configuration
             void set_output(
                     std::ostream* const out,

--- a/src/common/wflign/src/wflign.hpp
+++ b/src/common/wflign/src/wflign.hpp
@@ -76,6 +76,8 @@ namespace wflign {
             std::ostream* out_tsv;
             const std::string* prefix_wavefront_plot_in_png;
             uint64_t wfplot_max_size;
+            bool emit_patching_tsv;
+            std::ostream* out_patching_tsv;
 #endif
             bool merge_alignments;
             bool emit_md_tag;
@@ -108,6 +110,8 @@ namespace wflign {
                     std::ostream* const out_tsv,
                     const std::string &wfplot_filepath,
                     const uint64_t wfplot_max_size,
+                    const bool emit_patching_tsv,
+                    std::ostream* const out_patching_tsv,
 #endif
                     const bool merge_alignments,
                     const bool emit_md_tag,

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -266,6 +266,8 @@ void write_merged_alignment(
 #ifdef WFA_PNG_AND_TSV
         const std::string* prefix_wavefront_plot_in_png,
         const uint64_t& wfplot_max_size,
+        const bool& emit_patching_tsv,
+        std::ostream* out_patching_tsv,
 #endif
         const bool& with_endline) {
 
@@ -380,7 +382,13 @@ void write_merged_alignment(
                 &distance_close_big_enough_indels, &min_wf_length,
                 &max_dist_threshold, &wf_aligner,
                 &affine_penalties,
-                &chain_gap, &max_patching_score](std::vector<char> &unpatched,
+                &chain_gap, &max_patching_score
+#ifdef WFA_PNG_AND_TSV
+                ,
+                &emit_patching_tsv,
+                &out_patching_tsv
+#endif
+        ](std::vector<char> &unpatched,
                                    std::vector<char> &patched) {
             auto q = unpatched.begin();
 
@@ -922,6 +930,14 @@ void write_merged_alignment(
                                         size_region_to_repatch = 0;
                                     }
                                 }
+#ifdef WFA_PNG_AND_TSV
+                                if (emit_patching_tsv) {
+                                    *out_patching_tsv
+                                            << query_name << ":" << query_pos << "-" << query_pos + query_delta << "\t"
+                                            << target_name << ":" << target_pos - target_pointer_shift << "-" << target_pos - target_pointer_shift + target_delta << "\t"
+                                            << patch_aln.ok << std::endl;
+                                }
+#endif
                             }
                         }
                     }

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -91,6 +91,8 @@ namespace wflign {
 #ifdef WFA_PNG_AND_TSV
                 const std::string* prefix_wavefront_plot_in_png,
                 const uint64_t& wfplot_max_size,
+                const bool& emit_patching_tsv,
+                std::ostream* out_patching_tsv,
 #endif
                 const bool& with_endline = true);
         void write_alignment(

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -54,7 +54,9 @@ namespace wflign {
                 const uint64_t& target_length,
                 wfa::WFAlignerGapAffine& _wf_aligner,
                 const wflign_penalties_t& affine_penalties,
-                alignment_t& aln);
+                alignment_t& aln,
+                const int64_t& chain_gap,
+                const int& max_patching_score);
         void write_merged_alignment(
                 std::ostream &out,
                 const std::vector<alignment_t *> &trace,
@@ -82,6 +84,8 @@ namespace wflign {
                 const uint64_t& wflign_max_len_major,
                 const uint64_t& wflign_max_len_minor,
                 const int& erode_k,
+                const int64_t& chain_gap,
+                const int& max_patching_score,
                 const int& min_wf_length,
                 const int& max_dist_threshold,
 #ifdef WFA_PNG_AND_TSV

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -262,7 +262,7 @@ void parse_args(int argc,
     if (!args::get(wfa_score_params).empty()) {
         const std::vector<std::string> params_str = skch::CommonFunc::split(args::get(wfa_score_params), ',');
         if (params_str.size() != 3) {
-            std::cerr << "[wfmash] ERROR error: 3 scoring parameters must be given to -g/--wflamda-params."//either 3 or 5 scoring parameters must be given to -g/--wflamda-params
+            std::cerr << "[wfmash] ERROR error: 3 scoring parameters must be given to -g/--wfa-params"//either 3 or 5 scoring parameters must be given to -g/--wflamda-params
                       << std::endl;
             exit(1);
         }

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -136,6 +136,7 @@ void parse_args(int argc,
     args::ValueFlag<std::string> prefix_wavefront_info_in_tsv(parser, "PREFIX", " write wavefronts' information for each alignment in TSV format files with this PREFIX", {'T', "tsv"});
     args::ValueFlag<std::string> prefix_wavefront_plot_in_png(parser, "PREFIX", " write wavefronts' plot for each alignment in PNG format files with this PREFIX", {'u', "prefix-png"});
     args::ValueFlag<uint64_t> wfplot_max_size(parser, "N", "max size of the wfplot [default: 1500]", {'z', "wfplot-max-size"});
+    args::ValueFlag<std::string> path_patching_info_in_tsv(parser, "FILE", " write patching information for each alignment in TSV format in FILE", {"path-patching-tsv"});
 #endif
 
     args::Group threading_opts(parser, "[ Threading ]");
@@ -629,6 +630,10 @@ void parse_args(int argc,
     align_parameters.tsvOutputPrefix = (prefix_wavefront_info_in_tsv && !args::get(prefix_wavefront_info_in_tsv).empty())
             ? args::get(prefix_wavefront_info_in_tsv)
             : "";
+
+    align_parameters.path_patching_info_in_tsv = (path_patching_info_in_tsv && !args::get(path_patching_info_in_tsv).empty())
+                                               ? args::get(path_patching_info_in_tsv)
+                                               : "";
 
     // wfplotting
     if (prefix_wavefront_plot_in_png) {


### PR DESCRIPTION
A too-strict patching (on the bottom) does not allow to cleanly resolve structural variants:

![image](https://github.com/waveygang/wfmash/assets/62253982/4f4e8a93-2747-457e-a53a-66e38296a1e0)

This also exposes `--max-patching-score` for studying it for a while.