### PR TITLE
Enable one to one filtering

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -77,6 +77,7 @@ void parse_args(int argc,
     args::ValueFlag<float> kmer_pct_threshold(mapping_opts, "%", "ignore the top % most-frequent kmers [default: 0.001]", {'H', "kmer-threshold"});
 	args::Flag lower_triangular(mapping_opts, "", "only map shorter sequences against longer", {'L', "lower-triangular"});
     args::Flag skip_self(mapping_opts, "", "skip self mappings when the query and target name is the same (for all-vs-all mode)", {'X', "skip-self"});
+    args::Flag one_to_one(mapping_opts, "", "Perform one-to-one filtering", {'4', "one-to-one"});
     args::ValueFlag<char> skip_prefix(mapping_opts, "C", "skip mappings when the query and target have the same prefix before the last occurrence of the given character C", {'Y', "skip-prefix"});
 	args::ValueFlag<std::string> target_prefix(mapping_opts, "pfx", "use only targets whose name starts with this prefix", {'P', "target-prefix"});
 	args::ValueFlag<std::string> target_list(mapping_opts, "FILE", "file containing list of target sequence names to use", {'A', "target-list"});
@@ -237,11 +238,8 @@ void parse_args(int argc,
     if (no_filter) {
         map_parameters.filterMode = skch::filter::NONE;
     } else {
-        if (map_parameters.skip_self || map_parameters.skip_prefix) {
-            // before we set skch::filter::ONETOONE here
-            // but this does not provide a clear benefit in all-to-all
-            // as it sometimes introduces cases of over-filtering
-            map_parameters.filterMode = skch::filter::MAP;
+        if (one_to_one) {
+            map_parameters.filterMode = skch::filter::ONETOONE;
         } else {
             map_parameters.filterMode = skch::filter::MAP;
         }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -7,6 +7,7 @@
 #ifndef SKETCH_MAP_HPP
 #define SKETCH_MAP_HPP
 
+#include <iterator>
 #include <limits>
 #include <vector>
 #include <algorithm>
@@ -374,19 +375,54 @@ namespace skch
         //Filter over reference axis and report the mappings
         if (param.filterMode == filter::ONETOONE)
         {
-          skch::Filter::ref::filterMappings(allReadMappings, this->refSketch,
-                                            param.numMappingsForSegment - 1
-                                           // (input->len < param.segLength ? param.shortSecondaryToKeep : param.secondaryToKeep)
-                                            );
+          // how many secondary mappings to keep
+          int n_mappings = param.numMappingsForSegment - 1;
+
+          // Group sequences by query prefix, then pass to ref filter
+          auto subrange_begin = allReadMappings.begin();
+          auto subrange_end = allReadMappings.begin();
+          MappingResultsVector_t tempMappings;
+          MappingResultsVector_t filteredMappings;
+
+          std::cerr << "\n[mashmap::skch::Map::mapQuery] Number of mappings before ref filter = " << allReadMappings.size() << "\n";
+
+          while (subrange_end != allReadMappings.end())
+          {
+            if (param.skip_prefix)
+            {
+              int currGroup = this->getRefGroup(qmetadata[subrange_begin->querySeqId].name);
+              subrange_end = std::find_if_not(subrange_begin, allReadMappings.end(), [this, currGroup] (const auto& allReadMappings_candidate) {
+                  return currGroup == this->getRefGroup(this->qmetadata[allReadMappings_candidate.querySeqId].name);
+              });
+            }
+            else
+            {
+              subrange_end = allReadMappings.end();
+            }
+            tempMappings.insert(
+                tempMappings.end(), 
+                std::make_move_iterator(subrange_begin), 
+                std::make_move_iterator(subrange_end));
+
+            // tmpMappings now contains mappings from one group of query sequences to all reference groups
+            // we now run filterByGroup, which filters based on the reference group.
+            filterByGroup(tempMappings, filteredMappings, n_mappings, true);
+            tempMappings.clear();
+            subrange_begin = subrange_end;
+          }
+          std::swap(allReadMappings, filteredMappings);
 
           //Re-sort mappings by input order of query sequences
           //This order may be needed for any post analysis of output
-          std::sort(allReadMappings.begin(), allReadMappings.end(), [](const MappingResult &a, const MappingResult &b)
-          {
-            return (a.querySeqId < b.querySeqId);
-          });
+          std::sort(
+              allReadMappings.begin(), allReadMappings.end(),
+              [](const MappingResult &a, const MappingResult &b) {
+                  return std::tie(a.querySeqId, a.queryStartPos, a.refSeqId, a.refStartPos) 
+                    < std::tie(b.querySeqId, b.queryStartPos, b.refSeqId, b.refStartPos);
+              });
 
           reportReadMappings(allReadMappings, "", outstrm);
+          std::cerr << "[mashmap::skch::Map::mapQuery] Number of mappings after ref filter = " << allReadMappings.size() << "\n";
         }
 
         progress.finish();
@@ -478,17 +514,19 @@ namespace skch
       }
 
       /**
-       * @brief               helper to main filtering function
-       * @details             filters mappings by group
-       * @param[in]   input   unfiltered mappings
-       * @param[in]   output  filtered mappings
-       * @param[in]   input   num mappings per segment
-       * @return              void
+       * @brief                    helper to main filtering function
+       * @details                  filters mappings by group
+       * @param[in]   input        unfiltered mappings
+       * @param[in]   output       filtered mappings
+       * @param[in]   n_mappings   num mappings per segment
+       * @param[in]   filter_ref   use Filter::ref instead of Filter::query
+       * @return                   void
        */
       void filterByGroup(
           MappingResultsVector_t &unfilteredMappings,
           MappingResultsVector_t &filteredMappings,
-          int n_mappings)
+          int n_mappings,
+          bool filter_ref)
       {
         filteredMappings.reserve(unfilteredMappings.size());
 
@@ -498,6 +536,7 @@ namespace skch
         auto subrange_end = unfilteredMappings.begin();
         if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) 
         {
+          std::vector<skch::MappingResult> tmpMappings;
           while (subrange_end != unfilteredMappings.end())
           {
             if (param.skip_prefix)
@@ -511,13 +550,25 @@ namespace skch
             {
               subrange_end = unfilteredMappings.end();
             }
-            // TODO why are we filtering these before merging?
-            std::vector<skch::MappingResult> tmpMappings(std::distance(subrange_begin, subrange_end));
-            std::move(subrange_begin, subrange_end, tmpMappings.begin());
+            tmpMappings.insert(
+                tmpMappings.end(), 
+                std::make_move_iterator(subrange_begin), 
+                std::make_move_iterator(subrange_end));
             std::sort(tmpMappings.begin(), tmpMappings.end(), [](const auto& a, const auto& b) 
                 { return std::tie(a.queryStartPos, a.refSeqId, a.refStartPos) < std::tie(b.queryStartPos, b.refSeqId, b.refStartPos); });
-            skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand);
-            std::move(tmpMappings.begin(), tmpMappings.end(), std::back_inserter(filteredMappings));
+            if (filter_ref)
+            {
+              skch::Filter::ref::filterMappings(tmpMappings, this->refSketch, n_mappings);
+            }
+            else
+            {
+              skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand);
+            }
+            filteredMappings.insert(
+                filteredMappings.end(), 
+                std::make_move_iterator(tmpMappings.begin()), 
+                std::make_move_iterator(tmpMappings.end()));
+            tmpMappings.clear();
             subrange_begin = subrange_end;
           }
         }
