### PR TITLE
Fix uint64_t underflow

### DIFF
--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -691,9 +691,9 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
         /// ....
         // Calculate the sizes of unaligned regions using only the bounds
         uint64_t left_query_size = bounds.query_start_offset;
-        uint64_t right_query_size = remaining_query_length - bounds.query_end_offset;
+        uint64_t right_query_size = remaining_query_length > bounds.query_end_offset ? remaining_query_length - bounds.query_end_offset : 0;
         uint64_t left_target_size = bounds.target_start_offset;
-        uint64_t right_target_size = remaining_target_length - bounds.target_end_offset;
+        uint64_t right_target_size = remaining_target_length > bounds.target_end_offset ? remaining_target_length - bounds.target_end_offset : 0;
 
         uint64_t max_left_size = std::max(left_query_size, left_target_size);
         uint64_t max_right_size = std::max(right_query_size, right_target_size);


### PR DESCRIPTION
This fixes an issue where the alignment step would crash with
```
[wfmash::align::computeAlignments] aligned 21.03% @ 3.01e+06 bp/s elapsed: 00:00:01:31 remain: 00:00:05:41
terminate called after throwing an instance of 'std::length_error'
  what():  basic_string::_M_create
```

This PR fixes this specific case, but there are still other cases where underflow might be possible due to using `uint64_t`. I'd be in favor of converting all of the `uint64_t` to `int64_t`, since afaik there isn't any bitmasking and the 63 bits are sufficient for the coordinates. 