### PR TITLE
Subindexes in one file and remove frequent kmer filtering

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -74,7 +74,6 @@ void parse_args(int argc,
     args::ValueFlag<uint32_t> num_mappings_for_segments(mapping_opts, "N", "number of mappings to retain for each query/reference pair [default: 1]", {'n', "num-mappings-for-segment"});
     args::ValueFlag<uint32_t> num_mappings_for_short_seq(mapping_opts, "N", "number of mappings to retain for each query/reference pair where the query sequence is shorter than segment length [default: 1]", {'S', "num-mappings-for-short-seq"});
     args::ValueFlag<int> kmer_size(mapping_opts, "N", "kmer size [default: 15]", {'k', "kmer"});
-    args::ValueFlag<float> kmer_pct_threshold(mapping_opts, "%", "ignore the top % most-frequent kmers [default: 0.001]", {'H', "kmer-threshold"});
     args::Flag lower_triangular(mapping_opts, "", "only map shorter sequences against longer", {'L', "lower-triangular"});
     args::Flag skip_self(mapping_opts, "", "skip self mappings when the query and target name is the same (for all-vs-all mode)", {'X', "skip-self"});
     args::Flag one_to_one(mapping_opts, "", "Perform one-to-one filtering", {'4', "one-to-one"});
@@ -469,12 +468,6 @@ void parse_args(int argc,
                                   (map_parameters.percentageIdentity >= 0.9 ? 17 : 15));
         */
         map_parameters.kmerSize = 15;
-    }
-
-    if (kmer_pct_threshold) {
-        map_parameters.kmer_pct_threshold = args::get(kmer_pct_threshold);
-    } else {
-        map_parameters.kmer_pct_threshold = 0.001; // in percent! so we keep 99.999% of kmers
     }
 
     //if (spaced_seed_params) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -93,9 +93,9 @@ void parse_args(int argc,
     //ToFix: args::Flag keep_ties(mapping_opts, "", "keep all mappings with equal score even if it results in more than n mappings", {'D', "keep-ties"});
     args::ValueFlag<int64_t> sketch_size(mapping_opts, "N", "sketch size for sketching.", {'w', "sketch-size"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "F", "Drop segments w/ predicted kmer complexity below this cutoff. Kmer complexity defined as #kmers / (s - k + 1)", {'J', "kmer-complexity"});
-    args::Flag no_hg_filter(mapping_opts, "", "Don't use the hypergeometric filtering and instead use the MashMap2 first pass filtering.", {'1', "no-hg-filter"});
-    args::ValueFlag<double> hg_filter_ani_diff(mapping_opts, "%", "Filter out mappings unlikely to be this ANI less than the best mapping [default: 0.0]", {'2', "hg-filter-ani-diff"});
-    args::ValueFlag<double> hg_filter_conf(mapping_opts, "%", "Confidence value for the hypergeometric filtering [default: 99.9%]", {'3', "hg-filter-conf"});
+    args::Flag hg_filter(mapping_opts, "", "Use the hypergeometric filtering instead of the MashMap2 first pass filtering.", {"hg-filter"});
+    args::ValueFlag<double> hg_filter_ani_diff(mapping_opts, "%", "Filter out mappings unlikely to be this ANI less than the best mapping [default: 0.0]", {"hg-filter-ani-diff"});
+    args::ValueFlag<double> hg_filter_conf(mapping_opts, "%", "Confidence value for the hypergeometric filtering [default: 99.9%]", {"hg-filter-conf"});
     //args::Flag window_minimizers(mapping_opts, "", "Use window minimizers rather than world minimizers", {'U', "window-minimizers"});
     //args::ValueFlag<std::string> path_high_frequency_kmers(mapping_opts, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
     //args::ValueFlag<std::string> spaced_seed_params(mapping_opts, "spaced-seeds", "Params to generate spaced seeds <weight_of_seed> <number_of_seeds> <similarity> <region_length> e.g \"10 5 0.75 20\"", {'e', "spaced-seeds"});
@@ -608,7 +608,7 @@ void parse_args(int argc,
 
     map_parameters.filterLengthMismatches = true;
 
-    map_parameters.stage1_topANI_filter = !bool(no_hg_filter); 
+    map_parameters.stage1_topANI_filter = bool(hg_filter);
     map_parameters.stage2_full_scan = true;
 
     if (hg_filter_ani_diff)

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -93,7 +93,7 @@ void parse_args(int argc,
     //ToFix: args::Flag keep_ties(mapping_opts, "", "keep all mappings with equal score even if it results in more than n mappings", {'D', "keep-ties"});
     args::ValueFlag<int64_t> sketch_size(mapping_opts, "N", "sketch size for sketching.", {'w', "sketch-size"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "F", "Drop segments w/ predicted kmer complexity below this cutoff. Kmer complexity defined as #kmers / (s - k + 1)", {'J', "kmer-complexity"});
-    args::Flag hg_filter(mapping_opts, "", "Use the hypergeometric filtering instead of the MashMap2 first pass filtering.", {"hg-filter"});
+    args::Flag no_hg_filter(mapping_opts, "", "Don't use the hypergeometric filtering and instead use the MashMap2 first pass filtering.", {"no-hg-filter"});
     args::ValueFlag<double> hg_filter_ani_diff(mapping_opts, "%", "Filter out mappings unlikely to be this ANI less than the best mapping [default: 0.0]", {"hg-filter-ani-diff"});
     args::ValueFlag<double> hg_filter_conf(mapping_opts, "%", "Confidence value for the hypergeometric filtering [default: 99.9%]", {"hg-filter-conf"});
     //args::Flag window_minimizers(mapping_opts, "", "Use window minimizers rather than world minimizers", {'U', "window-minimizers"});
@@ -608,7 +608,7 @@ void parse_args(int argc,
 
     map_parameters.filterLengthMismatches = true;
 
-    map_parameters.stage1_topANI_filter = bool(hg_filter);
+    map_parameters.stage1_topANI_filter = !bool(no_hg_filter);
     map_parameters.stage2_full_scan = true;
 
     if (hg_filter_ani_diff)

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -470,12 +470,6 @@ namespace skch
         // For each subset of target sequences
         uint64_t subset_count = 0;
         for (const auto& target_subset : target_subsets) {
-            std::cerr << "processing subset " << subset_count << " of " << target_subsets.size() << std::endl;
-            std::cerr << "entries: ";
-            for (const auto& seqName : target_subset) {
-                std::cerr << seqName << " ";
-            }
-            std::cerr << std::endl;
             if (target_subset.empty()) {
                 continue;  // Skip empty subsets
             }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -470,6 +470,7 @@ namespace skch
         // Build index for the current subset
         // Open the index file once
         std::ifstream indexStream;
+        std::ifstream indexStream;
         if (!param.indexFilename.empty() && !param.create_index_only) {
             indexStream.open(param.indexFilename.string(), std::ios::binary);
             if (!indexStream) {
@@ -488,8 +489,7 @@ namespace skch
             if (!param.indexFilename.empty() && !param.create_index_only) {
                 // Load index from file
                 std::cerr << "[mashmap::skch::Map::mapQuery] Loading index for subset " << subset_count << std::endl;
-                refSketch = new skch::Sketch(param, *idManager, target_subset);
-                refSketch->readIndex(indexStream, target_subset);
+                refSketch = new skch::Sketch(param, *idManager, target_subset, &indexStream);
             } else {
                 refSketch = new skch::Sketch(param, *idManager, target_subset);
             }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -470,7 +470,6 @@ namespace skch
         // Build index for the current subset
         // Open the index file once
         std::ifstream indexStream;
-        std::ifstream indexStream;
         if (!param.indexFilename.empty() && !param.create_index_only) {
             indexStream.open(param.indexFilename.string(), std::ios::binary);
             if (!indexStream) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -200,17 +200,6 @@ namespace skch
             p.query_list,
             p.target_list))
           {
-              std::cerr << "Initializing Map with parameters:" << std::endl;
-              std::cerr << "Query sequences: " << p.querySequences.size() << std::endl;
-              std::cerr << "Reference sequences: " << p.refSequences.size() << std::endl;
-              std::cerr << "Query prefix: " << (p.query_prefix.empty() ? "None" : p.query_prefix[0]) << std::endl;
-              std::cerr << "Target prefix: " << (p.target_prefix.empty() ? "None" : p.target_prefix) << std::endl;
-              std::cerr << "Prefix delimiter: '" << p.prefix_delim << "'" << std::endl;
-              std::cerr << "Query list: " << (p.query_list.empty() ? "None" : p.query_list) << std::endl;
-              std::cerr << "Target list: " << (p.target_list.empty() ? "None" : p.target_list) << std::endl;
-              
-              idManager->dumpState();
-              
               if (p.stage1_topANI_filter) {
                   this->setProbs();
               }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -497,7 +497,7 @@ namespace skch
                 // Save the index to a file
                 std::string indexFilename = param.indexFilename.string();
                 bool append = (subset_count != 0); // Append if not the first subset
-                refSketch->writeIndex(indexFilename, append);
+                refSketch->writeIndex(target_subset, indexFilename, append);
                 std::cerr << "[mashmap::skch::Map::mapQuery] Index created for subset " << subset_count 
                           << " and saved to " << indexFilename << std::endl;
             } else {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1019,11 +1019,7 @@ namespace skch
           const double max_hash_01 = (long double)(Q.minmerTableQuery.back().hash) / std::numeric_limits<hash_t>::max();
           Q.kmerComplexity = (double(Q.minmerTableQuery.size()) / max_hash_01) / ((Q.len - param.kmerSize + 1)*2);
 
-          // TODO remove them from the original sketch instead of removing for each read
-          auto new_end = std::remove_if(Q.minmerTableQuery.begin(), Q.minmerTableQuery.end(), [&](auto& mi) {
-            return refSketch->isFreqSeed(mi.hash);
-          });
-          Q.minmerTableQuery.erase(new_end, Q.minmerTableQuery.end());
+          // Removed frequent kmer filtering
 
           Q.sketchSize = Q.minmerTableQuery.size();
 #ifdef DEBUG

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -467,6 +467,17 @@ namespace skch
 
         std::unordered_map<seqno_t, MappingResultsVector_t> combinedMappings;
 
+        // Build index for the current subset
+        // Open the index file once
+        std::ifstream indexStream;
+        if (!param.indexFilename.empty() && !param.create_index_only) {
+            indexStream.open(param.indexFilename.string(), std::ios::binary);
+            if (!indexStream) {
+                std::cerr << "Error: Unable to open index file: " << param.indexFilename << std::endl;
+                exit(1);
+            }
+        }
+
         // For each subset of target sequences
         uint64_t subset_count = 0;
         for (const auto& target_subset : target_subsets) {
@@ -474,19 +485,9 @@ namespace skch
                 continue;  // Skip empty subsets
             }
 
-            // Build index for the current subset
-            // Open the index file once
-            std::ifstream indexStream;
-            if (!param.indexFilename.empty() && !param.create_index_only) {
-                indexStream.open(param.indexFilename.string(), std::ios::binary);
-                if (!indexStream) {
-                    std::cerr << "Error: Unable to open index file: " << param.indexFilename << std::endl;
-                    exit(1);
-                }
-            }
-
             if (!param.indexFilename.empty() && !param.create_index_only) {
                 // Load index from file
+                std::cerr << "[mashmap::skch::Map::mapQuery] Loading index for subset " << subset_count << std::endl;
                 refSketch = new skch::Sketch(param, *idManager, target_subset);
                 refSketch->readIndex(indexStream, target_subset);
             } else {

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -32,7 +32,6 @@ struct ales_params {
 struct Parameters
 {
     int kmerSize;                                     //kmer size for sketching
-    float kmer_pct_threshold;                         //use only kmers not in the top kmer_pct_threshold %-ile
     offset_t segLength;                                //For split mapping case, this represents the fragment length
                                                       //for noSplit, it represents minimum read length to multimap
     offset_t block_length;                             // minimum (potentially merged) block to keep if we aren't split

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -94,7 +94,6 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     cmd.defineOption("kmer", "kmer size [default : 19]", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("kmer","k");
 
-    cmd.defineOption("kmerThreshold", "ignore the top \% most-frequent kmer window [default: 0.001]", ArgvParser::OptionRequiresValue);
     cmd.defineOption("kmerComplexity", "threshold for kmer complexity [0, 1] [default : 0.0]", ArgvParser::OptionRequiresValue);
 
 
@@ -490,14 +489,6 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     } else {
         parameters.keep_low_pct_id = true;
     }
-
-    if (cmd.foundOption("kmerThreshold")) {
-        str << cmd.optionValue("kmerThreshold");
-        str >> parameters.kmer_pct_threshold;
-    } else {
-        parameters.kmer_pct_threshold = 0.001; // in percent! so we keep 99.999% of kmers
-    }
-    str.clear();
 
     if (cmd.foundOption("numMappingsForSegment")) {
       uint32_t n;

--- a/src/map/include/sequenceIds.hpp
+++ b/src/map/include/sequenceIds.hpp
@@ -35,35 +35,6 @@ public:
         allPrefixes.insert(allPrefixes.end(), targetPrefixes.begin(), targetPrefixes.end());
         populateFromFiles(queryFiles, targetFiles, queryPrefixes, targetPrefixes, prefixDelim, queryList, targetList);
         buildRefGroups();
-        dumpState(); // Add this line to dump the state after initialization
-    }
-
-    // Add this method to dump the state of SequenceIdManager
-    void dumpState() const {
-        std::cerr << "SequenceIdManager State:" << std::endl;
-        std::cerr << "Total sequences: " << metadata.size() << std::endl;
-        std::cerr << "Query sequences: " << querySequenceNames.size() << std::endl;
-        std::cerr << "Target sequences: " << targetSequenceNames.size() << std::endl;
-        std::cerr << "\nSequence details:" << std::endl;
-        for (size_t i = 0; i < metadata.size(); ++i) {
-            std::cerr << "ID: " << i 
-                      << ", Name: " << metadata[i].name 
-                      << ", Length: " << metadata[i].len 
-                      << ", Group: " << metadata[i].groupId 
-                      << ", Type: " << (std::find(querySequenceNames.begin(), querySequenceNames.end(), metadata[i].name) != querySequenceNames.end() ? "Query" : "Target")
-                      << std::endl;
-        }
-        std::cerr << "\nGroup details:" << std::endl;
-        std::unordered_map<int, std::vector<std::string>> groupToSequences;
-        for (const auto& info : metadata) {
-            groupToSequences[info.groupId].push_back(info.name);
-        }
-        for (const auto& [groupId, sequences] : groupToSequences) {
-            std::cerr << "Group " << groupId << ": " << sequences.size() << " sequences" << std::endl;
-            for (const auto& seq : sequences) {
-                std::cerr << "  " << seq << std::endl;
-            }
-        }
     }
 
     seqno_t getSequenceId(const std::string& sequenceName) const {

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -574,7 +574,7 @@ namespace skch
         readParameters(inStream);
         readSketchBinary(inStream);
         readPosListBinary(inStream);
-        readFreqKmersBinary(inStream);
+        // Removed readFreqKmersBinary call
       }
 
       bool readSubIndexHeader(std::ifstream& inStream, const std::vector<std::string>& targetSequenceNames) 
@@ -642,8 +642,7 @@ namespace skch
         minmerPosLookupIndex.clear();
         minmerIndex.clear();
         minmerFreqHistogram.clear();
-        frequentSeeds.clear();
-        freqThreshold = std::numeric_limits<uint64_t>::max();
+        // Removed frequentSeeds and freqThreshold
       }
 
     }; //End of class Sketch

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -173,7 +173,7 @@ namespace skch
         this->hashFreq.clear();
         if (!param.indexFilename.empty())
         {
-            this->writeIndex();
+            this->writeIndex(targets);
         }
 
         std::cerr << "[mashmap::skch::Sketch] Unique minmer hashes after pruning = " << (minmerPosLookupIndex.size() - this->frequentSeeds.size()) << std::endl;
@@ -461,7 +461,7 @@ namespace skch
       /**
        * @brief  Write all index data structures to disk
        */
-      void writeIndex(const std::string& filename = "", bool append = false) 
+      void writeIndex(const std::vector<std::string>& target_subset, const std::string& filename = "", bool append = false) 
       {
         fs::path indexFilename = filename.empty() ? fs::path(param.indexFilename) : fs::path(filename);
         std::ofstream outStream;
@@ -474,7 +474,7 @@ namespace skch
             std::cerr << "Error: Unable to open index file for writing: " << indexFilename << std::endl;
             exit(1);
         }
-        writeSubIndexHeader(outStream);
+        writeSubIndexHeader(outStream, target_subset);
         writeParameters(outStream);
         writeSketchBinary(outStream);
         writePosListBinary(outStream);
@@ -482,13 +482,13 @@ namespace skch
         outStream.close();
       }
 
-      void writeSubIndexHeader(std::ofstream& outStream) 
+      void writeSubIndexHeader(std::ofstream& outStream, const std::vector<std::string>& target_subset) 
       {
         const uint64_t magic_number = 0xDEADBEEFCAFEBABE;
         outStream.write(reinterpret_cast<const char*>(&magic_number), sizeof(magic_number));
-        uint64_t num_sequences = idManager.getTargetSequenceNames().size();
+        uint64_t num_sequences = target_subset.size();
         outStream.write(reinterpret_cast<const char*>(&num_sequences), sizeof(num_sequences));
-        for (const auto& seqName : idManager.getTargetSequenceNames()) {
+        for (const auto& seqName : target_subset) {
             uint64_t name_length = seqName.size();
             outStream.write(reinterpret_cast<const char*>(&name_length), sizeof(name_length));
             outStream.write(seqName.c_str(), name_length);

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -623,6 +623,19 @@ namespace skch
             inStream.read(&seqName[0], name_length);
             sequenceNames.push_back(seqName);
         }
+        
+        // Debug: Print sequences from the index
+        std::cerr << "Sequences from the index:" << std::endl;
+        for (const auto& name : sequenceNames) {
+            std::cerr << name << std::endl;
+        }
+        
+        // Debug: Print expected sequences
+        std::cerr << "Expected sequences:" << std::endl;
+        for (const auto& name : targetSequenceNames) {
+            std::cerr << name << std::endl;
+        }
+        
         return sequenceNames == targetSequenceNames;
       }
 

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -67,8 +67,6 @@ namespace skch
       //algorithm parameters
       skch::Parameters param;
 
-      // Removed frequent kmer tracking
-
       //Make the default constructor protected, non-accessible
       protected:
       Sketch(SequenceIdManager& idMgr) : idManager(idMgr) {}
@@ -163,7 +161,6 @@ namespace skch
         std::cerr << "[mashmap::skch::Sketch] Initializing Sketch..." << std::endl;
         
         this->build(true, targets);
-        // Removed frequent kmer related function calls
         this->hashFreq.clear();
         if (!param.indexFilename.empty())
         {
@@ -530,12 +527,6 @@ namespace skch
 
 
       /**
-       * @brief  read frequent kmers from file
-       */
-      // Removed readFreqKmersBinary function
-
-
-      /**
        * @brief  Read parameters and compare to CLI params
        */
       void readParameters(std::ifstream& inStream)
@@ -600,12 +591,6 @@ namespace skch
       }
 
 
-      /**
-       * @brief   report the frequency histogram of minmers using position lookup index
-       *          and compute which high frequency minmers to ignore
-       */
-      // Removed computeFreqHist function
-
       public:
 
       /**
@@ -634,15 +619,12 @@ namespace skch
         return this->minmerIndex.end();
       }
 
-      // Removed frequent kmer related functions
-
       void clear()
       {
         hashFreq.clear();
         minmerPosLookupIndex.clear();
         minmerIndex.clear();
         minmerFreqHistogram.clear();
-        // Removed frequentSeeds and freqThreshold
       }
 
     }; //End of class Sketch

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -135,7 +135,7 @@ namespace skch
           idManager(idMgr)
       {
         if (indexStream) {
-          loadIndex(*indexStream);
+          readIndex(*indexStream, targets);
         } else {
           initialize(targets);
         }

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -130,30 +130,23 @@ namespace skch
       Sketch(skch::Parameters p,
              SequenceIdManager& idMgr,
              const std::vector<std::string>& targets = {},
-             const std::string& indexFilename = "")
+             std::ifstream* indexStream = nullptr)
         : param(std::move(p)),
           idManager(idMgr)
       {
-        if (!indexFilename.empty()) {
-          loadIndex(indexFilename);
+        if (indexStream) {
+          loadIndex(*indexStream);
         } else {
           initialize(targets);
         }
       }
 
-      void loadIndex(const std::string& indexFilename) {
-        std::ifstream inStream(indexFilename, std::ios::binary);
-        if (!inStream) {
-          std::cerr << "Error: Unable to open index file: " << indexFilename << std::endl;
-          exit(1);
-        }
+      void loadIndex(std::ifstream& inStream) {
         readParameters(inStream);
         readSketchBinary(inStream);
         readPosListBinary(inStream);
-        // Removed readFreqKmersBinary call
-        inStream.close();
         isInitialized = true;
-        std::cerr << "[mashmap::skch::Sketch] Sketch loaded from index file: " << indexFilename << std::endl;
+        std::cerr << "[mashmap::skch::Sketch] Sketch loaded from index stream" << std::endl;
       }
 
     public:

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -558,6 +558,7 @@ namespace skch
        */
       void readIndex(std::ifstream& inStream, const std::vector<std::string>& targetSequenceNames) 
       {
+        std::cerr << "[mashmap::skch::Sketch::readIndex] Reading index" << std::endl;
         if (!readSubIndexHeader(inStream, targetSequenceNames)) {
             std::cerr << "Error: Sequences in the index do not match the expected target sequences." << std::endl;
             exit(1);
@@ -592,14 +593,6 @@ namespace skch
 
 
       public:
-
-      /**
-       * @brief               search hash associated with given position inside the index
-       * @details             if MIIter_t iter is returned, than *iter's wpos >= winpos
-       * @param[in]   seqId
-       * @param[in]   winpos
-       * @return              iterator to the minmer in the index
-       */
 
       /**
        * @brief                 check if iterator points to index end

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -624,18 +624,6 @@ namespace skch
             sequenceNames.push_back(seqName);
         }
         
-        // Debug: Print sequences from the index
-        std::cerr << "Sequences from the index:" << std::endl;
-        for (const auto& name : sequenceNames) {
-            std::cerr << name << std::endl;
-        }
-        
-        // Debug: Print expected sequences
-        std::cerr << "Expected sequences:" << std::endl;
-        for (const auto& name : targetSequenceNames) {
-            std::cerr << name << std::endl;
-        }
-        
         return sequenceNames == targetSequenceNames;
       }
 

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -166,23 +166,6 @@ namespace skch
       void initialize(const std::vector<std::string>& targets = {}) {
         std::cerr << "[mashmap::skch::Sketch] Initializing Sketch..." << std::endl;
         
-        // Calculate total sequence length
-        /*
-        for (const auto& fileName : param.refSequences) {
-            std::cerr << "targets are " << targets.size() << " ";
-            for (const auto& target : targets) {
-                std::cerr << target << " ";
-            }
-            std::cerr << std::endl;
-            seqiter::for_each_seq_in_file(
-                fileName,
-                targets,
-                [&](const std::string& seq_name, const std::string& seq) {
-                    total_seq_length += seq.length();
-                });
-        }
-        */
-        
         this->build(true, targets);
         this->computeFreqHist();
         this->computeFreqSeedSet();
@@ -291,7 +274,6 @@ namespace skch
         std::chrono::time_point<std::chrono::system_clock> t0 = skch::Time::now();
 
         if (compute_seeds) {
-            std::cerr << "creating seeds" << std::endl;
 
           //Create the thread pool 
           ThreadPool<InputSeqContainer, MI_Type> threadPool([this](InputSeqContainer* e) { return buildHelper(e); }, param.threads);
@@ -306,13 +288,11 @@ namespace skch
               fileName,
               target_names,
               [&](const std::string& seq_name, const std::string& seq) {
-                  std::cerr << "on sequence " << seq_name << std::endl;
                   if (seq.length() >= param.segLength) {
                       seqno_t seqId = idManager.getSequenceId(seq_name);
                       threadPool.runWhenThreadAvailable(new InputSeqContainer(seq, seq_name, seqId));
                       totalSeqProcessed++;
                       shortestSeqLength = std::min(shortestSeqLength, seq.length());
-                      std::cerr << "DEBUG: Processing sequence: " << seq_name << " (length: " << seq.length() << ")" << std::endl;
 
                       //Collect output if available
                       while (threadPool.outputAvailable()) {
@@ -330,7 +310,6 @@ namespace skch
           
           // Update sequencesByFileInfo
           // Removed as sequencesByFileInfo is no longer used
-          std::cerr << "[mashmap::skch::Sketch::build] Shortest sequence length: " << shortestSeqLength << std::endl;
 
           //Collect remaining output objects
           while (threadPool.running())

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -486,9 +486,9 @@ namespace skch
       {
         const uint64_t magic_number = 0xDEADBEEFCAFEBABE;
         outStream.write(reinterpret_cast<const char*>(&magic_number), sizeof(magic_number));
-        uint64_t num_sequences = idManager.getSequenceNames().size();
+        uint64_t num_sequences = idManager.getTargetSequenceNames().size();
         outStream.write(reinterpret_cast<const char*>(&num_sequences), sizeof(num_sequences));
-        for (const auto& seqName : idManager.getSequenceNames()) {
+        for (const auto& seqName : idManager.getTargetSequenceNames()) {
             uint64_t name_length = seqName.size();
             outStream.write(reinterpret_cast<const char*>(&name_length), sizeof(name_length));
             outStream.write(seqName.c_str(), name_length);

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -80,9 +80,6 @@ namespace skch
       using MIIter_t = MI_Type::const_iterator;
       using HF_Map_t = ankerl::unordered_dense::map<hash_t, uint64_t>;
 
-      // Frequency of each hash
-      HF_Map_t hashFreq;
-
       public:
         uint64_t total_seq_length = 0;
 
@@ -146,15 +143,10 @@ namespace skch
         std::cerr << "[mashmap::skch::Sketch] Initializing Sketch..." << std::endl;
         
         this->build(true, targets);
-        this->hashFreq.clear();
-        if (!param.indexFilename.empty())
-        {
-            this->writeIndex(targets);
-        }
 
         std::cerr << "[mashmap::skch::Sketch] Unique minmer hashes = " << minmerPosLookupIndex.size() << std::endl;
         std::cerr << "[mashmap::skch::Sketch] Total minmer windows after pruning = " << minmerIndex.size() << std::endl;
-        std::cerr << "[mashmap::skch::Sketch] Number of sequences = " << idManager.size() << std::endl;
+        std::cerr << "[mashmap::skch::Sketch] Number of sequences = " << targets.size() << std::endl;
         isInitialized = true;
         std::cerr << "[mashmap::skch::Sketch] Sketch initialization complete." << std::endl;
       }
@@ -203,7 +195,6 @@ namespace skch
                   uint64_t seq_length = output->first;
                   MI_Type* minmers = output->second;
                   for (const auto& mi : *minmers) {
-                      this->hashFreq[mi.hash]++;
                       if (minmerPosLookupIndex[mi.hash].size() == 0 
                           || minmerPosLookupIndex[mi.hash].back().hash != mi.hash 
                           || minmerPosLookupIndex[mi.hash].back().pos != mi.wpos)
@@ -341,7 +332,6 @@ namespace skch
       {
         for (MinmerInfo& mi : *contigMinmerIndex)
         {
-          this->hashFreq[mi.hash]++;
           if (minmerPosLookupIndex[mi.hash].size() == 0 
                   || minmerPosLookupIndex[mi.hash].back().hash != mi.hash 
                   || minmerPosLookupIndex[mi.hash].back().pos != mi.wpos)
@@ -599,7 +589,6 @@ namespace skch
 
       void clear()
       {
-        hashFreq.clear();
         minmerPosLookupIndex.clear();
         minmerIndex.clear();
         minmerFreqHistogram.clear();

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -141,14 +141,6 @@ namespace skch
         }
       }
 
-      void loadIndex(std::ifstream& inStream) {
-        readParameters(inStream);
-        readSketchBinary(inStream);
-        readPosListBinary(inStream);
-        isInitialized = true;
-        std::cerr << "[mashmap::skch::Sketch] Sketch loaded from index stream" << std::endl;
-      }
-
     public:
       void initialize(const std::vector<std::string>& targets = {}) {
         std::cerr << "[mashmap::skch::Sketch] Initializing Sketch..." << std::endl;


### PR DESCRIPTION
Fixes a lot of bugs with subindexing. We remove the kmer frequency based filtering which isn't compatible with subindexing and which appears to cause issues in repeats. However, at present we're still not getting exactly the same results when mapping against subindexes and not. Investigating.