### PR TITLE
minimap3 parallelism improvements

### DIFF
--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -521,8 +521,8 @@ void computeAlignments() {
 
     // Create queues
     atomic_queue::AtomicQueue<std::string*, 1024> line_queue;
-    atomic_queue::AtomicQueue<InputSeqProgContainer*, 1024> seq_queue;
-    atomic_queue::AtomicQueue<MapModuleOutput*, 1024> output_queue;
+    atomic_queue::AtomicQueue<skch::InputSeqProgContainer*, 1024> seq_queue;
+    atomic_queue::AtomicQueue<skch::MapModuleOutput*, 1024> output_queue;
 
     // Calculate max_processors based on the number of worker threads
     size_t max_processors = std::max(1UL, static_cast<unsigned long>(param.threads));
@@ -565,14 +565,14 @@ void computeAlignments() {
     std::vector<std::thread> workers;
     std::vector<std::atomic<bool>> worker_working(param.threads);
     for (uint64_t t = 0; t < param.threads; ++t) {
-        workers.emplace_back([this, t, &worker_working, &seq_queue, &paf_queue, &reader_done, &processor_done, &progress, &processed_alignment_length]() {
-            this->worker_thread(t, worker_working[t], seq_queue, paf_queue, reader_done, processor_done, progress, processed_alignment_length);
+        workers.emplace_back([this, t, &worker_working, &seq_queue, &output_queue, &reader_done, &processor_done, &progress, &processed_alignment_length]() {
+            this->worker_thread(t, worker_working[t], seq_queue, output_queue, reader_done, processor_done, progress, processed_alignment_length);
         });
     }
 
     // Launch writer thread
-    std::thread writer([this, &paf_queue, &reader_done, &processor_done, &worker_working]() {
-        this->writer_thread(param.pafOutputFile, paf_queue, reader_done, processor_done, worker_working);
+    std::thread writer([this, &output_queue, &reader_done, &processor_done, &worker_working]() {
+        this->writer_thread(param.pafOutputFile, output_queue, reader_done, processor_done, worker_working);
     });
 
     // Wait for all threads to complete

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -521,8 +521,8 @@ void computeAlignments() {
 
     // Create queues
     atomic_queue::AtomicQueue<std::string*, 1024> line_queue;
-    seq_atomic_queue_t seq_queue;
-    paf_atomic_queue_t paf_queue;  // Add this line
+    atomic_queue::AtomicQueue<InputSeqProgContainer*, 1024> seq_queue;
+    atomic_queue::AtomicQueue<MapModuleOutput*, 1024> output_queue;
 
     // Calculate max_processors based on the number of worker threads
     size_t max_processors = std::max(1UL, static_cast<unsigned long>(param.threads));

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -390,7 +390,7 @@ namespace skch
               seqiter::for_each_seq_in_file_filtered(
                   fileName,
                   param.query_prefix,
-                  allowed_query_names,
+                  param.allowed_query_names,
                   [&](const std::string& seq_name,
                       const std::string& seq) {
                       offset_t len = seq.length();
@@ -473,7 +473,7 @@ namespace skch
                   if (param.filterMode == filter::ONETOONE) {
                       // Save for another filtering round
                       std::lock_guard<std::mutex> guard(qmetadata_mutex);
-                      allReadMappings.insert(allReadMappings.end(), output->readMappings.begin(), output->readMappings.end());
+                      this->allReadMappings.insert(this->allReadMappings.end(), output->readMappings.begin(), output->readMappings.end());
                   } else {
                       // Report mapping
                       reportReadMappings(output->readMappings, output->qseqName, outstrm);
@@ -494,7 +494,7 @@ namespace skch
               int n_mappings = param.numMappingsForSegment - 1;
 
               // Group sequences by query prefix, then pass to ref filter
-              auto subrange_begin = allReadMappings.begin();
+              auto subrange_begin = this->allReadMappings.begin();
               auto subrange_end = allReadMappings.begin();
               MappingResultsVector_t tmpMappings;
               MappingResultsVector_t filteredMappings;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -274,6 +274,9 @@ namespace skch
 
           // Allowed set of queries
           std::unordered_set<std::string> allowed_query_names;
+          
+          // Mutex for allReadMappings
+          std::mutex allReadMappings_mutex;
           if (!param.query_list.empty()) {
               std::ifstream filter_list(param.query_list);
               std::string name;
@@ -390,7 +393,7 @@ namespace skch
               seqiter::for_each_seq_in_file_filtered(
                   fileName,
                   param.query_prefix,
-                  param.query_list,
+                  allowed_query_names,
                   [&](const std::string& seq_name,
                       const std::string& seq) {
                       offset_t len = seq.length();
@@ -472,7 +475,7 @@ namespace skch
 
                   if (param.filterMode == filter::ONETOONE) {
                       // Save for another filtering round
-                      std::lock_guard<std::mutex> guard(qmetadata_mutex);
+                      std::lock_guard<std::mutex> guard(allReadMappings_mutex);
                       allReadMappings.insert(allReadMappings.end(), output->readMappings.begin(), output->readMappings.end());
                   } else {
                       // Report mapping

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -390,7 +390,7 @@ namespace skch
               seqiter::for_each_seq_in_file_filtered(
                   fileName,
                   param.query_prefix,
-                  param.allowed_query_names,
+                  param.query_list,
                   [&](const std::string& seq_name,
                       const std::string& seq) {
                       offset_t len = seq.length();
@@ -473,7 +473,7 @@ namespace skch
                   if (param.filterMode == filter::ONETOONE) {
                       // Save for another filtering round
                       std::lock_guard<std::mutex> guard(qmetadata_mutex);
-                      this->allReadMappings.insert(this->allReadMappings.end(), output->readMappings.begin(), output->readMappings.end());
+                      allReadMappings.insert(allReadMappings.end(), output->readMappings.begin(), output->readMappings.end());
                   } else {
                       // Report mapping
                       reportReadMappings(output->readMappings, output->qseqName, outstrm);
@@ -494,7 +494,7 @@ namespace skch
               int n_mappings = param.numMappingsForSegment - 1;
 
               // Group sequences by query prefix, then pass to ref filter
-              auto subrange_begin = this->allReadMappings.begin();
+              auto subrange_begin = allReadMappings.begin();
               auto subrange_end = allReadMappings.begin();
               MappingResultsVector_t tmpMappings;
               MappingResultsVector_t filteredMappings;


### PR DESCRIPTION
The goal of this branch is to run minimap3 in a more parallel mode, particularly important when mapping a small number of contigs against each other. Parallelism is currently over query contig. This can be broken down much further, potentially over individual segments, although the final merging and filtering steps will remain single threaded per query sequence. An additional goal is to break the target index into chunks, so that we will be able to limit total memory usage. In this case as well we'll need to collect all `unfilteredMappings` from each subset of the full query/target comparison. I'm trying to work through the problem in small chunks without breaking the build or tests.