### PR TITLE
axis-weighted chaining

### DIFF
--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -1630,7 +1630,6 @@ void write_merged_alignment(
 #endif
         };
 
-        std::vector<char> pre_tracev;
         {
             std::vector<char> erodev;
             {
@@ -1787,13 +1786,13 @@ void write_merged_alignment(
 
             //std::cerr << "FIRST PATCH ROUND" << std::endl;
             // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-            patching(erodev, pre_tracev, 4096, 32, 512, false);
+            patching(erodev, tracev, 4096, 8, 512, false);
 
 #ifdef VALIDATE_WFA_WFLIGN
-            if (!validate_trace(pre_tracev, query,
+            if (!validate_trace(tracev, query,
                         target - target_pointer_shift, query_length,
                         target_length_mut, query_start, target_start)) {
-                std::cerr << "cigar failure in pre_tracev "
+                std::cerr << "cigar failure in tracev "
                           << "\t" << query_name << "\t" << query_total_length
                           << "\t"
                           << query_offset + (query_is_rev
@@ -1811,13 +1810,7 @@ void write_merged_alignment(
             }
 #endif
 
-            // normalize: sort so that I<D and otherwise leave it as-is
-            sort_indels(pre_tracev);
         }
-
-        //std::cerr << "SECOND PATCH ROUND" << std::endl;
-        // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-        patching(pre_tracev, tracev, 256, 8, 128, true);
     }
 
     // normalize the indels

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -86,7 +86,7 @@ void parse_args(int argc,
     args::Flag approx_mapping(mapping_opts, "approx-map", "skip base-level alignment, producing an approximate mapping in PAF", {'m',"approx-map"});
     args::Flag no_split(mapping_opts, "no-split", "disable splitting of input sequences during mapping [default: enabled]", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "N", "chain mappings closer than this distance in query and target, sets approximate maximum variant length detectable in alignment [default: 6*segment_length, up to 30k]", {'c', "chain-gap"});
-    args::ValueFlag<std::string> max_mapping_length(mapping_opts, "N", "maximum length of a single mapping before breaking [default: 1M]", {'P', "max-mapping-length"});
+    args::ValueFlag<std::string> max_mapping_length(mapping_opts, "N", "maximum length of a single mapping before breaking [default: inf]", {'P', "max-mapping-length"});
     args::Flag drop_low_map_pct_identity(mapping_opts, "K", "drop mappings with estimated identity below --map-pct-id=%", {'K', "drop-low-map-id"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "F", "drop mappings overlapping more than fraction F with a higher scoring mapping [default: 0.5]", {'O', "overlap-threshold"});
     args::Flag no_filter(mapping_opts, "MODE", "disable mapping filtering", {'f', "no-filter"});
@@ -439,7 +439,7 @@ void parse_args(int argc,
         }
         map_parameters.max_mapping_length = l;
     } else {
-        map_parameters.max_mapping_length = 1000000; // 1 Mbp default
+        map_parameters.max_mapping_length = std::numeric_limits<int64_t>::max();
     }
 
     if (drop_low_map_pct_identity) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1585,7 +1585,7 @@ namespace skch
 
       double axis_weighted_euclidean_distance(int64_t dx, int64_t dy, double w = 0.5) {
           double euclidean = std::sqrt(dx*dx + dy*dy);
-          double axis_factor = (dx + dy > 0) ? 1.0 - (2.0 * std::min(std::abs(dx), std::abs(dy))) / (std::abs(dx) + std::abs(dy)) : 0.0;
+          double axis_factor = 1.0 - (2.0 * std::min(std::abs(dx), std::abs(dy))) / (std::abs(dx) + std::abs(dy));
           return euclidean * (1.0 + w * axis_factor);
       }
       


### PR DESCRIPTION
This adjusts the chaining so that we permit less distance to be traversed off-diagonal, aiming for up to our chain gap on the x=y diagonal but less off diagonal. Includes a lot of tweaks for better performance at large scale.