### PR TITLE
smooth the introduction of max mapping length parameter

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -441,6 +441,11 @@ void parse_args(int argc,
         map_parameters.max_mapping_length = 50000;
     }
 
+    if (map_parameters.segLength >= map_parameters.max_mapping_length) {
+        std::cerr << "[wfmash] ERROR, skch::parseandSave, segment length should not be larger than max mapping length." << std::endl;
+        exit(1);
+    }
+
     if (drop_low_map_pct_identity) {
         map_parameters.keep_low_pct_id = false;
     } else {

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -223,6 +223,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
 
     }
     std::cerr << "[mashmap] Chaining gap max = " << parameters.chain_gap << std::endl;
+    std::cerr << "[mashmap] Max mapping length = " << parameters.max_mapping_length << std::endl;
     std::cerr << "[mashmap] Mappings per segment = " << parameters.numMappingsForSegment << std::endl;
     std::cerr << "[mashmap] Percentage identity threshold = " << 100 * parameters.percentageIdentity << "\%" << std::endl;
 


### PR DESCRIPTION
We were previously using large values of `-s`, which now seems to reliably segfault if segment length exceeds the default max mapping length of 50k. Increasing `-P` or decreasing `-s` fixes this. It doesn't seem to matter if the block length or chain gap exceed `-P`. 

This just adds an early exit if segment length exceeds the max mapping length. Also prints the max mapping length out to the log (although technically this isn't part of mashmap, but it seemed easier to do there).