### PR TITLE
Don't use hypergeometric model for low-complexity segments.

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -758,7 +758,7 @@ namespace skch
             }
 
             //Sort L1 windows based on intersection size if using hg filter
-            if (param.stage1_topANI_filter)
+            if (param.stage1_topANI_filter && Q.kmerComplexity >= skch::fixed::stage1_kmer_complexity_thresh)
             {
               std::make_heap(l1_begin, l1_end, L1_locus_intersection_cmp);
             }
@@ -917,7 +917,7 @@ namespace skch
           // Only necessary when windowLen != 0.
           std::unordered_map<hash_t, int> hash_to_freq;
 
-          if (param.stage1_topANI_filter) {
+          if (param.stage1_topANI_filter && Q.kmerComplexity >= skch::fixed::stage1_kmer_complexity_thresh) {
             while (leadingIt != ip_end)
             {
               // Catch the trailing iterator up to the leading iterator - windowLen
@@ -1161,7 +1161,7 @@ namespace skch
           {
             L1_candidateLocus_t& candidateLocus = *loc_iterator;
 
-            if (param.stage1_topANI_filter)
+            if (param.stage1_topANI_filter && Q.kmerComplexity >= skch::fixed::stage1_kmer_complexity_thresh)
             {
               // If using HG filter, don't consider any mappings which have no chance of being 
               // within param.ANIDiff of the best mapping seen so far
@@ -1223,7 +1223,7 @@ namespace skch
               }
             }
 
-            if (param.stage1_topANI_filter) 
+            if (param.stage1_topANI_filter && Q.kmerComplexity >= skch::fixed::stage1_kmer_complexity_thresh)
             {
               std::pop_heap(l1_begin, l1_end, L1_locus_intersection_cmp); 
               l1_end--; //"Pop back" 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -33,10 +33,10 @@ struct Parameters
 {
     int kmerSize;                                     //kmer size for sketching
     float kmer_pct_threshold;                         //use only kmers not in the top kmer_pct_threshold %-ile
-    offset_t segLength;                                //For split mapping case, this represents the fragment length
+    offset_t segLength;                               //For split mapping case, this represents the fragment length
                                                       //for noSplit, it represents minimum read length to multimap
-    offset_t block_length;                             // minimum (potentially merged) block to keep if we aren't split
-    offset_t chain_gap;                                // max distance for 2d range union-find mapping chaining
+    offset_t block_length;                            // minimum (potentially merged) block to keep if we aren't split
+    offset_t chain_gap;                               // max distance for 2d range union-find mapping chaining
     int alphabetSize;                                 //alphabet size
     offset_t referenceSize;                           //Approximate reference size
     float percentageIdentity;                         //user defined threshold for good similarity
@@ -99,7 +99,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.90;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
-float stage1_kmer_complexity_thresh = 0.75;          // Minimum kmer complexity required to allow HG filter
+float stage1_kmer_complexity_thresh = 0.75;         // Minimum kmer complexity required to allow HG filter
 std::string VERSION = "3.1.1";                      // Version of MashMap
 }
 }

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -99,6 +99,7 @@ float confidence_interval = 0.95;                   // Confidence interval to re
 float percentage_identity = 0.90;                   // Percent identity in the mapping step
 float ANIDiff = 0.0;                                // Stage 1 ANI diff threshold
 float ANIDiffConf = 0.999;                          // ANI diff confidence
+float stage1_kmer_complexity_thresh = 0.75;          // Minimum kmer complexity required to allow HG filter
 std::string VERSION = "3.1.1";                      // Version of MashMap
 }
 }


### PR DESCRIPTION
Don't use hypergeometric model for low-complexity segments, where a segment is "low-complexity" if the number of distinct kmers is less than 75% of the total number of kmers.

For segments with low kmer complexity, we now examine all candidate windows from the L1 stage, even if their maximum predicted ANI cannot be higher than the threshold. This is because the ANI predictions at low-complexity are more noisy. 

Since such a small fraction of segments are low-complexity, the mapping stage takes an extra ~10% cpu time now. Alternatively, low complexity mappings can be skipped entirely with `--kmer-complexity F`