### PR TITLE
All outputs in [0, 1] now (again)

### DIFF
--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -124,7 +124,7 @@ namespace align
         // Extract the mashmap identity from the string
         const vector<string> mm_id_vec = skch::CommonFunc::split(tokens[12], ':');
         // if the estimated identity is missing, avoid assuming too low values
-        const float mm_id = wfmash::is_a_number(mm_id_vec.back()) ? std::stof(mm_id_vec.back())/(float) 100.0 : skch::fixed::percentage_identity; // divide by 100 for consistency with block alignment
+        const float mm_id = wfmash::is_a_number(mm_id_vec.back()) ? std::stof(mm_id_vec.back()) : skch::fixed::percentage_identity;
 
         //Save words into currentRecord
         {

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -1625,9 +1625,9 @@ query_start : query_end)
                 << std::round(float2phred(1.0 - block_identity))
                 //<< "\t" << "as:i:" << total_score
                 << "\t"
-                << "gi:f:" << gap_compressed_identity * 100.0 << "\t"
+                << "gi:f:" << gap_compressed_identity << "\t"
                 << "bi:f:"
-                << block_identity * 100.0
+                << block_identity
                 //<< "\t" << "md:f:" << mash_dist_sum / trace.size()
                 //<< "\t" << "ma:i:" << matches
                 //<< "\t" << "mm:i:" << mismatches
@@ -1636,7 +1636,7 @@ query_start : query_end)
                 //<< "\t" << "nd:i:" << deletions
                 //<< "\t" << "dd:i:" << deleted_bp
                 << "\t"
-                << "md:f:" << mashmap_estimated_identity * 100.0;
+                << "md:f:" << mashmap_estimated_identity;
 
             if (emit_md_tag) {
                 out << "\t";

--- a/src/interface/main.cpp
+++ b/src/interface/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
             << "\t" << 0
             << "\t" << std::max(e.rEndPos - e.rStartPos, e.qEndPos - e.qStartPos)
             << "\t" << 255
-            << "\t" << "id:f:" << e.mashmap_estimated_identity * 100.0
+            << "\t" << "id:f:" << e.mashmap_estimated_identity
             << "\n";
         }
     }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1747,7 +1747,7 @@ namespace skch
             outstrm  << sep << e.conservedSketches
                      << sep << e.blockLength
                      << sep << fakeMapQ
-                     << sep << "id:f:" << (param.legacy_output ? 1.0 : 100.0) * e.nucIdentity
+                     << sep << "id:f:" << e.nucIdentity
                      << sep << "kc:f:" << e.kmerComplexity;
             if (!param.mergeMappings) 
             {


### PR DESCRIPTION
All identity outputs are `[0, 1]`, including those from the alignment output (`gi`, `bi`, and `md`).