### PR TITLE
Do not allow a segment to chain with itself

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1616,6 +1616,10 @@ namespace skch
           for (auto it = readMappings.begin(); it != readMappings.end(); it++) {
               std::vector<std::pair<double, uint64_t>> distances;
               for (auto it2 = std::next(it); it2 != readMappings.end(); it2++) {
+                  //If this mapping is for the same segment, ignore
+                  if (it2->refSeqId == it->refSeqId && it2->queryStartPos == it->queryStartPos) {
+                    continue;
+                  }
                   //If this mapping is too far from current mapping being evaluated, stop finding a merge
                   if (it2->refSeqId != it->refSeqId || it2->refStartPos > it->refEndPos + max_dist) {
                       break;


### PR DESCRIPTION
* This was causing segments to map to large ranges of repetitive regions.