### PR TITLE
Initialize stage2 scan flag

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -580,6 +580,7 @@ void parse_args(int argc,
     map_parameters.filterLengthMismatches = true;
 
     map_parameters.stage1_topANI_filter = !bool(no_hg_filter); 
+    map_parameters.stage2_full_scan = true;
 
     if (hg_filter_ani_diff)
     {


### PR DESCRIPTION
Fixes issue where a MM3 flag was not initialized in wfmash, leading to non-deterministic behavior. 