### PR TITLE
Handle thread output incrementally

### DIFF
--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -531,8 +531,8 @@ namespace skch
 
       void computeFreqSeedSet()
       {
-        for(auto& [kmerHash, posList] : this->minmerPosLookupIndex) {
-          if (posList.size() / 2 >= this->freqThreshold) {
+        for(auto& [kmerHash, frequency] : this->hashFreq) {
+          if (frequency >= this->freqThreshold) {
             this->frequentSeeds.insert(kmerHash);
           }
         }


### PR DESCRIPTION
* Moved the position-lookup construction code to the thread output handler, so that the map is incrementally constructed as each thread finishes processing a contig as opposed to doing it only once all contigs are indexed. Leads to a much more parallel index construction. Output remains unchanged.
* Improved the index-saving feature so that the frequent seeds are also saved.
* Slightly changed the logging text to be more precise.