### PR TITLE
speed up inversion patching

### DIFF
--- a/src/common/wflign/src/wflign.cpp
+++ b/src/common/wflign/src/wflign.cpp
@@ -1026,7 +1026,7 @@ void WFlign::wflign_affine_wavefront(
             } else {
                 // todo old implementation (and SAM format is not supported)
                 for (auto x = trace.rbegin(); x != trace.rend(); ++x) {
-                    write_alignment(
+                    write_alignment_paf(
                             *out,
                             **x,
                             query_name,

--- a/src/common/wflign/src/wflign_alignment.cpp
+++ b/src/common/wflign/src/wflign_alignment.cpp
@@ -14,7 +14,7 @@
 
 // Default constructor
 alignment_t::alignment_t()
-    : j(0), i(0), query_length(0), target_length(0), ok(false), keep(false) {
+    : j(0), i(0), query_length(0), target_length(0), score(std::numeric_limits<int>::max()), ok(false), keep(false) {
     edit_cigar = {nullptr, 0, 0};
 }
 

--- a/src/common/wflign/src/wflign_alignment.cpp
+++ b/src/common/wflign/src/wflign_alignment.cpp
@@ -14,7 +14,7 @@
 
 // Default constructor
 alignment_t::alignment_t()
-    : j(0), i(0), query_length(0), target_length(0), score(std::numeric_limits<int>::max()), ok(false), keep(false) {
+    : j(0), i(0), query_length(0), target_length(0), score(std::numeric_limits<int>::max()), ok(false), keep(false), is_rev(false) {
     edit_cigar = {nullptr, 0, 0};
 }
 
@@ -25,7 +25,7 @@ alignment_t::~alignment_t() {
 
 // Copy constructor
 alignment_t::alignment_t(const alignment_t& other)
-    : j(other.j), i(other.i), query_length(other.query_length),
+    : j(other.j), i(other.i), query_length(other.query_length), is_rev(other.is_rev),
       target_length(other.target_length), ok(other.ok), keep(other.keep) {
     if (other.edit_cigar.cigar_ops) {
         edit_cigar.cigar_ops = (char*)malloc((other.edit_cigar.end_offset - other.edit_cigar.begin_offset) * sizeof(char));
@@ -40,7 +40,7 @@ alignment_t::alignment_t(const alignment_t& other)
 
 // Move constructor
 alignment_t::alignment_t(alignment_t&& other) noexcept
-    : j(other.j), i(other.i), query_length(other.query_length),
+    : j(other.j), i(other.i), query_length(other.query_length), is_rev(other.is_rev),
       target_length(other.target_length), ok(other.ok), keep(other.keep),
       edit_cigar(other.edit_cigar) {
     other.edit_cigar = {nullptr, 0, 0};
@@ -55,6 +55,7 @@ alignment_t& alignment_t::operator=(const alignment_t& other) {
         target_length = other.target_length;
         ok = other.ok;
         keep = other.keep;
+        is_rev = other.is_rev;
 
         free(edit_cigar.cigar_ops);
         if (other.edit_cigar.cigar_ops) {
@@ -79,6 +80,7 @@ alignment_t& alignment_t::operator=(alignment_t&& other) noexcept {
         target_length = other.target_length;
         ok = other.ok;
         keep = other.keep;
+        is_rev = other.is_rev;
 
         free(edit_cigar.cigar_ops);
         edit_cigar = other.edit_cigar;
@@ -87,19 +89,19 @@ alignment_t& alignment_t::operator=(alignment_t&& other) noexcept {
     return *this;
 }
 
-int alignment_t::query_begin() {
+int alignment_t::query_begin() const {
     return j;
 }
 
-int alignment_t::query_end() {
+int alignment_t::query_end() const {
     return j + query_length;
 }
 
-int alignment_t::target_begin() {
+int alignment_t::target_begin() const {
     return i;
 }
 
-int alignment_t::target_end() {
+int alignment_t::target_end() const {
     return i + target_length;
 }
 
@@ -705,6 +707,28 @@ int calculate_alignment_score(const wflign_cigar_t& cigar, const wflign_penaltie
     }
 
     return score;
+}
+
+std::string cigar_to_string(const wflign_cigar_t& cigar) {
+    std::stringstream ss;
+    const int start_idx = cigar.begin_offset;
+    const int end_idx = cigar.end_offset;
+    for (int c = start_idx; c < end_idx; c++) {
+        ss << cigar.cigar_ops[c];
+    }
+    return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const alignment_t& aln) {
+    return os << "Alignment: "
+              << "Query(" << aln.query_begin() << "-" << aln.query_end() << "/" << aln.query_length << ") "
+              << "Target(" << aln.target_begin() << "-" << aln.target_end() << "/" << aln.target_length << ") "
+              << "Score=" << aln.score << " "
+              << "Rev=" << (aln.is_rev ? "Yes" : "No") << " "
+              << "Status=" << (aln.ok ? "OK" : "NotOK") << " "
+              << "Keep=" << (aln.keep ? "Yes" : "No") << " "
+              << "CIGAR=" << cigar_to_string(aln.edit_cigar) << " "
+              << "Indices(i,j)=(" << aln.i << "," << aln.j << ")";
 }
 
 /*

--- a/src/common/wflign/src/wflign_alignment.hpp
+++ b/src/common/wflign/src/wflign_alignment.hpp
@@ -35,6 +35,7 @@ public:
     int i;
     int query_length;
     int target_length;
+    int score;
     bool ok;
     bool keep;
     bool is_rev;

--- a/src/common/wflign/src/wflign_alignment.hpp
+++ b/src/common/wflign/src/wflign_alignment.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <sstream>
 #include "WFA2-lib/bindings/cpp/WFAligner.hpp"
 
 /*
@@ -57,11 +58,15 @@ public:
     void trim_back(int query_trim);
     // query_begin, query_end, target_begin, target_end
     // Accessors
-    int query_begin();
-    int query_end();
-    int target_begin();
-    int target_end();
+    int query_begin() const;
+    int query_end() const;
+    int target_begin() const;
+    int target_end() const;
 };
+
+// debugging alignment writer
+std::ostream& operator<<(std::ostream& os, const alignment_t& aln);
+// debugging cigar writer
 
 
 /*

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -438,7 +438,6 @@ AlignmentBounds find_alignment_bounds(const alignment_t& aln, const int& erode_k
     int match_count = 0;
     bool found_start = false;
     bool found_end = false;
-    std::cerr << "erode_k = " << erode_k << std::endl;
 
     // Forward pass
     for (int i = aln.edit_cigar.begin_offset; i < aln.edit_cigar.end_offset; ++i) {
@@ -588,12 +587,12 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
     const uint64_t query_end = query_start + query_length;
     const uint64_t target_end = target_start + target_length;
 
-    std::cerr << "BEGIN do_progressive_wfa_patch_alignment: " << current_query_start << " " << remaining_query_length << " " << current_target_start << " " << remaining_target_length << std::endl;
+    //std::cerr << "BEGIN do_progressive_wfa_patch_alignment: " << current_query_start << " " << remaining_query_length << " " << current_target_start << " " << remaining_target_length << std::endl;
     bool first = true;
 
     while (first || remaining_query_length >= min_inversion_length && remaining_target_length >= min_inversion_length) {
         first = false;
-        std::cerr << "do_progressive_wfa_patch_alignment: " << current_query_start << " " << remaining_query_length << " " << current_target_start << " " << remaining_target_length << std::endl;
+        //std::cerr << "do_progressive_wfa_patch_alignment: " << current_query_start << " " << remaining_query_length << " " << current_target_start << " " << remaining_target_length << std::endl;
         alignment_t aln, rev_aln;
         aln.is_rev = false;
         rev_aln.is_rev = true;
@@ -612,14 +611,16 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
             max_patching_score,
             min_inversion_length);
 
-        std::cerr << "WFA fwd alignment: " << aln << std::endl;
-        std::cerr << "WFA rev alignment: " << rev_aln << std::endl;
+        //std::cerr << "WFA fwd alignment: " << aln << std::endl;
+        //std::cerr << "WFA rev alignment: " << rev_aln << std::endl;
 
         if (rev_aln.ok && (!aln.ok || rev_aln.score < aln.score)) {
             alignments.push_back(rev_aln);
         } else if (aln.ok) {
             alignments.push_back(aln);
-            //break;
+            if (alignments.size() == 1) {
+                break;
+            }
         }
 
 #ifdef VALIDATE_WFA_WFLIGN
@@ -645,10 +646,8 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
             break;
         }
         auto& chosen_aln = alignments.back();
-        //auto bounds = ok_find_alignment_bounds(chosen_aln, erode_k);
-        //auto bounds = find_alignment_bounds(chosen_aln, erode_k);
         auto bounds = find_alignment_bounds(chosen_aln, 7); // very light erosion of bounds on ends to avoid single-match starts and ends
-        std::cerr << "bounds: " << bounds.query_start_offset << " " << bounds.query_end_offset << " " << bounds.target_start_offset << " " << bounds.target_end_offset << std::endl;
+        //std::cerr << "bounds: " << bounds.query_start_offset << " " << bounds.query_end_offset << " " << bounds.target_start_offset << " " << bounds.target_end_offset << std::endl;
                 
 #ifdef VALIDATE_WFA_WFLIGN
         {
@@ -699,20 +698,16 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
         uint64_t max_left_size = std::max(left_query_size, left_target_size);
         uint64_t max_right_size = std::max(right_query_size, right_target_size);
 
-        std::cerr << "left_query_size: " << left_query_size << " left_target_size: " << left_target_size << std::endl
-                  << "right_query_size: " << right_query_size << " right_target_size: " << right_target_size << std::endl
-                  << "max_left_size: " << max_left_size << " max_right_size: " << max_right_size << std::endl;
+        //std::cerr << "left_query_size: " << left_query_size << " left_target_size: " << left_target_size << std::endl
+        //          << "right_query_size: " << right_query_size << " right_target_size: " << right_target_size << std::endl
+        //          << "max_left_size: " << max_left_size << " max_right_size: " << max_right_size << std::endl;
 
         if (max_left_size >= max_right_size && max_left_size > 0) {
-            std::cerr << "aligning left region" << std::endl
-                      << "left_query_size: " << left_query_size << " left_target_size: " << left_target_size << std::endl;
             // Align the left region
             remaining_query_length = left_query_size;
             remaining_target_length = left_target_size;
             // current_query_start and current_target_start remain unchanged
         } else if (max_right_size > 0) {
-            std::cerr << "aligning right region" << std::endl
-                      << "right_query_size: " << right_query_size << " right_target_size: " << right_target_size << std::endl;
             // Align the right region
             current_query_start += bounds.query_end_offset;
             current_target_start += bounds.target_end_offset;

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -2203,7 +2203,7 @@ void write_alignment_sam(
     if (patch_gap_compressed_identity >= min_identity) {
 
         out << query_name << "\t"
-            << (query_is_rev ? "16" : "0") << "\t"
+            << (query_is_rev ^ patch_aln.is_rev ? "16" : "0") << "\t"
             << target_name << "\t"
             << target_offset + patch_aln.i + 1 << "\t"
             << std::round(float2phred(1.0 - patch_block_identity)) << "\t"
@@ -2217,7 +2217,7 @@ void write_alignment_sam(
             for (uint64_t p = patch_aln.j; p < patch_aln.j + patch_aln.query_length; ++p) {
                 seq << query[p];
             }
-            if (query_is_rev) {
+            if (patch_aln.is_rev) {
                 // reverse complement
                 out << reverse_complement(seq.str());
             } else {

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -1223,10 +1223,12 @@ void write_merged_alignment(
 
 #ifdef WFA_PNG_TSV_TIMING
                                 if (emit_patching_tsv) {
-                                    *out_patching_tsv
+                                    for (auto& aln : patch_alignments) {
+                                        *out_patching_tsv
                                             << query_name << "\t" << query_pos << "\t" << query_pos + query_delta << "\t"
                                             << target_name << "\t" << (target_pos - target_pointer_shift) << "\t" << (target_pos - target_pointer_shift + target_delta) << "\t"
-                                            << patch_aln.ok << std::endl;
+                                            << aln.ok << std::endl;
+                                    }
                                 }
 #endif
                             }

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -438,6 +438,7 @@ AlignmentBounds find_alignment_bounds(const alignment_t& aln, const int& erode_k
     int match_count = 0;
     bool found_start = false;
     bool found_end = false;
+    std::cerr << "erode_k = " << erode_k << std::endl;
 
     // Forward pass
     for (int i = aln.edit_cigar.begin_offset; i < aln.edit_cigar.end_offset; ++i) {
@@ -455,16 +456,16 @@ AlignmentBounds find_alignment_bounds(const alignment_t& aln, const int& erode_k
                 ++target_pos;
                 break;
             case 'X':
-                match_count = 0;
+                //match_count = 0;
                 ++query_pos;
                 ++target_pos;
                 break;
             case 'I':
-                match_count = 0;
+                //match_count = 0;
                 ++query_pos;
                 break;
             case 'D':
-                match_count = 0;
+                //match_count = 0;
                 ++target_pos;
                 break;
         }
@@ -490,16 +491,16 @@ AlignmentBounds find_alignment_bounds(const alignment_t& aln, const int& erode_k
                 --target_pos;
                 break;
             case 'X':
-                match_count = 0;
+                //match_count = 0;
                 --query_pos;
                 --target_pos;
                 break;
             case 'I':
-                match_count = 0;
+                //match_count = 0;
                 --query_pos;
                 break;
             case 'D':
-                match_count = 0;
+                //match_count = 0;
                 --target_pos;
                 break;
         }
@@ -511,16 +512,16 @@ AlignmentBounds find_alignment_bounds(const alignment_t& aln, const int& erode_k
         bounds.target_start_offset = 0;
     } else {
         // heuristic: subtract erode_k
-        //bounds.query_start_offset = std::max((int64_t)0, bounds.query_start_offset - erode_k);
-        //bounds.target_start_offset = std::max((int64_t)0, bounds.target_start_offset - erode_k);
+        bounds.query_start_offset = std::max((int64_t)0, bounds.query_start_offset - erode_k);
+        bounds.target_start_offset = std::max((int64_t)0, bounds.target_start_offset - erode_k);
     }
     if (!found_end) {
         bounds.query_end_offset = aln.query_length;
         bounds.target_end_offset = aln.target_length;
     } else {
         // heuristic: add erode_k
-        //bounds.query_end_offset = std::min((int64_t)aln.query_length, bounds.query_end_offset + erode_k);
-        //bounds.target_end_offset = std::min((int64_t)aln.target_length, bounds.target_end_offset + erode_k);
+        bounds.query_end_offset = std::min((int64_t)aln.query_length, bounds.query_end_offset + erode_k);
+        bounds.target_end_offset = std::min((int64_t)aln.target_length, bounds.target_end_offset + erode_k);
     }
 
     // Adjust bounds for reverse complement alignments
@@ -644,7 +645,9 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
             break;
         }
         auto& chosen_aln = alignments.back();
-        auto bounds = find_alignment_bounds(chosen_aln, erode_k);
+        //auto bounds = ok_find_alignment_bounds(chosen_aln, erode_k);
+        //auto bounds = find_alignment_bounds(chosen_aln, erode_k);
+        auto bounds = find_alignment_bounds(chosen_aln, 7); // very light erosion of bounds on ends to avoid single-match starts and ends
         std::cerr << "bounds: " << bounds.query_start_offset << " " << bounds.query_end_offset << " " << bounds.target_start_offset << " " << bounds.target_end_offset << std::endl;
                 
 #ifdef VALIDATE_WFA_WFLIGN

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -1215,8 +1215,7 @@ void write_merged_alignment(
                                 if (rev_patch_aln.ok && save_multi_patch_alns) {
                                     //
                                     do_progressive_patch = true;
-                                }
-                                if (patch_aln.ok) {
+                                } else if (patch_aln.ok) {
                                     got_alignment = true;
                                     const int start_idx =
                                             patch_aln.edit_cigar.begin_offset;
@@ -1253,11 +1252,11 @@ void write_merged_alignment(
                                         if (aln.ok) {
                                             // avoid overlapping patches: if alignments is non-empty, pop alignments off its back until
                                             // the current query and target start are greater than the query and target end of the last alignment
+                                            /*
                                             while (!multi_patch_alns.empty()
                                                    && (multi_patch_alns.back().query_end() > aln.query_begin()
                                                        || multi_patch_alns.back().target_end() > aln.target_begin())) {
                                                 // write some info about the popped alignment vs the current one
-                                                /*
                                                 std::cerr << std::endl
                                                           << "Popped alignment: "
                                                           << multi_patch_alns.back().query_begin() << "-" << multi_patch_alns.back().query_end()
@@ -1265,9 +1264,9 @@ void write_merged_alignment(
                                                     // target
                                                           << multi_patch_alns.back().target_begin() << "-" << multi_patch_alns.back().target_end()
                                                           << " vs " << aln.target_begin() << "-" << aln.target_end() << std::endl;
-                                                */
                                                 multi_patch_alns.pop_back();
                                             }
+                                            */
                                             multi_patch_alns.push_back(aln);
                                         }
                                     }
@@ -1677,7 +1676,7 @@ void write_merged_alignment(
 
             //std::cerr << "FIRST PATCH ROUND" << std::endl;
             // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-            patching(erodev, pre_tracev, 4096, 32, 512, false); // one patching pass
+            patching(erodev, pre_tracev, 4096, 32, 512, false);
 
 #ifdef VALIDATE_WFA_WFLIGN
             if (!validate_trace(pre_tracev, query,
@@ -1707,8 +1706,7 @@ void write_merged_alignment(
 
         //std::cerr << "SECOND PATCH ROUND" << std::endl;
         // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-        // in some tests long ago this appeared to help, but now it's unclear if it's necessary
-        patching(pre_tracev, tracev, 256, 8, 128, true); // In the 2nd round, we patch less aggressively but we save inversions
+        patching(pre_tracev, tracev, 256, 8, 128, true);
     }
 
     // normalize the indels

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -2283,38 +2283,8 @@ void write_alignment_paf(
         double block_identity =
                 (double)matches /
                 (double)(matches + mismatches + inserted_bp + deleted_bp);
-        // convert our coordinates to be relative to forward strand (matching
-        // PAF standard)
 
         if (gap_compressed_identity >= min_identity) {
-            //uint64_t q_start = query_offset;
-            /*
-            if (query_is_rev && !is_rev_patch) {
-                q_start =
-                    query_offset + (query_length - (aln.j + qAlignedLength));
-            } else {
-                q_start = query_offset + aln.j;
-                }*/
-            /*
-            << query_offset +
-                (query_is_rev ? query_length - query_end : query_start)
-                << "\t"
-                << query_offset +
-                   (query_is_rev ? query_length - query_start : query_end)
-            */
-            std::cerr << "query_is_rev: " << query_is_rev
-                      << ", aln.is_rev: " << aln.is_rev
-                        << ", query_offset: " << query_offset
-                        << ", query_length: " << query_length
-                        << ", aln.j: " << aln.j
-                        << ", qAlignedLength: " << qAlignedLength
-                        << ", aln.query_length: " << aln.query_length
-                      << std::endl;
-            // four cases
-            // 1. query is forward, alignment is forward
-            // 2. query is forward, alignment is reverse
-            // 3. query is reverse, alignment is forward
-            // 4. query is reverse, alignment is reverse
             uint64_t q_start, q_end;
             if (query_is_rev) {
                 q_start = query_offset + (query_length - aln.j - qAlignedLength);

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -1677,13 +1677,13 @@ void write_merged_alignment(
 
             //std::cerr << "FIRST PATCH ROUND" << std::endl;
             // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-            patching(erodev, tracev, 4096, 32, 512, true); // one patchin gpass
+            patching(erodev, pre_tracev, 4096, 32, 512, false); // one patching pass
 
 #ifdef VALIDATE_WFA_WFLIGN
-            if (!validate_trace(tracev, query,
+            if (!validate_trace(pre_tracev, query,
                         target - target_pointer_shift, query_length,
                         target_length_mut, query_start, target_start)) {
-                std::cerr << "cigar failure in tracev "
+                std::cerr << "cigar failure in pre_tracev "
                           << "\t" << query_name << "\t" << query_total_length
                           << "\t"
                           << query_offset + (query_is_rev
@@ -1702,13 +1702,13 @@ void write_merged_alignment(
 #endif
 
             // normalize: sort so that I<D and otherwise leave it as-is
-            //sort_indels(pre_tracev);
+            sort_indels(pre_tracev);
         }
 
         //std::cerr << "SECOND PATCH ROUND" << std::endl;
         // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
         // in some tests long ago this appeared to help, but now it's unclear if it's necessary
-        //patching(pre_tracev, tracev, 256, 8, 128, true); // In the 2nd round, we patch less aggressively but we save inversions
+        patching(pre_tracev, tracev, 256, 8, 128, true); // In the 2nd round, we patch less aggressively but we save inversions
     }
 
     // normalize the indels

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <functional>
 #include <fstream>
+#include <sstream>
 #include <lodepng/lodepng.h>
 
 #include "dna.hpp"
@@ -114,7 +115,35 @@ namespace wflign {
                 std::ostream* out_patching_tsv,
 #endif
                 const bool& with_endline = true);
-        void write_alignment(
+        void write_tag_and_md_string(
+            std::ostream &out,
+            const char *cigar_ops,
+            const int cigar_start,
+            const int cigar_end,
+            const int target_start,
+            const char *target,
+            const int64_t target_offset,
+            const int64_t target_pointer_shift);
+        void write_alignment_sam(
+            std::ostream &out,
+            const alignment_t& patch_aln,
+            const std::string& query_name,
+            const uint64_t& query_total_length,
+            const uint64_t& query_offset,
+            const uint64_t& query_length,
+            const bool& query_is_rev,
+            const std::string& target_name,
+            const uint64_t& target_total_length,
+            const uint64_t& target_offset,
+            const uint64_t& target_length,
+            const float& min_identity,
+            const float& mashmap_estimated_identity,
+            const bool& no_seq_in_sam,
+            const bool& emit_md_tag,
+            const char* query,
+            const char* target,
+            const int64_t& target_pointer_shift);
+        void write_alignment_paf(
                 std::ostream& out,
                 const alignment_t& aln,
                 const std::string& query_name,

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -59,6 +59,7 @@ namespace wflign {
             const int64_t& chain_gap,
             const int& max_patching_score,
             const uint64_t& min_inversion_length);
+        void trim_alignment(alignment_t& aln);
         std::vector<alignment_t> do_progressive_wfa_patch_alignment(
             const char* query,
             const uint64_t& query_start,

--- a/src/common/wflign/src/wflign_patch.hpp
+++ b/src/common/wflign/src/wflign_patch.hpp
@@ -72,7 +72,6 @@ namespace wflign {
             const int& max_patching_score,
             const uint64_t& min_inversion_length,
             const int& erode_k);
-        void trim_alignment(alignment_t& aln);
         void write_merged_alignment(
                 std::ostream &out,
                 const std::vector<alignment_t *> &trace,


### PR DESCRIPTION
Major speedup from capping the inverse patch alignment score with the score from the forward patch. In most cases, this is pretty good, leading to a short-circuit of the inverse patch. This gives a big speedup.

Second potential improvement: single patching round. Rationale: with BiWFA we don't need to stress about multiple rounds. We always patch global. @AndreaGuarracino if you have a test case showing the need for 2 rounds, lmk.