### PR TITLE
Don't include endpoint in L2 range

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1403,11 +1403,8 @@ namespace skch
               l2_out.sharedSketchSize = slideMap.sharedSketchElements;
 
               //Save the position
-              l2_out.optimalStart = windowIt->wpos;
-              l2_out.optimalEnd = std::next(
-                  windowIt, 
-                  windowIt != minmerIndex.end() && std::next(windowIt)->seqId == windowIt->seqId
-                )->wpos - windowLen;
+              l2_out.optimalStart = windowIt->wpos - windowLen;
+              l2_out.optimalEnd = windowIt->wpos - windowLen;
             }
             else if(slideMap.sharedSketchElements == bestSketchSize)
             {
@@ -1420,17 +1417,10 @@ namespace skch
 
               in_candidate = true;
               //Still save the position
-              l2_out.optimalEnd = std::next(
-                  windowIt, 
-                  windowIt != minmerIndex.end() && std::next(windowIt)->seqId == windowIt->seqId
-                )->wpos  - windowLen;
+              l2_out.optimalEnd = windowIt->wpos - windowLen;
             } else {
               if (in_candidate) {
                 // Save and reset
-                l2_out.optimalEnd = std::next(
-                    windowIt, 
-                    windowIt != minmerIndex.end() && std::next(windowIt)->seqId == windowIt->seqId
-                  )->wpos - windowLen;
                 l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
                 l2_out.seqId = windowIt->seqId;
                 l2_out.strand = prev_strand_votes >= 0 ? strnd::FWD : strnd::REV;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -718,14 +718,14 @@ namespace skch
 
         output->readMappings = std::move(unfilteredMappings);
 
+        //Make sure mapping boundary don't exceed sequence lengths
+        this->mappingBoundarySanityCheck(input, output->readMappings);
+
         // remove alignments where the ratio between query and target length is < our identity threshold
         if (param.filterLengthMismatches)
         {
           this->filterFalseHighIdentity(output->readMappings);
         }
-
-        //Make sure mapping boundary don't exceed sequence lengths
-        this->mappingBoundarySanityCheck(input, output->readMappings);
 
         // sparsify the mappings, if requested
         this->sparsifyMappings(output->readMappings);


### PR DESCRIPTION
Segment mapping start positions are computed as the midpoint of candidate mapping regions. The problem is that for small reference contigs (<2x segment size), the minmers/seed window boundaries are not uniformly distributed; they bunch up near the boundaries of the index. As a result, the start position for mappings which map to the end of these contigs can be offset.

An example of this issue is shown in #218. The contigs are all slightly less than 1kbp. If you set the segment length to 900bp and turn merging off (`--no-merge`) in the main branch, you'll see that the first split `[0,900)` maps okay, but the `[100, 1000)` split will map to ~500. The problem is mitigated by shifting the candidate window one minmer back. 

Also, in cases where segments map towards the end of a reference contig, we should truncate the coordinates *before* doing the length mismatch filter.