### PR TITLE
Let me overlap

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -364,7 +364,7 @@ void parse_args(int argc,
     if (overlap_threshold) {
         map_parameters.overlap_threshold = args::get(overlap_threshold);
     } else {
-        map_parameters.overlap_threshold = 0.5;
+        map_parameters.overlap_threshold = 1.0;
     }
 
     if (kmer_size) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -93,7 +93,7 @@ void parse_args(int argc,
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k]", {'P', "max-length"});
-    args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "maximum overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
+    args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -93,7 +93,7 @@ void parse_args(int argc,
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k]", {'P', "max-length"});
-    args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "maximum mapping overlap fraction [0.5]", {'O', "overlap"});
+    args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "maximum overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});

--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -112,16 +112,19 @@ namespace skch
             }
             auto kit = it;
 
-            // Check for overlaps and mark bad if necessary
-            for ( ; it != L.end(); it++) {
-                if (it == L.begin()) continue;
-                int idx = *it;
-                for (auto it2 = L.begin(); it2 != kit; it2++) {
-                    double overlap = get_overlap(idx, *it2);
-                    if (overlap > overlapThreshold) {
-                        vec[idx].overlapped = 1;  // Mark as bad if it overlaps >50% with the best mapping
-                        vec[idx].discard = 1;
-                        break;
+            // Skip overlap checking if threshold is 1.0 (allow all overlaps)
+            if (overlapThreshold < 1.0) {
+                // Check for overlaps and mark bad if necessary
+                for ( ; it != L.end(); it++) {
+                    if (it == L.begin()) continue;
+                    int idx = *it;
+                    for (auto it2 = L.begin(); it2 != kit; it2++) {
+                        double overlap = get_overlap(idx, *it2);
+                        if (overlap > overlapThreshold) {
+                            vec[idx].overlapped = 1;  // Mark as bad if overlaps more than threshold
+                            vec[idx].discard = 1;
+                            break;
+                        }
                     }
                 }
             }
@@ -393,15 +396,18 @@ namespace skch
             }
             auto kit = it;
 
-            // Check for overlaps and mark bad if necessary
-            for ( ; it != L.end(); it++) {
-                if (it == L.begin()) continue;
-                int idx = *it;
-                for (auto it2 = L.begin(); it2 != kit; it2++) {
-                    if (get_overlap(idx, *it2) > overlapThreshold) {
-                        vec[idx].overlapped = 1;  // Mark as bad if it overlaps >50% with the best mapping
-                        vec[idx].discard = 1;
-                        break;
+            // Skip overlap checking if threshold is 1.0 (allow all overlaps)
+            if (overlapThreshold < 1.0) {
+                // Check for overlaps and mark bad if necessary
+                for ( ; it != L.end(); it++) {
+                    if (it == L.begin()) continue;
+                    int idx = *it;
+                    for (auto it2 = L.begin(); it2 != kit; it2++) {
+                        if (get_overlap(idx, *it2) > overlapThreshold) {
+                            vec[idx].overlapped = 1;  // Mark as bad if overlaps more than threshold
+                            vec[idx].discard = 1;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This sets the maximum overlap filter to be 1 all the time, so it's effectively disabled. It also short-circuits the computation that was used to do this, which could be a bit expensive in repetitive sequences.