@@ -664,7 +715,7 @@ namespace skch
         if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {                      
           MappingResultsVector_t tempMappings;
           tempMappings.reserve(output->readMappings.size());
-          filterByGroup(unfilteredMappings, tempMappings, n_mappings);
+          filterByGroup(unfilteredMappings, tempMappings, n_mappings, false);
           std::swap(tempMappings, unfilteredMappings);
         }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -410,7 +410,7 @@ namespace skch
             tempMappings.clear();
             subrange_begin = subrange_end;
           }
-          std::swap(allReadMappings, filteredMappings);
+          allReadMappings = std::move(filteredMappings);
 
           //Re-sort mappings by input order of query sequences
           //This order may be needed for any post analysis of output
@@ -716,10 +716,10 @@ namespace skch
           MappingResultsVector_t tempMappings;
           tempMappings.reserve(output->readMappings.size());
           filterByGroup(unfilteredMappings, tempMappings, n_mappings, false);
-          std::swap(tempMappings, unfilteredMappings);
+          unfilteredMappings = std::move(tempMappings);
         }
 
-        std::swap(output->readMappings, unfilteredMappings);
+        output->readMappings = std::move(unfilteredMappings);
 
         // remove alignments where the ratio between query and target length is < our identity threshold
         if (param.filterLengthMismatches)

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -384,8 +384,6 @@ namespace skch
           MappingResultsVector_t tmpMappings;
           MappingResultsVector_t filteredMappings;
 
