### PR TITLE
fix unset variable

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1747,7 +1747,7 @@ namespace skch
             outstrm  << sep << e.conservedSketches
                      << sep << e.blockLength
                      << sep << fakeMapQ
-                     << sep << "id:f:" << (param.report_ANI_percentage ? 100.0 : 1.0) * e.nucIdentity
+                     << sep << "id:f:" << (param.legacy_output ? 100.0 : 1.0) * e.nucIdentity
                      << sep << "kc:f:" << e.kmerComplexity;
             if (!param.mergeMappings) 
             {


### PR DESCRIPTION
This avoids instability for the `id:f` field:

```
(base) ➜ head 1.paf -n 1
S288C#1#chrI    219929  0       219929  +       SGDref#1#chrI   230218  0       219484  196     219929  34      id:f:0.999645   kc:f:0.956227
(base) ➜ head 2.paf -n 1
S288C#1#chrI    219929  0       219929  +       SGDref#1#chrI   230218  0       219484  196     219929  34      id:f:0.999645   kc:f:0.956227
(base) ➜ head 3.paf -n 1
S288C#1#chrI    219929  0       219929  +       SGDref#1#chrI   230218  0       219484  196     219929  34      id:f:99.9645    kc:f:0.956227
```