### PR TITLE
Inversion patching

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -91,6 +91,7 @@ WFlign::WFlign(
     this->erode_k = erode_k;
     this->chain_gap = chain_gap;
     this->max_patching_score = max_patching_score;
+    this->min_inversion_length = 23;
     // Query
     this->query_name = nullptr;
     this->query = nullptr;
@@ -539,6 +540,7 @@ void WFlign::wflign_affine_wavefront(
                 erode_k,
                 chain_gap,
                 max_patching_score,
+                min_inversion_length,
                 MIN_WF_LENGTH,
                 wf_max_dist_threshold
 #ifdef WFA_PNG_TSV_TIMING
@@ -1007,6 +1009,7 @@ void WFlign::wflign_affine_wavefront(
                         erode_k,
                         chain_gap,
                         max_patching_score,
+                        min_inversion_length,
                         MIN_WF_LENGTH,
                         wf_max_dist_threshold
 #ifdef WFA_PNG_TSV_TIMING

--- a/src/common/wflign/src/wflign.hpp
+++ b/src/common/wflign/src/wflign.hpp
@@ -64,6 +64,7 @@ namespace wflign {
             int erode_k;
             int64_t chain_gap;
             int max_patching_score;
+            uint64_t min_inversion_length;
             // Query
             const std::string* query_name;
             char* query;

--- a/src/common/wflign/src/wflign_alignment.cpp
+++ b/src/common/wflign/src/wflign_alignment.cpp
@@ -645,6 +645,51 @@ void wflign_edit_cigar_copy(
     cigar_dst->end_offset = cigar_length;
     memcpy(cigar_dst->cigar_ops,cigar_ops,cigar_length);
 }
+
+int calculate_alignment_score(const wflign_cigar_t& cigar, const wflign_penalties_t& penalties) {
+    int score = 0;
+    char prev_op = '\0';
+    int gap_length = 0;
+
+    auto process_gap = [&](char op, int length) {
+        switch (op) {
+            case 'M':
+                // Match is free (best case)
+                break;
+            case 'X':
+                score += length * penalties.mismatch;
+                break;
+            case 'I':
+            case 'D':
+                score += penalties.gap_opening1 + penalties.gap_extension1;
+                if (length > 1) {
+                    score += std::min(
+                        penalties.gap_extension1 * (length - 1),
+                        penalties.gap_opening2 + penalties.gap_extension2 * (length - 1)
+                    );
+                }
+                break;
+        }
+    };
+
+    for (int i = cigar.begin_offset; i <= cigar.end_offset; ++i) {
+        char op = (i < cigar.end_offset) ? cigar.cigar_ops[i] : '\0';  // '\0' to process last gap
+        
+        if (op != prev_op || i == cigar.end_offset) {
+            if (gap_length > 0) {
+                process_gap(prev_op, gap_length);
+            }
+            gap_length = 1;
+        } else {
+            ++gap_length;
+        }
+        
+        prev_op = op;
+    }
+
+    return score;
+}
+
 /*
 // No more necessary
 bool hack_cigar(wfa::cigar_t &cigar, const char *query, const char *target,

--- a/src/common/wflign/src/wflign_alignment.cpp
+++ b/src/common/wflign/src/wflign_alignment.cpp
@@ -11,18 +11,82 @@
 /*
  * Wflign Alignment
  */
-alignment_t::alignment_t() {
-    j = 0;
-    i = 0;
-    query_length = 0;
-    target_length = 0;
-    ok = false;
-    keep = false;
-    edit_cigar = {NULL, 0, 0};
+
+// Default constructor
+alignment_t::alignment_t()
+    : j(0), i(0), query_length(0), target_length(0), ok(false), keep(false) {
+    edit_cigar = {nullptr, 0, 0};
 }
+
+// Destructor
 alignment_t::~alignment_t() {
-    free(edit_cigar.cigar_ops);
+        free(edit_cigar.cigar_ops);
+    }
+
+// Copy constructor
+alignment_t::alignment_t(const alignment_t& other)
+    : j(other.j), i(other.i), query_length(other.query_length),
+      target_length(other.target_length), ok(other.ok), keep(other.keep) {
+    if (other.edit_cigar.cigar_ops) {
+        edit_cigar.cigar_ops = (char*)malloc((other.edit_cigar.end_offset - other.edit_cigar.begin_offset) * sizeof(char));
+        memcpy(edit_cigar.cigar_ops, other.edit_cigar.cigar_ops + other.edit_cigar.begin_offset, 
+               (other.edit_cigar.end_offset - other.edit_cigar.begin_offset) * sizeof(char));
+    } else {
+        edit_cigar.cigar_ops = nullptr;
+    }
+    edit_cigar.begin_offset = 0;
+    edit_cigar.end_offset = other.edit_cigar.end_offset - other.edit_cigar.begin_offset;
 }
+
+// Move constructor
+alignment_t::alignment_t(alignment_t&& other) noexcept
+    : j(other.j), i(other.i), query_length(other.query_length),
+      target_length(other.target_length), ok(other.ok), keep(other.keep),
+      edit_cigar(other.edit_cigar) {
+    other.edit_cigar = {nullptr, 0, 0};
+}
+
+// Copy assignment operator
+alignment_t& alignment_t::operator=(const alignment_t& other) {
+    if (this != &other) {
+        j = other.j;
+        i = other.i;
+        query_length = other.query_length;
+        target_length = other.target_length;
+        ok = other.ok;
+        keep = other.keep;
+
+        free(edit_cigar.cigar_ops);
+        if (other.edit_cigar.cigar_ops) {
+            edit_cigar.cigar_ops = (char*)malloc((other.edit_cigar.end_offset - other.edit_cigar.begin_offset) * sizeof(char));
+            memcpy(edit_cigar.cigar_ops, other.edit_cigar.cigar_ops + other.edit_cigar.begin_offset, 
+                   (other.edit_cigar.end_offset - other.edit_cigar.begin_offset) * sizeof(char));
+        } else {
+            edit_cigar.cigar_ops = nullptr;
+        }
+        edit_cigar.begin_offset = 0;
+        edit_cigar.end_offset = other.edit_cigar.end_offset - other.edit_cigar.begin_offset;
+    }
+    return *this;
+}
+
+// Move assignment operator
+alignment_t& alignment_t::operator=(alignment_t&& other) noexcept {
+    if (this != &other) {
+        j = other.j;
+        i = other.i;
+        query_length = other.query_length;
+        target_length = other.target_length;
+        ok = other.ok;
+        keep = other.keep;
+
+        free(edit_cigar.cigar_ops);
+        edit_cigar = other.edit_cigar;
+        other.edit_cigar = {nullptr, 0, 0};
+    }
+    return *this;
+}
+
 //void alignment_t::display(void) {
 //    std::cerr << j << " " << i << " " << query_length << " "
 //              << target_length << " " << ok << std::endl;

--- a/src/common/wflign/src/wflign_alignment.hpp
+++ b/src/common/wflign/src/wflign_alignment.hpp
@@ -33,8 +33,8 @@ class alignment_t {
 public:
     int j;
     int i;
-    uint16_t query_length;
-    uint16_t target_length;
+    int query_length;
+    int target_length;
     bool ok;
     bool keep;
     wflign_cigar_t edit_cigar;

--- a/src/common/wflign/src/wflign_alignment.hpp
+++ b/src/common/wflign/src/wflign_alignment.hpp
@@ -139,4 +139,6 @@ void wflign_edit_cigar_copy(
         wfa::WFAligner& wf_aligner,
         wflign_cigar_t* const cigar_dst);
 
+int calculate_alignment_score(const wflign_cigar_t& cigar, const wflign_penalties_t& penalties);
+
 #endif /* WFLIGN_ALIGNMENT_HPP_ */

--- a/src/common/wflign/src/wflign_alignment.hpp
+++ b/src/common/wflign/src/wflign_alignment.hpp
@@ -35,21 +35,27 @@ public:
     int i;
     uint16_t query_length;
     uint16_t target_length;
-    bool ok = false;
-    bool keep = false;
+    bool ok;
+    bool keep;
     wflign_cigar_t edit_cigar;
-    // Setup
+    // Default constructor
     alignment_t();
+    // Destructor
     ~alignment_t();
-    // Utils
-//    bool validate(
-//            const char* query,
-//            const char* target);
+    // Copy constructor
+    alignment_t(const alignment_t& other);
+    // Move constructor
+    alignment_t(alignment_t&& other) noexcept;
+    // Copy assignment operator
+    alignment_t& operator=(const alignment_t& other);
+    // Move assignment operator
+    alignment_t& operator=(alignment_t&& other) noexcept;
+    // Trim functions
     void trim_front(int query_trim);
     void trim_back(int query_trim);
-//    // Display
-//    void display(void);
 };
+
+
 /*
  * Wflign Trace-Pos: Links a position in a traceback matrix to its edit
  */

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -472,11 +472,13 @@ void write_merged_alignment(
                 ,&emit_patching_tsv,
                 &out_patching_tsv
 #endif
-        ](std::vector<char> &unpatched,
-                                   std::vector<char> &patched,
-                                   const uint16_t &min_wfa_head_tail_patch_length,
-                                   const uint16_t &min_wfa_patch_length,
-                                   const uint16_t &max_dist_to_look_at) {
+            ](std::vector<char> &unpatched,
+              std::vector<char> &patched,
+              const uint16_t &min_wfa_head_tail_patch_length,
+              const uint16_t &min_wfa_patch_length,
+              const uint16_t &max_dist_to_look_at,
+              bool save_rev_patch_alns) {
+
             auto q = unpatched.begin();
 
             uint64_t query_pos = query_start;
@@ -984,7 +986,7 @@ void write_merged_alignment(
                                         target - target_pointer_shift, target_pos, target_delta,
                                         wf_aligner, convex_penalties, patch_aln, rev_patch_aln,
                                         chain_gap, max_patching_score);
-                                if (rev_patch_aln.ok) {
+                                if (rev_patch_aln.ok && save_rev_patch_alns) {
                                     // we got a good reverse alignment
                                     rev_patch_alns.push_back(rev_patch_aln);
                                 }
@@ -1414,7 +1416,7 @@ void write_merged_alignment(
 
             //std::cerr << "FIRST PATCH ROUND" << std::endl;
             // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-            patching(erodev, pre_tracev, 4096, 32, 512); // In the 1st round, we patch more aggressively
+            patching(erodev, pre_tracev, 4096, 32, 512, false); // In the 1st round, we patch more aggressively and don't save inversions
 
 #ifdef VALIDATE_WFA_WFLIGN
             if (!validate_trace(pre_tracev, query,
@@ -1444,7 +1446,7 @@ void write_merged_alignment(
 
         //std::cerr << "SECOND PATCH ROUND" << std::endl;
         // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-        patching(pre_tracev, tracev, 256, 8, 128); // In the 2nd round, we patch less aggressively
+        patching(pre_tracev, tracev, 256, 8, 128, true); // In the 2nd round, we patch less aggressively but we save inversions
     }
 
     // normalize the indels

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -296,6 +296,7 @@ void do_wfa_patch_alignment(
     if (rev_aln.ok && rev_score < fwd_score) {
         rev_aln.ok = true;
         aln.ok = false;
+#ifdef WFLIGN_DEBUG
         std::cerr << "got better score with reverse complement alignment" << std::endl
               << " query_length " << query_length
               << " target_length " << target_length
@@ -308,6 +309,7 @@ void do_wfa_patch_alignment(
               << "query " << std::string(query + j, query_length)
               << " target " << std::string(target + i, target_length)
               << std::endl;
+#endif
     } else {
         rev_aln.ok = false;
     }

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -216,7 +216,7 @@ void do_wfa_patch_alignment(
     const int status = wf_aligner.alignEnd2End(target + i, target_length, query + j, query_length);
     aln.ok = (status == WF_STATUS_ALG_COMPLETED);
 
-    std::cerr << "score is " << wf_aligner.getAlignmentScore() << std::endl;
+    //std::cerr << "score is " << wf_aligner.getAlignmentScore() << std::endl;
 
     if (aln.ok) {
 #ifdef VALIDATE_WFA_WFLIGN
@@ -243,7 +243,7 @@ void do_wfa_patch_alignment(
         rev_aln.ok = (wf_aligner.getAlignmentScore() > -2147483648 && rev_status == WF_STATUS_ALG_COMPLETED);
 
         if (rev_aln.ok) {
-            std::cerr << "reverse complement alignment worked!" << std::endl;
+            //std::cerr << "reverse complement alignment worked!" << std::endl;
 #ifdef VALIDATE_WFA_WFLIGN
             if (!validate_cigar(wf_aligner.cigar, rev_comp_query.c_str(), target + i, query_length,
                                 target_length, 0, 0)) {
@@ -1824,6 +1824,31 @@ query_start : query_end)
 
     // always clean up
     free(cigarv);
+
+    // write how many reverse complement alignments were found
+    //std::cerr << "got " << rev_patch_alns.size() << " rev patch alns" << std::endl;
+    for (auto& rev_patch_aln : rev_patch_alns) {
+        bool rev_query_is_rev = !query_is_rev;  // Flip the orientation
+        write_alignment(
+            out,
+            rev_patch_aln,
+            query_name,
+            query_total_length,
+            query_offset,
+            query_length,
+            rev_query_is_rev,  // Use the flipped orientation
+            target_name,
+            target_total_length,
+            target_offset,
+            target_length,
+            min_identity,
+            mashmap_estimated_identity,
+            false  // Don't add an endline after each alignment
+            );
+        // write tag indicating that this is a reverse complement alignment
+        out << "\t" << "rc:Z:true" << "\n";
+    }
+    out << std::flush;
 }
 
 void write_alignment(

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -112,7 +112,8 @@ namespace wflign {
                 const uint64_t& target_length, // unused
                 const float& min_identity,
                 const float& mashmap_estimated_identity,
-                const bool& with_endline = true);
+                const bool& with_endline = true,
+                const bool& is_rev_patch = false);
         double float2phred(const double& prob);
         void sort_indels(std::vector<char>& v);
 

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -57,7 +57,8 @@ namespace wflign {
             alignment_t& aln,
             alignment_t& rev_aln,
             const int64_t& chain_gap,
-            const int& max_patching_score);
+            const int& max_patching_score,
+            const uint64_t& min_inversion_length);
         void write_merged_alignment(
                 std::ostream &out,
                 const std::vector<alignment_t *> &trace,
@@ -89,6 +90,7 @@ namespace wflign {
                 const int& erode_k,
                 const int64_t& chain_gap,
                 const int& max_patching_score,
+                const uint64_t& min_inversion_length,
                 const int& min_wf_length,
                 const int& max_dist_threshold,
 #ifdef WFA_PNG_TSV_TIMING

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -46,17 +46,18 @@ namespace wflign {
                 wflign_extend_data_t* extend_data,
                 alignment_t& aln);
         void do_wfa_patch_alignment(
-                const char* query,
-                const uint64_t& j,
-                const uint64_t& query_length,
-                const char* target,
-                const uint64_t& i,
-                const uint64_t& target_length,
-                wfa::WFAlignerGapAffine2Pieces& _wf_aligner,
-                const wflign_penalties_t& convex_penalties,
-                alignment_t& aln,
-                const int64_t& chain_gap,
-                const int& max_patching_score);
+            const char* query,
+            const uint64_t& j,
+            const uint64_t& query_length,
+            const char* target,
+            const uint64_t& i,
+            const uint64_t& target_length,
+            wfa::WFAlignerGapAffine2Pieces& wf_aligner,
+            const wflign_penalties_t& convex_penalties,
+            alignment_t& aln,
+            alignment_t& rev_aln,
+            const int64_t& chain_gap,
+            const int& max_patching_score);
         void write_merged_alignment(
                 std::ostream &out,
                 const std::vector<alignment_t *> &trace,


### PR DESCRIPTION
This adds a way to patch in the reverse complement direction when the forward patching fails. It turns this happen. It actually is capable of detecting inversions in the wflign phase, and these can be as short as detectable with this approach.