-          std::cerr << "\n[mashmap::skch::Map::mapQuery] Number of mappings before ref filter = " << allReadMappings.size() << "\n";
-
           while (subrange_end != allReadMappings.end())
           {
             if (param.skip_prefix)
@@ -422,7 +420,6 @@ namespace skch
               });
 
           reportReadMappings(allReadMappings, "", outstrm);
-          std::cerr << "[mashmap::skch::Map::mapQuery] Number of mappings after ref filter = " << allReadMappings.size() << "\n";
         }
 
         progress.finish();

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -381,7 +381,7 @@ namespace skch
           // Group sequences by query prefix, then pass to ref filter
           auto subrange_begin = allReadMappings.begin();
           auto subrange_end = allReadMappings.begin();
-          MappingResultsVector_t tempMappings;
+          MappingResultsVector_t tmpMappings;
           MappingResultsVector_t filteredMappings;
 
           std::cerr << "\n[mashmap::skch::Map::mapQuery] Number of mappings before ref filter = " << allReadMappings.size() << "\n";
@@ -399,15 +399,15 @@ namespace skch
             {
               subrange_end = allReadMappings.end();
             }
-            tempMappings.insert(
-                tempMappings.end(), 
+            tmpMappings.insert(
+                tmpMappings.end(), 
                 std::make_move_iterator(subrange_begin), 
                 std::make_move_iterator(subrange_end));
 
             // tmpMappings now contains mappings from one group of query sequences to all reference groups
             // we now run filterByGroup, which filters based on the reference group.
-            filterByGroup(tempMappings, filteredMappings, n_mappings, true);
-            tempMappings.clear();
+            filterByGroup(tmpMappings, filteredMappings, n_mappings, true);
+            tmpMappings.clear();
             subrange_begin = subrange_end;
           }
           allReadMappings = std::move(filteredMappings);
@@ -713,10 +713,10 @@ namespace skch
         }
 
         if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {                      
-          MappingResultsVector_t tempMappings;
-          tempMappings.reserve(output->readMappings.size());
-          filterByGroup(unfilteredMappings, tempMappings, n_mappings, false);
-          unfilteredMappings = std::move(tempMappings);
+          MappingResultsVector_t tmpMappings;
+          tmpMappings.reserve(output->readMappings.size());
+          filterByGroup(unfilteredMappings, tmpMappings, n_mappings, false);
+          unfilteredMappings = std::move(tmpMappings);
         }
 
         output->readMappings = std::move(unfilteredMappings);


### PR DESCRIPTION
* Adds `--one-to-one` option, which performs the plane-sweep filtering in both directions.