### PR TITLE
expose min inversion patch length on CLI

### DIFF
--- a/src/align/include/align_parameters.hpp
+++ b/src/align/include/align_parameters.hpp
@@ -49,6 +49,7 @@ struct Parameters {
     int wflign_erode_k;
     int kmerSize;                                 //kmer size for pre-checking before aligning a fragment
     int64_t chain_gap;                            //max distance for 2d range union-find mapping chaining;
+    int wflign_min_inv_patch_len;                 //minimum length of an inverted patch
     int wflign_max_patching_score;                //maximum score allowed for patching
 
     std::vector<std::string> refSequences;        //reference sequence(s)

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -507,6 +507,7 @@ typedef atomic_queue::AtomicQueue<std::string*, 1024, nullptr, true, true, false
               param.wflign_max_len_minor,
               param.wflign_erode_k,
               param.chain_gap,
+              param.wflign_min_inv_patch_len,
               param.wflign_max_patching_score);
           wflign->set_output(
               &output,

--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -62,6 +62,7 @@ WFlign::WFlign(
     const uint64_t wflign_max_len_minor,
     const int erode_k,
     const int64_t chain_gap,
+    const int min_inversion_length,
     const int max_patching_score) {
     // Parameters
     this->segment_length = segment_length;
@@ -91,7 +92,7 @@ WFlign::WFlign(
     this->erode_k = erode_k;
     this->chain_gap = chain_gap;
     this->max_patching_score = max_patching_score;
-    this->min_inversion_length = 23;
+    this->min_inversion_length = min_inversion_length;
     // Query
     this->query_name = nullptr;
     this->query = nullptr;

--- a/src/common/wflign/src/wflign.hpp
+++ b/src/common/wflign/src/wflign.hpp
@@ -63,8 +63,8 @@ namespace wflign {
             uint64_t wflign_max_len_minor;
             int erode_k;
             int64_t chain_gap;
+            int min_inversion_length;
             int max_patching_score;
-            uint64_t min_inversion_length;
             // Query
             const std::string* query_name;
             char* query;
@@ -117,6 +117,7 @@ namespace wflign {
                     const uint64_t wflign_max_len_minor,
                     const int erode_k,
                     const int64_t chain_gap,
+                    const int min_inversion_length,
                     const int max_patching_score);
             // Set output configuration
             void set_output(

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -124,6 +124,7 @@ void parse_args(int argc,
     args::ValueFlag<std::string> wflign_max_len_major(alignment_opts, "N", "maximum length to patch in the major axis [default: 512*segment-length]", {'C', "max-patch-major"});
     args::ValueFlag<std::string> wflign_max_len_minor(alignment_opts, "N", "maximum length to patch in the minor axis [default: 128*segment-length]", {'F', "max-patch-minor"});
     args::ValueFlag<int> wflign_erode_k(alignment_opts, "N", "maximum length of match/mismatch islands to erode before patching [default: adaptive]", {'E', "erode-match-mismatch"});
+    args::ValueFlag<int> wflign_min_inv_patch_len(alignment_opts, "N", "minimum length of inverted patch for output [default: 23]", {'V', "min-inv-len"});
     args::ValueFlag<int> wflign_max_patching_score(alignment_opts, "N", "maximum score allowed when patching [default: adaptive with respect to gap penalties and sequence length]", {"max-patching-score"});
 
     args::Group output_opts(parser, "[ Output Format Options ]");
@@ -544,6 +545,12 @@ void parse_args(int argc,
         align_parameters.wflign_erode_k = args::get(wflign_erode_k);
     } else {
         align_parameters.wflign_erode_k = -1; // will trigger estimation based on sequence divergence
+    }
+
+    if (wflign_min_inv_patch_len) {
+        align_parameters.wflign_min_inv_patch_len = args::get(wflign_min_inv_patch_len);
+    } else {
+        align_parameters.wflign_min_inv_patch_len = 23;
     }
 
     if (wflign_max_patching_score) {


### PR DESCRIPTION
This completes the updates from inversion patching by exposing a parameter to suppress the output of short inversion patches.