### PR TITLE
allow only creating the index and exiting

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -99,8 +99,9 @@ void parse_args(int argc,
     //args::ValueFlag<std::string> path_high_frequency_kmers(mapping_opts, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
     //args::ValueFlag<std::string> spaced_seed_params(mapping_opts, "spaced-seeds", "Params to generate spaced seeds <weight_of_seed> <number_of_seeds> <similarity> <region_length> e.g \"10 5 0.75 20\"", {'e', "spaced-seeds"});
     args::Flag no_merge(mapping_opts, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
-    args::ValueFlag<std::string> mashmap_index(mapping_opts, "FILE", "Use MashMap index if FILE exists, else create one and save as FILE", {'4', "mm-index"});
-    args::Flag overwrite_mashmap_index(mapping_opts, "", "Confidence value for the hypergeometric filtering [default: 99.9%]", {'5', "overwrite-mm-index"});
+    args::ValueFlag<std::string> mashmap_index(mapping_opts, "FILE", "Use MashMap index in FILE, create if it doesn't exist", {"mm-index"});
+    args::Flag create_mashmap_index_only(mapping_opts, "create-index-only", "Create only the index file without performing mapping", {"create-index-only"});
+    args::Flag overwrite_mashmap_index(mapping_opts, "overwrite-mm-index", "Overwrite MashMap index if it exists", {"overwrite-mm-index"});
 
     args::Group alignment_opts(parser, "[ Alignment Options ]");
     args::ValueFlag<std::string> align_input_paf(alignment_opts, "FILE", "derive precise alignments for this input PAF", {'i', "input-paf"});
@@ -621,6 +622,7 @@ void parse_args(int argc,
     }
 
     map_parameters.overwrite_index = overwrite_mashmap_index;
+    map_parameters.create_index_only = create_mashmap_index_only;
 
     if (approx_mapping) {
         map_parameters.outFileName = "/dev/stdout";

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -54,6 +54,7 @@ struct Parameters
     std::string outFileName;                          //output file name
     stdfs::path indexFilename;                        //output file name of index
     bool overwrite_index;                             //overwrite index if it exists
+    bool create_index_only;                           //only create index and exit
     bool split;                                       //Split read mapping (done if this is true)
     bool lower_triangular;                            // set to true if we should filter out half of the mappings
     bool skip_self;                                   //skip self mappings

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -139,6 +139,11 @@ namespace skch
               {
                 this->writeIndex();
               }
+              if (param.create_index_only)
+              {
+                std::cerr << "[mashmap::skch::Sketch] Index created successfully. Exiting." << std::endl;
+                exit(0);
+              }
             } else {
               this->build(false);
               this->readIndex();


### PR DESCRIPTION
Update to @bkille 's patch that lets us only create the mashmap3 index and then exit. This is useful for e.g. building all indexes before a big run without the need to also create mappings in the process.