### PR TITLE
Add error when the index is empty 

### DIFF
--- a/src/interface/main.cpp
+++ b/src/interface/main.cpp
@@ -73,6 +73,12 @@ int main(int argc, char** argv) {
         std::chrono::duration<double> timeRefSketch = skch::Time::now() - t0;
         std::cerr << "[wfmash::map] time spent computing the reference index: " << timeRefSketch.count() << " sec" << std::endl;
 
+        if (referSketch.minmerIndex.size() == 0)
+        {
+            std::cerr << "[wfmash::map] ERROR, reference sketch is empty. Reference sequences shorter than the segment length are not indexed" << std::endl;
+            return 1;
+        }
+
         //Map the sequences in query file
         t0 = skch::Time::now();
 


### PR DESCRIPTION
If all of the sequences in the reference file are too small to be indexed, the mapping step will now print an error and exit with non-zero return value instead of segfaulting (Fixes #218).