### PR TITLE
Use approximate filter for large segment sizes

### DIFF
--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -92,12 +92,13 @@ namespace fixed
 //int max_best_mappings_per_position = 25;          // At a particular position, if algorithm finds more than a certain best
 //mappings, it doesn't mark them as best anymore
 
+double ss_table_max = 1000.0;                       // Maximum size of dp table for filtering
 double pval_cutoff = 1e-3;                          // p-value cutoff for determining window size
 float confidence_interval = 0.95;                   // Confidence interval to relax jaccard cutoff for mapping (0-1)
 float percentage_identity = 0.85;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-std::string VERSION = "3.1.0";                      // Version of MashMap
+std::string VERSION = "3.1.1";                      // Version of MashMap
 }
 }
 


### PR DESCRIPTION
Using a large sketch size would result in significantly increased time setting up the hypergeometric filter. This PR makes it so that the filter is approximated for sketch sizes over 1000.

As for the [chr14/chr21 alignment](http://hypervolu.me/~guarracino/wfmash_bug/README.txt), that seems to be resolved:

```
chr14   101161492       6400000 7000000 -       h1tg000002l     133244587       96659290        97259982        5908    600692  21      id:f:0.991238   kc:f:0.972173
chr14   101161492       7000000 8200000 -       h1tg000002l     133244587       95398158        96619266        7078    1221108 26      id:f:0.997357   kc:f:0.656011
chr14   101161492       8200000 9200000 -       h1tg000002l     133244587       94306437        95304479        6876    1000000 26      id:f:0.997424   kc:f:0.262739
chr14   101161492       9200000 10200000        -       h1tg000002l     133244587       93178283        94194481        2057    1016198 22      id:f:0.993255   kc:f:0.0855598
chr14   101161492       12700000        13500000        -       h1tg000002l     133244587       89483810        90283356        7803    800000  26      id:f:0.997376   kc:f:0.704989
chr14   101161492       13600000        14100000        -       h1tg000002l     133244587       88143834        88636862        5953    500000  24      id:f:0.995709   kc:f:0.950428
chr14   101161492       13700000        35400000        -       h1tg000002l     133244587       65766998        87443559        7867    21700000        29      id:f:0.998708   kc:f:0.970572
chr14   101161492       35400000        80300000        -       h1tg000002l     133244587       20901301        65808854        7856    44907553        30      id:f:0.99909    kc:f:0.946764
chr14   101161492       80300000        100700000       -       h1tg000002l     133244587       523822  20932812        7690    20408990        30      id:f:0.999011   kc:f:0.938355
chr21   45090682        8200000 8900000 +       h1tg000002l     133244587       95397452        96097026        6118    700000  23      id:f:0.994422   kc:f:0.385636
chr21   45090682        8900000 10900000        +       h1tg000002l     133244587       96154486        98109859        7029    2000000 26      id:f:0.997439   kc:f:0.778426
chr21   45090682        11200000        12200000        +       h1tg000002l     133244587       99276151        100290627       7147    1014476 27      id:f:0.997801   kc:f:0.962472
chr21   45090682        12200000        45090682        +       h1tg000002l     133244587       100339465       133242510       7759    32903045        30      id:f:0.998908   kc:f:0.880052
```
![chr14-chr21](https://github.com/waveygang/wfmash/assets/22685902/59a8e585-bd00-4a65-acd5-af138df976b4)
