### PR TITLE
break if both fwd and rev alignments are not okay

### DIFF
--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -613,7 +613,11 @@ std::vector<alignment_t> do_progressive_wfa_patch_alignment(
 
         //std::cerr << "WFA fwd alignment: " << aln << std::endl;
         //std::cerr << "WFA rev alignment: " << rev_aln << std::endl;
-
+        
+        // If both the forward and reverse alignments are not okay, we break here to avoid an occasional infinite loop
+        if (!rev_aln.ok && !aln.ok) {
+            break;
+        }
         if (rev_aln.ok && (!aln.ok || rev_aln.score < aln.score)) {
             alignments.push_back(rev_aln);
         } else if (aln.ok) {


### PR DESCRIPTION
At least on same test cases that were getting stuck from #262, this change seems to be enough. If the forward and reverse alignments both fail, it seems reasonable anyway to break out. This doesn't appear to conflict with #288, which still froze at this stage. 

The resulting alignment looked fine after checking with pafcheck, so this may not catch every case, but seems to resolve all cases I do have.