### PR TITLE
Reenable writing index only

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -586,15 +586,20 @@ void parse_args(int argc,
         //map_parameters.world_minimizers = true;
     //}
 
-    if (read_index)
+    if (read_index || write_index)
     {
       map_parameters.indexFilename = args::get(read_index);
     } else {
       map_parameters.indexFilename = "";
     }
 
-    map_parameters.overwrite_index = false;
-    map_parameters.create_index_only = false;
+    if (write_index) {
+        map_parameters.overwrite_index = true;
+        map_parameters.create_index_only = true;
+    } else {
+        map_parameters.overwrite_index = false;
+        map_parameters.create_index_only = false;
+    }
 
     if (index_by) {
         const int64_t index_size = handy_parameter(args::get(index_by));


### PR DESCRIPTION
Relatively minor change after some parameters changed. Not sure if indexing on the fly will be the preferred option going forward, but seems intuitive if you want to write the index that that is all you want to do. Also assumes if you have an index and still want to write an index, you want to overwrite it