### PR TITLE
Average kmer complexities over chain in mergeMappingsInRange

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1655,6 +1655,11 @@ namespace skch
                                       [](double x, MappingResult &e){ return x + e.nucIdentity; })
                   ) / it->n_merged; // this would scale directly by the number of mappings in the chain
 
+              //Mean identity of all kmer complexities in the chain
+              it->kmerComplexity = ( std::accumulate(
+                                      it, it_end, 0.0,
+                                      [](double x, MappingResult &e){ return x + e.kmerComplexity; })
+                  ) / it->n_merged; // this would scale directly by the number of mappings in the chain
 
               //Discard other mappings of this chain
               std::for_each( std::next(it), it_end, [&](MappingResult &e){ e.discard = 1; });


### PR DESCRIPTION
Kmer complexities were only averaged for the `mergeMappings` function, not the `mergeMappingsInRange` function. This bug doesn't impact any of the alignments, as the kmer-complexity filter is applied to segments before they are chained, but the reported `kc` tag is incorrect for chains.