### PR TITLE
Tweak hits

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -330,7 +330,7 @@ void parse_args(int argc,
             std::cerr << "[wfmash] ERROR, skch::parseandSave, chain gap has to be a float value greater than or equal to 0." << std::endl;
             exit(1);
         }
-        map_parameters.chain_gap = l;
+        map_parameters.chain_gap = l;p
         align_parameters.chain_gap = l;
     } else {
         map_parameters.chain_gap = 2000;
@@ -521,6 +521,8 @@ void parse_args(int argc,
 
     map_parameters.filterLengthMismatches = true;
 
+    // OMG This must be rewritten to remove these args parsing flags, which are broken, and to correctly use the hg_filer comma-separated list above, and if it's not set, to use the defaults!!!!!!!!!
+    
     args::Flag no_hg_filter(mapping_opts, "", "disable hypergeometric filter", {"no-hg-filter"});
     map_parameters.stage1_topANI_filter = !bool(no_hg_filter);
     map_parameters.stage2_full_scan = true;

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -328,7 +328,7 @@ void parse_args(int argc,
             std::cerr << "[wfmash] ERROR, skch::parseandSave, chain gap has to be a float value greater than or equal to 0." << std::endl;
             exit(1);
         }
-        map_parameters.chain_gap = l;p
+        map_parameters.chain_gap = l;
         align_parameters.chain_gap = l;
     } else {
         map_parameters.chain_gap = 2000;

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -97,6 +97,7 @@ void parse_args(int argc,
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
     args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
+    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {"min-hits"});
 
     args::Group alignment_opts(options_group, "Alignment:");
     args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF/SAM file for alignment", {'i', "input-mapping"});
@@ -548,6 +549,8 @@ void parse_args(int argc,
 
     if (min_hits) {
         map_parameters.minimum_hits = args::get(min_hits);
+    } else {
+        map_parameters.minimum_hits = -1; // auto
     }
 
     //if (window_minimizers) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -98,6 +98,7 @@ void parse_args(int argc,
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
     args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
     args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {"min-hits"});
+    args::ValueFlag<uint64_t> max_kmer_freq(mapping_opts, "INT", "maximum allowed k-mer frequency [unlimited]", {"max-kmer-freq"});
 
     args::Group alignment_opts(options_group, "Alignment:");
     args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF/SAM file for alignment", {'i', "input-mapping"});
@@ -551,6 +552,12 @@ void parse_args(int argc,
         map_parameters.minimum_hits = args::get(min_hits);
     } else {
         map_parameters.minimum_hits = -1; // auto
+    }
+
+    if (max_kmer_freq) {
+        map_parameters.max_kmer_freq = args::get(max_kmer_freq);
+    } else {
+        map_parameters.max_kmer_freq = std::numeric_limits<uint64_t>::max(); // unlimited
     }
 
     //if (window_minimizers) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -101,7 +101,7 @@ void parse_args(int argc,
     args::ValueFlag<uint64_t> max_kmer_freq(mapping_opts, "INT", "maximum allowed k-mer frequency [unlimited]", {'F', "max-kmer-freq"});
 
     args::Group alignment_opts(options_group, "Alignment:");
-    args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF/SAM file for alignment", {'i', "input-mapping"});
+    args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF file for alignment", {'i', "align-paf"});
     args::ValueFlag<std::string> wfa_params(alignment_opts, "vals", 
         "scoring: mismatch, gap1(o,e), gap2(o,e) [6,6,2,26,1]", {'g', "wfa-params"});
 
@@ -607,7 +607,7 @@ void parse_args(int argc,
         }
 
         if (input_mapping) {
-            // directly use the input mapping file
+            // directly use the input PAF file
             yeet_parameters.remapping = true;
             map_parameters.outFileName = args::get(input_mapping);
             align_parameters.mashmapPafFile = args::get(input_mapping);

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -535,12 +535,17 @@ void parse_args(int argc,
     }
 
     args::ValueFlag<double> hg_filter_conf(mapping_opts, "FLOAT", "hypergeometric filter confidence [99.9]", {"hg-filter-conf"});
+    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {"min-hits"});
     if (hg_filter_conf)
     {
         map_parameters.ANIDiffConf = args::get(hg_filter_conf);
         map_parameters.ANIDiffConf /= 100;
     } else {
         map_parameters.ANIDiffConf = skch::fixed::ANIDiffConf;
+    }
+
+    if (min_hits) {
+        map_parameters.minimum_hits = args::get(min_hits);
     }
 
     //if (window_minimizers) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -150,7 +150,7 @@ void parse_args(int argc,
     }
 
     map_parameters.skip_self = false;
-    map_parameters.lower_triangular = args::get(lower_triangular);
+    map_parameters.lower_triangular = lower_triangular ? args::get(lower_triangular) : false;
     map_parameters.keep_low_pct_id = true;
 
     if (skip_prefix) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -97,8 +97,8 @@ void parse_args(int argc,
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
     args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {"min-hits"});
-    args::ValueFlag<uint64_t> max_kmer_freq(mapping_opts, "INT", "maximum allowed k-mer frequency [unlimited]", {"max-kmer-freq"});
+    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {'H', "l1-hits"});
+    args::ValueFlag<uint64_t> max_kmer_freq(mapping_opts, "INT", "maximum allowed k-mer frequency [unlimited]", {'F', "max-kmer-freq"});
 
     args::Group alignment_opts(options_group, "Alignment:");
     args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF/SAM file for alignment", {'i', "input-mapping"});

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1453,7 +1453,9 @@ namespace skch
 
           //3. Compute L1 windows
           int minimumHits;
