### PR TITLE
Tune patching

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -338,7 +338,7 @@ void WFlign::wflign_affine_wavefront(
     } else {
         wfa_affine_penalties.match = 0;
         wfa_affine_penalties.mismatch = 4;
-        wfa_affine_penalties.gap_opening = 6;
+        wfa_affine_penalties.gap_opening = 8;
         wfa_affine_penalties.gap_extension = 1;
         /*
         if (mashmap_estimated_identity >= 0.80) {
@@ -554,7 +554,7 @@ void WFlign::wflign_affine_wavefront(
         } else {
             wflambda_affine_penalties.match = 0;
             wflambda_affine_penalties.mismatch = 4;
-            wflambda_affine_penalties.gap_opening = 6;
+            wflambda_affine_penalties.gap_opening = 8;
             wflambda_affine_penalties.gap_extension = 1;
         }
 

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -203,7 +203,10 @@ void do_wfa_patch_alignment(
                      (affine_penalties.gap_extension * std::min(
                        (int)chain_gap,
                        (int)std::max(target_length, query_length)
-                     ));
+                     )) + 32;
+    // + 32 because we are not really setting the MaxScore, but the MaxAlignmentSteps.
+    // AlignmentStep is usually > Score (they are the same with edit-distance)
+    
     wf_aligner.setMaxAlignmentSteps(max_score);
     const int status = wf_aligner.alignEnd2End(target + i,target_length,query + j,query_length);
     aln.ok = (status == WF_STATUS_ALG_COMPLETED);
@@ -933,8 +936,8 @@ void write_merged_alignment(
 #ifdef WFA_PNG_AND_TSV
                                 if (emit_patching_tsv) {
                                     *out_patching_tsv
-                                            << query_name << ":" << query_pos << "-" << query_pos + query_delta << "\t"
-                                            << target_name << ":" << target_pos - target_pointer_shift << "-" << target_pos - target_pointer_shift + target_delta << "\t"
+                                            << query_name << "\t" << query_pos << "\t" << query_pos + query_delta << "\t"
+                                            << target_name << "\t" << (target_pos - target_pointer_shift) << "\t" << (target_pos - target_pointer_shift + target_delta) << "\t"
                                             << patch_aln.ok << std::endl;
                                 }
 #endif

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -105,11 +105,11 @@ void parse_args(int argc,
                                 {'O', "invert-filtering"});
     args::ValueFlag<uint16_t> wflambda_segment_length(alignment_opts, "N", "wflambda segment length: size (in bp) of segment mapped in hierarchical WFA problem [default: 256]", {'W', "wflamda-segment"});
     args::ValueFlag<std::string> wfa_score_params(alignment_opts, "mismatch,gap1,ext1",
-                                            "score parameters for the wfa alignment (affine); match score is fixed at 0 [default: 4,6,1]",//, if 4 values then gaps are affine, if 6 values then gaps are convex",
+                                            "score parameters for the wfa alignment (affine); match score is fixed at 0 [default: 4,8,1]",//, if 4 values then gaps are affine, if 6 values then gaps are convex",
                                             {'g', "wfa-params"});
     //wflign parameters
     args::ValueFlag<std::string> wflign_score_params(alignment_opts, "mismatch,gap1,ext1",
-                                                       "score parameters for the wflign alignment (affine); match score is fixed at 0 [default: 4,6,1]",//, if 4 then gaps are affine, if 6 then gaps are convex [default: 1,4,6,2,26,1]",
+                                                       "score parameters for the wflign alignment (affine); match score is fixed at 0 [default: 4,8,1]",//, if 4 then gaps are affine, if 6 then gaps are convex [default: 1,4,6,2,26,1]",
                                                        {'G', "wflign-params"});
     args::ValueFlag<float> wflign_max_mash_dist(alignment_opts, "N", "maximum mash distance to perform the alignment in a wflambda segment [default: adaptive with respect to the estimated identity]", {'b', "max-mash-dist"});
     args::ValueFlag<int> wflign_min_wavefront_length(alignment_opts, "N", "min wavefront length for heuristic WFlign [default: 1024]", {'j', "wflign-min-wf-len"});


### PR DESCRIPTION
This reduces the number of failing patchings (less INS-DEL CIGAR strings) and changes the gap-opening penalty to get variant representations closer to what you get with other aligners.