### PR TITLE
Make chain gap dynamic

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -419,8 +419,8 @@ void parse_args(int argc,
         map_parameters.chain_gap = l;
         align_parameters.chain_gap = l;
     } else {
-        map_parameters.chain_gap = 20000;
-        align_parameters.chain_gap = 20000;
+        map_parameters.chain_gap = 4*map_parameters.segLength;
+        align_parameters.chain_gap = 4*map_parameters.segLength;
     }
 
     if (drop_low_map_pct_identity) {


### PR DESCRIPTION
* Chaining gap should likely change w/ size of the segment. I've set 4x now, just so that the default behavior remains the same.

Noticed this when testing w/ the data in #233. If users provide a segment size of 500, they likely don't want to chain through 40 missed segments.