-          if (Q.len == cached_segment_length) {
+          if (param.minimum_hits > 0) {
+              minimumHits = param.minimum_hits;
+          } else if (Q.len == cached_segment_length) {
               minimumHits = cached_minimum_hits;
           } else {
               minimumHits = Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval);

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -492,7 +492,7 @@ namespace skch
                   << "cached_minimum_hits=" << cached_minimum_hits << " "
                   << "sketch_size=" << param.sketchSize << " "
                   << "kmer_size=" << param.kmerSize << " "
-                  << "percent_identity=" << param.percentageIdentity << std::endl;
+                  << "percent_identity=" << (param.percentageIdentity * 100) << "%" << std::endl;
 
         //Count of reads mapped by us
         //Some reads are dropped because of short length

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -209,7 +209,7 @@ namespace skch
             p.query_list,
             p.target_list)),
         cached_segment_length(p.segLength),
-        cached_minimum_hits(Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval))
+        cached_minimum_hits(p.minimum_hits > 0 ? p.minimum_hits : Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval))
           {
               // Initialize sequence names right after creating idManager
               this->querySequenceNames = idManager->getQuerySequenceNames();
@@ -1452,14 +1452,12 @@ namespace skch
           getSeedIntervalPoints(Q, intervalPoints);
 
           //3. Compute L1 windows
-          int minimumHits;
-          if (param.minimum_hits > 0) {
-              minimumHits = param.minimum_hits;
-          } else if (Q.len == cached_segment_length) {
-              minimumHits = cached_minimum_hits;
-          } else {
-              minimumHits = Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval);
-          }
+          // Always respect the minimum hits parameter if set
+          int minimumHits = param.minimum_hits > 0 ? 
+              param.minimum_hits : 
+              (Q.len == cached_segment_length ? 
+                  cached_minimum_hits : 
+                  Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval));
 
           // For each "group"
           auto ip_begin = intervalPoints.begin();

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -487,13 +487,12 @@ namespace skch
 
       void mapQuery()
       {
-        std::cerr << "[wfmash::mashmap] L1 filtering parameters:"
-                  << "\n  cached segment length: " << cached_segment_length
-                  << "\n  cached minimum hits: " << cached_minimum_hits 
-                  << "\n  sketch size: " << param.sketchSize
-                  << "\n  kmer size: " << param.kmerSize
-                  << "\n  percent identity: " << param.percentageIdentity
-                  << std::endl;
+        std::cerr << "[wfmash::mashmap] L1 filtering parameters: "
+                  << "cached_segment_length=" << cached_segment_length << " "
+                  << "cached_minimum_hits=" << cached_minimum_hits << " "
+                  << "sketch_size=" << param.sketchSize << " "
+                  << "kmer_size=" << param.kmerSize << " "
+                  << "percent_identity=" << param.percentageIdentity << std::endl;
 
         //Count of reads mapped by us
         //Some reads are dropped because of short length

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -487,12 +487,7 @@ namespace skch
 
       void mapQuery()
       {
-        std::cerr << "[wfmash::mashmap] L1 filtering parameters: "
-                  << "cached_segment_length=" << cached_segment_length << " "
-                  << "cached_minimum_hits=" << cached_minimum_hits << " "
-                  << "sketch_size=" << param.sketchSize << " "
-                  << "kmer_size=" << param.kmerSize << " "
-                  << "percent_identity=" << (param.percentageIdentity * 100) << "%" << std::endl;
+        std::cerr << "[wfmash::mashmap] L1 filtering parameters: cached_minimum_hits=" << cached_minimum_hits << std::endl;
 
         //Count of reads mapped by us
         //Some reads are dropped because of short length

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -487,6 +487,14 @@ namespace skch
 
       void mapQuery()
       {
+        std::cerr << "[wfmash::mashmap] L1 filtering parameters:"
+                  << "\n  cached segment length: " << cached_segment_length
+                  << "\n  cached minimum hits: " << cached_minimum_hits 
+                  << "\n  sketch size: " << param.sketchSize
+                  << "\n  kmer size: " << param.kmerSize
+                  << "\n  percent identity: " << param.percentageIdentity
+                  << std::endl;
+
         //Count of reads mapped by us
         //Some reads are dropped because of short length
         seqno_t totalReadsPickedForMapping = 0;

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -86,6 +86,7 @@ struct Parameters
     bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //
     int64_t index_by_size = std::numeric_limits<int64_t>::max();  // Target total size of sequences for each index subset
+    int minimum_hits = -1;  // Minimum number of hits required for L1 filtering (-1 means auto)
 };
 
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -87,6 +87,7 @@ struct Parameters
     //std::unordered_set<std::string> high_freq_kmers;  //
     int64_t index_by_size = std::numeric_limits<int64_t>::max();  // Target total size of sequences for each index subset
     int minimum_hits = -1;  // Minimum number of hits required for L1 filtering (-1 means auto)
+    uint64_t max_kmer_freq = std::numeric_limits<uint64_t>::max();  // Maximum allowed k-mer frequency
 };
 
 

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -258,7 +258,7 @@ namespace skch
                   
                   auto& pos_list = minmerPosLookupIndex[mi.hash];
                   
-                  // Skip if this hash is too frequent
+                  // Check if this hash is too frequent and clear its position list if so
                   if (pos_list.size() / 2 > param.max_kmer_freq) {
                       if (!pos_list.empty()) {
                           filtered_kmers++;
@@ -266,14 +266,11 @@ namespace skch
                           pos_list.shrink_to_fit();  // Release memory
                           pos_list.reserve(1);  // Mark as processed by setting capacity > 0
                       }
-                      continue;
                   }
                   
-                  // Add to minmer index if frequency is acceptable
-                  if (!pos_list.empty()) {
-                      minmerIndex.push_back(mi);
-                      index_progress.increment(1);
-                  }
+                  // Always add to minmer index
+                  minmerIndex.push_back(mi);
+                  index_progress.increment(1);
               }
               delete output;
           }

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -170,11 +170,6 @@ namespace skch
               total_seq_length += idManager.getSequenceLength(seqId);
           }
 
