### PR TITLE
plane sweep using log block length times identity as score

### DIFF
--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -254,7 +254,7 @@ namespace skch
 
         Helper(MappingResultsVector_t &v) : vec(v) {}
 
-        double get_score(const int x) const {return vec[x].nucIdentity; }
+        double get_score(const int x) const {return vec[x].nucIdentity * log(vec[x].blockLength) ; }
 
         //Greater than comparison by score and begin position
         //used to define order in BST

--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -41,7 +41,7 @@ namespace skch
 
         Helper(MappingResultsVector_t &v) : vec(v) {}
 
-        double get_score(const int x) const {return vec[x].nucIdentity; }
+        double get_score(const int x) const {return vec[x].nucIdentity * log(vec[x].blockLength) ; }
 
         //Greater than comparison by score and begin position
         //used to define order in BST


### PR DESCRIPTION
This tries to balance alignment identity and length when running the plane sweep algorithm.

We take our score to be:

```
double get_score(const int x) const {return vec[x].nucIdentity * log(vec[x].blockLength) ; }
```

It seems to help in highly repetitive sequences.