### PR TITLE
Avoid division by 0 to determine `minhash_kmer_size`

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -329,7 +329,9 @@ void WFlign::wflign_affine_wavefront(
         return;
     }
 
-    const int minhash_kmer_size = std::max(8, std::min(17, (int)std::floor(1.0 / (1.0 - mashmap_estimated_identity))));
+    // Check if mashmap_estimated_identity == 1 to avoid division by zero, leading to a minhash_kmer_size of 8.
+    // Such low value was leading to confusion in HORs alignments in the human centromeres (high runtime and memory usage, and wrong alignments)
+    const int minhash_kmer_size = mashmap_estimated_identity == 1 ? 17 : std::max(8, std::min(17, (int)std::floor(1.0 / (1.0 - mashmap_estimated_identity))));
 
     // Set penalties for wfa affine
     wflign_penalties_t wfa_affine_penalties;


### PR DESCRIPTION
When the estimated identity is 1, we were getting a division by 0, resulting in a `minhash_kmer_size` equal to 8. While this isn't typically problematic for very highly similar regions, it causes issues inside the human centromeres when aligning their HORs. This leads to increased runtime, high memory usage, and inaccurate alignments.

Here is an example of a chr10 alignment with an HG002 assembly vs HG002v1.0.1:

**Whole wrong region**
![image](https://github.com/waveygang/wfmash/assets/62253982/ef8b08d3-fb06-4561-9b65-e04bc266d7ca)

**Zoom ins**
![image](https://github.com/waveygang/wfmash/assets/62253982/1e275f15-2c8c-4d3b-a895-08426b2ed114)
![image](https://github.com/waveygang/wfmash/assets/62253982/0e08ca89-8109-41ed-8588-97a8deef5017)