-          // Initialize progress meter with known total
-          progress_meter::ProgressMeter progress(
-              total_seq_length,
-              "[wfmash::mashmap] computing sketch");
-
           // First progress meter for sketch computation
           progress_meter::ProgressMeter sketch_progress(
               total_seq_length,
@@ -273,7 +268,7 @@ namespace skch
                   
                   // Add to minmer index since frequency is still acceptable
                   minmerIndex.push_back(mi);
-                  progress.increment(1);
+                  index_progress.increment(1);
               }
               delete output;
           }

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -317,7 +317,7 @@ namespace skch
           std::mutex index_mutex; // For thread-safe index updates
 
           for (size_t i = 0; i < num_threads; ++i) {
-              threads.emplace_back([this, &chunks, i, &progress, &index_mutex]() {
+              threads.emplace_back([this, &chunks, i, &progress, &index_mutex, &kmer_freqs]() {
                   MI_Map_t local_index; // Thread-local index
                   
                   // Process all outputs in this chunk

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -78,7 +78,7 @@ namespace skch
 
       using MI_Type = std::vector< MinmerInfo >;
       using MIIter_t = MI_Type::const_iterator;
-      using HF_Map_t = MI_Map_t;
+      using HF_Map_t = ankerl::unordered_dense::map<hash_t, uint64_t>;
 
       public:
         uint64_t total_seq_length = 0;
@@ -336,7 +336,7 @@ namespace skch
       void buildHandleThreadOutput(MI_Type* contigMinmerIndex)
       {
           // Count k-mer frequencies first
-          MI_Map_t kmer_freqs;
+          HF_Map_t kmer_freqs;
           for (const auto& mi : *contigMinmerIndex) {
               kmer_freqs[mi.hash]++;
           }

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -264,8 +264,7 @@ namespace skch
                           filtered_kmers++;
                           pos_list.clear();  // Clear the vector
                           pos_list.shrink_to_fit();  // Release memory
-                          pos_list.reserve(1);  // Mark as processed by setting capacity > 0
-                      }
+                       }
                   }
                   
                   // Always add to minmer index

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -78,7 +78,7 @@ namespace skch
 
       using MI_Type = std::vector< MinmerInfo >;
       using MIIter_t = MI_Type::const_iterator;
-      using HF_Map_t = ankerl::unordered_dense::map<hash_t, uint64_t>;
+      using HF_Map_t = MI_Map_t;
 
       public:
         uint64_t total_seq_length = 0;
@@ -336,7 +336,7 @@ namespace skch
       void buildHandleThreadOutput(MI_Type* contigMinmerIndex)
       {
           // Count k-mer frequencies first
-          std::unordered_map<hash_t, uint64_t> kmer_freqs;
+          MI_Map_t kmer_freqs;
           for (const auto& mi : *contigMinmerIndex) {
               kmer_freqs[mi.hash]++;
           }


### PR DESCRIPTION
Debugging indexing (n.b. current main can drop parts of the index due to badly implement parallel index merging).

Remove entries from the index if they have too many hits, for manual experimentation with mapping runtime in big genomes with big repeats.

Modify "L1" filter pass scan min count of minmer hits in a segment window.