### PR TITLE
target padding during alignment

### DIFF
--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -802,11 +802,11 @@ std::string processAlignment(seq_record_t* rec) {
             fields[2] = std::to_string(rec->currentRecord.qStartPos);
             fields[3] = std::to_string(rec->currentRecord.qEndPos);
             // Target positions (0-based)
-            fields[7] = std::to_string(rec->currentRecord.rStartPos);
+            fields[7] = std::to_string(rec->currentRecord.rStartPos + target_offset);
             fields[8] = std::to_string(rec->currentRecord.rEndPos);
         } else {  // SAM format
             // Target position (1-based)
-            fields[3] = std::to_string(rec->currentRecord.rStartPos + 1);
+            fields[3] = std::to_string(rec->currentRecord.rStartPos + 1 + target_offset);
             // If necessary, adjust the query positions stored in optional fields
         }
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -493,19 +493,7 @@ std::string adjust_cigar_string(const std::string& cigar,
         // Check if sequences match at the new positions after potential swap
         for (int k = 0; k < first_count && can_swap; ++k) {
             int64_t q_idx = query_start + k;
-            int64_t t_idx = target_start + second_count + k;
-            
-            if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
-                std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
-                          << " (max: " << query_seq.size() << "), t_idx: " << t_idx 
-                          << " (max: " << target_seq.size() << ")" << std::endl;
-                can_swap = false;
-                break;
-            }
-            
-            // Calculate correct target position after deletion
-            q_idx = query_start + k;
-            t_idx = target_start + second_count + k;
+            int64_t t_idx = target_start + k; // Don't add second_count here
             
             if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
                 std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
@@ -522,8 +510,6 @@ std::string adjust_cigar_string(const std::string& cigar,
                       << ", t_idx: " << t_idx 
                       << ", q_char: " << q_char 
                       << ", t_char: " << t_char << std::endl;
-            std::cerr << "[DEBUG] Comparing position " << k << ": Query[" << q_idx << "]=" 
-                      << q_char << " vs Target[" << t_idx << "]=" << t_char << std::endl;
             
             if (q_char != t_char) {
                 std::cerr << "[DEBUG] Characters don't match at position " << k << std::endl;
@@ -532,23 +518,12 @@ std::string adjust_cigar_string(const std::string& cigar,
             }
         }
 
-        // Also verify the deletion region matches between query and target
-        if (can_swap) {
-            for (int k = 0; k < second_count && can_swap; ++k) {
-                int64_t t_idx = target_start + k;
-                if (t_idx >= target_seq.size()) {
-                    can_swap = false;
-                    break;
-                }
-            }
-        }
-
         std::cerr << "[DEBUG] Leading swap validation - can_swap: " << (can_swap ? "true" : "false") << std::endl;
         
         if (can_swap) {
-            // Directly construct the swapped string
-            return std::to_string(second_count) + 'D' + 
-                   std::to_string(first_count) + '=' +
+            // Don't swap, just convert the = to X since we found they don't match
+            return std::to_string(first_count) + 'X' + 
+                   std::to_string(second_count) + 'D' +
                    cigar.substr(second_op_end + 1);
         }
     }

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -779,7 +779,7 @@ std::string processAlignment(seq_record_t* rec) {
             fields[2] = std::to_string(rec->currentRecord.qStartPos);
             fields[3] = std::to_string(rec->currentRecord.qEndPos);
             // Target positions (0-based)
-            fields[7] = std::to_string(rec->currentRecord.rStartPos + target_offset);
+            fields[7] = std::to_string(rec->currentRecord.rStartPos);
             fields[8] = std::to_string(rec->currentRecord.rEndPos);
         } else {  // SAM format
             // Target position (1-based)

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -710,13 +710,6 @@ std::string processAlignment(seq_record_t* rec) {
         if (cigar_end == std::string::npos) cigar_end = alignment_output.length();
         std::string original_cigar = alignment_output.substr(cigar_start, cigar_end - cigar_start);
 
-        // Add debugging print statements
-        std::cerr << "[DEBUG] Alignment output before modification:\n" << alignment_output << "\n";
-        std::cerr << "[DEBUG] Original CIGAR string: " << original_cigar << "\n";
-        std::cerr << "[DEBUG] Target positions: start=" << rec->currentRecord.rStartPos 
-                  << ", end=" << rec->currentRecord.rEndPos << "\n";
-        std::cerr << "[DEBUG] Query positions: start=" << rec->currentRecord.qStartPos 
-                  << ", end=" << rec->currentRecord.qEndPos << "\n";
 
         // Adjust the CIGAR string
         std::string adjusted_cigar = adjust_cigar_string(original_cigar,
@@ -735,7 +728,6 @@ std::string processAlignment(seq_record_t* rec) {
         }
 
         // Initial validation before any modifications
-        std::cerr << "[DEBUG] Step 1: Performing initial validation of unmodified alignment\n";
         verify_cigar_alignment(adjusted_cigar,
                              queryRegionStrand.data(),
                              ref_seq_ptr,
@@ -751,11 +743,7 @@ std::string processAlignment(seq_record_t* rec) {
             rec->currentRecord.rEndPos
         );
         adjusted_cigar = trimmed_cigar;
-        std::cerr << "[DEBUG] Trimmed CIGAR string: " << adjusted_cigar << "\n";
-        std::cerr << "[DEBUG] New target positions: start=" << new_coords.first 
-                  << ", end=" << new_coords.second << "\n";
         auto target_offset = new_coords.first - rec->currentRecord.rStartPos;
-        std::cerr << "[DEBUG] Target offset: " << target_offset << "\n";
         rec->currentRecord.rStartPos = new_coords.first;
         rec->currentRecord.rEndPos = new_coords.second;
 
@@ -764,7 +752,6 @@ std::string processAlignment(seq_record_t* rec) {
         char* adjusted_query_seq_ptr = queryRegionStrand.data();
 
         // Verify alignment after trimming leading/trailing deletions
-        std::cerr << "[DEBUG] Step 2: Verifying alignment after trimming leading/trailing deletions\n";
         verify_cigar_alignment(adjusted_cigar,
                                adjusted_query_seq_ptr,
                                adjusted_ref_seq_ptr,
@@ -773,12 +760,6 @@ std::string processAlignment(seq_record_t* rec) {
                                rec->queryLen,
                                rec->refLen);
 
-        // Debug output for adjusted sequences
-        std::cerr << "[DEBUG] Adjusted positions and sequences:\n"
-                  << "Adjusted target_start: " << rec->currentRecord.rStartPos << "\n"
-                  << "Adjusted target_end: " << rec->currentRecord.rEndPos << "\n"
-                  << "Adjusted query_start: " << rec->currentRecord.qStartPos << "\n"
-                  << "Adjusted query_end: " << rec->currentRecord.qEndPos << "\n";
 
         // Recompute identity metrics
         int matches, mismatches, insertions, insertion_events, deletions, deletion_events;
@@ -857,7 +838,6 @@ std::string processAlignment(seq_record_t* rec) {
             updated_output += "\n";
         }
 
-        std::cerr << "[DEBUG] Alignment output after modification:\n" << updated_output << "\n";
         return updated_output;
     }
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -1038,6 +1038,19 @@ void worker_thread(uint64_t tid,
         seq_record_t* rec = nullptr;
         if (seq_queue.try_pop(rec)) {
             is_working.store(true);
+            // Debug output for alignment record
+            std::cerr << "\n[DEBUG] Processing alignment record:" << std::endl
+                      << "Query ID: " << rec->currentRecord.qId << std::endl
+                      << "Query start-end: " << rec->currentRecord.qStartPos << "-" << rec->currentRecord.qEndPos << std::endl
+                      << "Query length: " << rec->queryLen << std::endl
+                      << "Query total length: " << rec->queryTotalLength << std::endl
+                      << "Strand: " << (rec->currentRecord.strand == skch::strnd::FWD ? "+" : "-") << std::endl
+                      << "Reference ID: " << rec->currentRecord.refId << std::endl
+                      << "Reference start-end: " << rec->currentRecord.rStartPos << "-" << rec->currentRecord.rEndPos << std::endl
+                      << "Reference length: " << rec->refLen << std::endl
+                      << "Reference total length: " << rec->refTotalLength << std::endl
+                      << "Estimated identity: " << rec->currentRecord.mashmap_estimated_identity << std::endl;
+
             std::string alignment_output = processAlignment(rec);
             
             // Push the alignment output to the paf_queue

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -486,8 +486,8 @@ std::string adjust_cigar_string(const std::string& cigar,
             }
             
             // Calculate correct target position after deletion
-            int64_t t_idx = target_start + second_count + k;
-            int64_t q_idx = query_start + k;
+            q_idx = query_start + k;
+            t_idx = target_start + second_count + k;
             
             if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
                 std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -458,10 +458,6 @@ std::string processAlignment(seq_record_t* rec) {
         if (cigar_end == std::string::npos) cigar_end = alignment_output.length();
         std::string original_cigar = alignment_output.substr(cigar_start, cigar_end - cigar_start);
 
-        // Print the original CIGAR string before editing
-        std::cerr << "Original CIGAR for alignment between " << rec->currentRecord.qId 
-                 << " and " << rec->currentRecord.refId << ": " << original_cigar << std::endl;
-
         // Adjust the CIGAR string
         std::string adjusted_cigar = adjust_cigar_string(original_cigar, queryRegionStrand.data(), ref_seq_ptr);
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -406,7 +406,8 @@ std::string adjust_cigar_string(const std::string& cigar,
                                int64_t& query_start,
                                int64_t& query_end,
                                int64_t& target_start,
-                               int64_t& target_end) {
+                               int64_t& target_end,
+                               uint64_t max_shift) {
     // Parse the CIGAR string into operations
     std::vector<std::pair<int, char>> ops;
     size_t i = 0;
@@ -426,7 +427,7 @@ std::string adjust_cigar_string(const std::string& cigar,
             int match_len = ops[0].first;
             int del_len = ops[1].first;
 
-            bool moved = left_align_leading_deletion(target_seq, query_seq, match_len, del_len);
+            bool moved = left_align_leading_deletion(target_seq, query_seq, match_len, del_len, max_shift);
             if (moved) {
                 // Update operations
                 ops[0].first = match_len;
@@ -455,7 +456,7 @@ std::string adjust_cigar_string(const std::string& cigar,
             int match_len = ops.back().first;
 
             bool moved = right_align_trailing_deletion(
-                target_seq, query_seq, del_pos, del_len, match_len, param.target_padding);
+                target_seq, query_seq, del_pos, del_len, match_len, max_shift);
             if (moved) {
                 // Update operations
                 ops[ops.size() - 2].first = del_len;
@@ -713,7 +714,8 @@ std::string processAlignment(seq_record_t* rec) {
                                                        rec->currentRecord.qStartPos,
                                                        rec->currentRecord.qEndPos,
                                                        rec->currentRecord.rStartPos,
-                                                       rec->currentRecord.rEndPos);
+                                                       rec->currentRecord.rEndPos,
+                                                       param.target_padding);
 
         // Trim leading/trailing deletions and adjust positions
         int64_t target_start = rec->currentRecord.rStartPos;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -351,11 +351,11 @@ void verify_cigar_alignment(const std::string& cigar,
                         
                         // Calculate context range for query sequence
                         size_t query_context_start = (q_pos + k >= 5) ? q_pos + k - 5 : 0;
-                        size_t query_context_end = std::min(q_pos + k + 5, static_cast<size_t>(query_length - 1));
+                        size_t query_context_end = std::min(static_cast<size_t>(q_pos + k + 5), static_cast<size_t>(query_length - 1));
                 
                         // Calculate context range for target sequence
                         size_t target_context_start = (t_pos + k >= 5) ? t_pos + k - 5 : 0;
-                        size_t target_context_end = std::min(t_pos + k + 5, static_cast<size_t>(target_length - 1));
+                        size_t target_context_end = std::min(static_cast<size_t>(t_pos + k + 5), static_cast<size_t>(target_length - 1));
                         
                         // Extract context sequences
                         std::string query_context(query_seq + query_context_start, query_seq + query_context_end + 1);

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -305,6 +305,10 @@ void verify_cigar_alignment(const std::string& cigar,
               << "\n  Query length: " << query_length
               << "\n  Target length: " << target_length
               << "\n  CIGAR: " << cigar << std::endl;
+    
+    // Store initial positions for debugging
+    int64_t initial_q_pos = 0;
+    int64_t initial_t_pos = 0;
     size_t q_pos = 0;  // position in query sequence
     size_t t_pos = 0;  // position in target sequence
 
@@ -319,6 +323,8 @@ void verify_cigar_alignment(const std::string& cigar,
 
         switch (op) {
             case '=':  // match
+                std::cerr << "[DEBUG] Processing '=' operation at q_pos: " << q_pos 
+                          << ", t_pos: " << t_pos << ", length: " << op_len << std::endl;
                 // Verify that query_seq[q_pos .. q_pos + op_len] matches target_seq[t_pos .. t_pos + op_len]
                 for (int k = 0; k < op_len; ++k) {
                     char q_char = query_seq[q_pos + k];
@@ -331,10 +337,12 @@ void verify_cigar_alignment(const std::string& cigar,
                         exit(1);
                     }
                     if (q_char != t_char) {
-                        // Print error message
+                        // Print error message with both relative and absolute positions
                         std::cerr << "[wfmash::align] Error: Mismatch at position "
                                   << "query pos " << query_start + q_pos + k
+                                  << " (relative: " << q_pos + k << ")"
                                   << " vs target pos " << target_start + t_pos + k
+                                  << " (relative: " << t_pos + k << ")"
                                   << ": query char '" << q_char
                                   << "' vs target char '" << t_char << "' in '=' operation of CIGAR.\n";
                         

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -299,6 +299,12 @@ void verify_cigar_alignment(const std::string& cigar,
                            int64_t target_start,
                            int64_t query_length,
                            int64_t target_length) {
+    std::cerr << "[DEBUG] Starting CIGAR verification with:"
+              << "\n  Query start: " << query_start
+              << "\n  Target start: " << target_start
+              << "\n  Query length: " << query_length
+              << "\n  Target length: " << target_length
+              << "\n  CIGAR: " << cigar << std::endl;
     size_t q_pos = 0;  // position in query sequence
     size_t t_pos = 0;  // position in target sequence
 
@@ -497,8 +503,13 @@ std::string adjust_cigar_string(const std::string& cigar,
                 break;
             }
             
+            // Store the actual characters for debugging
             char q_char = query_seq[q_idx];
             char t_char = target_seq[t_idx];
+            std::cerr << "[DEBUG] Detailed position check - q_idx: " << q_idx 
+                      << ", t_idx: " << t_idx 
+                      << ", q_char: " << q_char 
+                      << ", t_char: " << t_char << std::endl;
             std::cerr << "[DEBUG] Comparing position " << k << ": Query[" << q_idx << "]=" 
                       << q_char << " vs Target[" << t_idx << "]=" << t_char << std::endl;
             

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -466,6 +466,9 @@ std::string adjust_cigar_string(const std::string& cigar,
     
     // Check if we need to swap leading operations
     if (first_op == '=' && second_op == 'D') {
+        std::cerr << "\n[DEBUG] Considering leading swap of " << first_count << "= with " << second_count << "D" << std::endl;
+        std::cerr << "[DEBUG] Current positions - Query start: " << query_start << ", Target start: " << target_start << std::endl;
+        
         // Check if swapping is valid by verifying sequence matches both before and after
         bool can_swap = true;
         
@@ -474,8 +477,21 @@ std::string adjust_cigar_string(const std::string& cigar,
             int64_t q_idx = query_start + k;
             int64_t t_idx = target_start + second_count + k;
             
-            if (q_idx >= query_seq.size() || t_idx >= target_seq.size() ||
-                query_seq[q_idx] != target_seq[t_idx]) {
+            if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
+                std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
+                          << " (max: " << query_seq.size() << "), t_idx: " << t_idx 
+                          << " (max: " << target_seq.size() << ")" << std::endl;
+                can_swap = false;
+                break;
+            }
+            
+            char q_char = query_seq[q_idx];
+            char t_char = target_seq[t_idx];
+            std::cerr << "[DEBUG] Comparing position " << k << ": Query[" << q_idx << "]=" 
+                      << q_char << " vs Target[" << t_idx << "]=" << t_char << std::endl;
+            
+            if (q_char != t_char) {
+                std::cerr << "[DEBUG] Characters don't match at position " << k << std::endl;
                 can_swap = false;
                 break;
             }
@@ -525,6 +541,9 @@ std::string adjust_cigar_string(const std::string& cigar,
         int query_pos = query_start + query_seq.size() - last_count - second_last_count;
         int target_pos = target_start + target_seq.size() - last_count - second_last_count;
         
+        std::cerr << "\n[DEBUG] Considering trailing swap of " << second_last_count << "D with " << last_count << "=" << std::endl;
+        std::cerr << "[DEBUG] Current positions - Query pos: " << query_pos << ", Target pos: " << target_pos << std::endl;
+        
         bool can_swap = true;
         
         // Check if sequences match at the new positions after potential swap
@@ -532,8 +551,21 @@ std::string adjust_cigar_string(const std::string& cigar,
             int64_t q_idx = query_pos + k;
             int64_t t_idx = target_pos + k;
             
-            if (q_idx >= query_seq.size() || t_idx >= target_seq.size() ||
-                query_seq[q_idx] != target_seq[t_idx]) {
+            if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
+                std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
+                          << " (max: " << query_seq.size() << "), t_idx: " << t_idx 
+                          << " (max: " << target_seq.size() << ")" << std::endl;
+                can_swap = false;
+                break;
+            }
+            
+            char q_char = query_seq[q_idx];
+            char t_char = target_seq[t_idx];
+            std::cerr << "[DEBUG] Comparing position " << k << ": Query[" << q_idx << "]=" 
+                      << q_char << " vs Target[" << t_idx << "]=" << t_char << std::endl;
+            
+            if (q_char != t_char) {
+                std::cerr << "[DEBUG] Characters don't match at position " << k << std::endl;
                 can_swap = false;
                 break;
             }

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -532,8 +532,8 @@ std::string adjust_cigar_string(const std::string& cigar,
         int query_pos = query_start + query_seq.size() - last_count - second_last_count;
         int target_pos = target_start + target_seq.size() - last_count - second_last_count;
         
-        std::cerr << "\n[DEBUG] Considering trailing swap of " << second_last_count << "D with " << last_count << "=" << std::endl;
-        std::cerr << "[DEBUG] Current positions - Query pos: " << query_pos << ", Target pos: " << target_pos << std::endl;
+        /* std::cerr << "\n[DEBUG] Considering trailing swap of " << second_last_count << "D with " << last_count << "=" << std::endl;
+        std::cerr << "[DEBUG] Current positions - Query pos: " << query_pos << ", Target pos: " << target_pos << std::endl; */
         
         bool can_swap = true;
         
@@ -543,9 +543,9 @@ std::string adjust_cigar_string(const std::string& cigar,
             int64_t t_idx = target_pos + k;
             
             if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
-                std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
+                /* std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
                           << " (max: " << query_seq.size() << "), t_idx: " << t_idx 
-                          << " (max: " << target_seq.size() << ")" << std::endl;
+                          << " (max: " << target_seq.size() << ")" << std::endl; */
                 can_swap = false;
                 break;
             }
@@ -573,7 +573,7 @@ std::string adjust_cigar_string(const std::string& cigar,
             }
         }
 
-        std::cerr << "[DEBUG] Trailing swap validation - can_swap: " << (can_swap ? "true" : "false") << std::endl;
+        /* std::cerr << "[DEBUG] Trailing swap validation - can_swap: " << (can_swap ? "true" : "false") << std::endl; */
         
         if (can_swap) {
             // Directly construct the swapped string

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -504,14 +504,7 @@ std::string adjust_cigar_string(const std::string& cigar,
             }
             
             // Store the actual characters for debugging
-            char q_char = query_seq[q_idx];
-            char t_char = target_seq[t_idx];
-            std::cerr << "[DEBUG] Detailed position check - q_idx: " << q_idx 
-                      << ", t_idx: " << t_idx 
-                      << ", q_char: " << q_char 
-                      << ", t_char: " << t_char << std::endl;
-            
-            if (q_char != t_char) {
+            if (query_seq[q_idx] != target_seq[t_idx]) {
                 std::cerr << "[DEBUG] Characters don't match at position " << k << std::endl;
                 can_swap = false;
                 break;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -175,36 +175,40 @@ std::string merge_cigar_operations(const std::string& cigar) {
     if (cigar.empty()) return cigar;
     
     std::string result;
+    result.reserve(cigar.length());  // Preallocate to avoid reallocations
+    
     size_t i = 0;
+    char current_op = '\0';
+    int current_count = 0;
     
-    // Parse first operation
-    size_t j = i;
-    while (j < cigar.size() && isdigit(cigar[j])) j++;
-    int current_count = std::stoi(cigar.substr(i, j - i));
-    char current_op = cigar[j];
-    i = j + 1;
-    
-    // Process remaining operations
-    while (i < cigar.size()) {
-        j = i;
-        while (j < cigar.size() && isdigit(cigar[j])) j++;
-        int next_count = std::stoi(cigar.substr(i, j - i));
-        char next_op = cigar[j];
-        i = j + 1;
+    while (i < cigar.length()) {
+        // Parse the count
+        int count = 0;
+        while (i < cigar.length() && isdigit(cigar[i])) {
+            count = count * 10 + (cigar[i] - '0');
+            i++;
+        }
         
-        // If operations are the same, merge them
-        if (next_op == current_op) {
-            current_count += next_count;
+        // Get the operation
+        char op = cigar[i++];
+        
+        // If it's the same operation, add to current count
+        if (op == current_op) {
+            current_count += count;
         } else {
-            // Write out current operation and start new one
-            result += std::to_string(current_count) + current_op;
-            current_count = next_count;
-            current_op = next_op;
+            // Write out the previous operation if it exists
+            if (current_op != '\0') {
+                result += std::to_string(current_count) + current_op;
+            }
+            current_op = op;
+            current_count = count;
         }
     }
     
-    // Write final operation
-    result += std::to_string(current_count) + current_op;
+    // Write the final operation
+    if (current_op != '\0') {
+        result += std::to_string(current_count) + current_op;
+    }
     
     return result;
 }

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -485,6 +485,18 @@ std::string adjust_cigar_string(const std::string& cigar,
                 break;
             }
             
+            // Calculate correct target position after deletion
+            int64_t t_idx = target_start + second_count + k;
+            int64_t q_idx = query_start + k;
+            
+            if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
+                std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
+                          << " (max: " << query_seq.size() << "), t_idx: " << t_idx 
+                          << " (max: " << target_seq.size() << ")" << std::endl;
+                can_swap = false;
+                break;
+            }
+            
             char q_char = query_seq[q_idx];
             char t_char = target_seq[t_idx];
             std::cerr << "[DEBUG] Comparing position " << k << ": Query[" << q_idx << "]=" 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -299,16 +299,6 @@ void verify_cigar_alignment(const std::string& cigar,
                            int64_t target_start,
                            int64_t query_length,
                            int64_t target_length) {
-    std::cerr << "[DEBUG] Starting CIGAR verification with:"
-              << "\n  Query start: " << query_start
-              << "\n  Target start: " << target_start
-              << "\n  Query length: " << query_length
-              << "\n  Target length: " << target_length
-              << "\n  CIGAR: " << cigar << std::endl;
-    
-    // Store initial positions for debugging
-    int64_t initial_q_pos = 0;
-    int64_t initial_t_pos = 0;
     int64_t q_pos = 0;  // position in query sequence
     int64_t t_pos = 0;  // position in target sequence
     int64_t cigar_ref_pos = 0;  // track reference position through CIGAR
@@ -324,8 +314,6 @@ void verify_cigar_alignment(const std::string& cigar,
 
         switch (op) {
             case '=':  // match
-                std::cerr << "[DEBUG] Processing '=' operation at q_pos: " << q_pos 
-                          << ", t_pos: " << t_pos << ", length: " << op_len << std::endl;
                 // Verify that query_seq[q_pos .. q_pos + op_len] matches target_seq[t_pos .. t_pos + op_len]
                 for (int k = 0; k < op_len; ++k) {
                     char q_char = query_seq[q_pos + k];

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -654,6 +654,14 @@ std::string processAlignment(seq_record_t* rec) {
             updated_output += "\n";
         }
 
+        // Add debug statements to show post-modification state
+        std::cerr << "[DEBUG] Adjusted CIGAR string: " << adjusted_cigar << "\n";
+        std::cerr << "[DEBUG] Updated target positions: start=" << target_start << ", end=" << target_end << "\n";
+        std::cerr << "[DEBUG] Updated query positions: start=" << query_start << ", end=" << query_end << "\n";
+        std::cerr << "[DEBUG] Gap-compressed identity (gi): " << gap_compressed_identity << "\n";
+        std::cerr << "[DEBUG] BLAST identity (bi): " << blast_identity << "\n";
+        std::cerr << "[DEBUG] Alignment output after modification:\n" << updated_output << "\n";
+
         return updated_output;
     }
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -538,6 +538,14 @@ std::string processAlignment(seq_record_t* rec) {
         if (cigar_end == std::string::npos) cigar_end = alignment_output.length();
         std::string original_cigar = alignment_output.substr(cigar_start, cigar_end - cigar_start);
 
+        // Add debugging print statements
+        std::cerr << "[DEBUG] Alignment output before modification:\n" << alignment_output << "\n";
+        std::cerr << "[DEBUG] Original CIGAR string: " << original_cigar << "\n";
+        std::cerr << "[DEBUG] Target positions: start=" << rec->currentRecord.rStartPos 
+                  << ", end=" << rec->currentRecord.rEndPos << "\n";
+        std::cerr << "[DEBUG] Query positions: start=" << rec->currentRecord.qStartPos 
+                  << ", end=" << rec->currentRecord.qEndPos << "\n";
+
         // Adjust the CIGAR string
         std::string adjusted_cigar = adjust_cigar_string(original_cigar, queryRegionStrand.data(), ref_seq_ptr);
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -652,9 +652,9 @@ std::string processAlignment(seq_record_t* rec) {
                                       query_start, query_end,
                                       rec->refTotalLength, rec->queryTotalLength);
 
-        // Recompute sequence pointers after position adjustments
-        char* adjusted_ref_seq_ptr = &ref_seq[target_start - rec->refStartPos];
-        char* adjusted_query_seq_ptr = &queryRegionStrand[query_start - rec->currentRecord.qStartPos];
+        // Use original sequence pointers
+        char* adjusted_ref_seq_ptr = ref_seq_ptr;
+        char* adjusted_query_seq_ptr = queryRegionStrand.data();
 
         // Debug output for adjusted sequences
         std::cerr << "[DEBUG] Adjusted positions and sequences:\n"
@@ -713,14 +713,14 @@ std::string processAlignment(seq_record_t* rec) {
         // Update positions based on format
         if (!param.sam_format) {  // PAF format
             // Query positions (0-based)
-            fields[2] = std::to_string(query_start);
-            fields[3] = std::to_string(query_end);
+            fields[2] = std::to_string(rec->currentRecord.qStartPos);
+            fields[3] = std::to_string(rec->currentRecord.qEndPos);
             // Target positions (0-based)
-            fields[7] = std::to_string(target_start);
-            fields[8] = std::to_string(target_end);
+            fields[7] = std::to_string(rec->currentRecord.rStartPos);
+            fields[8] = std::to_string(rec->currentRecord.rEndPos);
         } else {  // SAM format
             // Target position (1-based)
-            fields[3] = std::to_string(target_start + 1);
+            fields[3] = std::to_string(rec->currentRecord.rStartPos + 1);
             // If necessary, adjust the query positions stored in optional fields
         }
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -632,25 +632,13 @@ std::string processAlignment(seq_record_t* rec) {
                                                        queryRegionStrand.data(),
                                                        ref_seq_ptr,
                                                        rec->currentRecord.qStartPos,
-                                                       rec->currentRecord.qEndPos,
                                                        rec->currentRecord.rStartPos,
-                                                       rec->currentRecord.rEndPos,
                                                        param.target_padding);
 
-        // Trim leading/trailing deletions and adjust positions
-        int64_t target_start = rec->currentRecord.rStartPos;
-        int64_t target_end = rec->currentRecord.rEndPos;
-        int64_t query_start = rec->currentRecord.qStartPos;
-        int64_t query_end = rec->currentRecord.qEndPos;
-
-        // Skip empty alignments after adjustment
+        // Skip empty alignments
         if (adjusted_cigar.empty()) {
             return "";
         }
-
-        trim_cigar_and_adjust_positions(adjusted_cigar, target_start, target_end, 
-                                      query_start, query_end,
-                                      rec->refTotalLength, rec->queryTotalLength);
 
         // Use original sequence pointers
         char* adjusted_ref_seq_ptr = ref_seq_ptr;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -739,6 +739,8 @@ std::string processAlignment(seq_record_t* rec) {
         size_t cigar_end = alignment_output.find('\t', cigar_start);
         if (cigar_end == std::string::npos) cigar_end = alignment_output.length();
         std::string original_cigar = alignment_output.substr(cigar_start, cigar_end - cigar_start);
+        std::cerr << "[DEBUG] Original CIGAR: " << original_cigar << std::endl;
+        
         // Adjust the CIGAR string
         std::string adjusted_cigar = adjust_cigar_string(original_cigar,
                                                        queryRegionStrand.data(),
@@ -746,9 +748,12 @@ std::string processAlignment(seq_record_t* rec) {
                                                        rec->currentRecord.qStartPos,
                                                        rec->currentRecord.rStartPos,
                                                        param.target_padding);
+        
+        std::cerr << "[DEBUG] After adjust_cigar_string: " << adjusted_cigar << std::endl;
 
         // Merge any equivalent successive operations
         adjusted_cigar = merge_cigar_operations(adjusted_cigar);
+        std::cerr << "[DEBUG] After merge_cigar_operations: " << adjusted_cigar << std::endl;
 
         // Skip empty alignments
         if (adjusted_cigar.empty()) {
@@ -756,6 +761,12 @@ std::string processAlignment(seq_record_t* rec) {
         }
 
 #if VALIDATE_CIGAR
+        std::cerr << "[DEBUG] Validating CIGAR after merge_cigar_operations" << std::endl;
+        std::cerr << "[DEBUG] Query start: " << rec->queryStartPos 
+                  << ", Target start: " << rec->currentRecord.rStartPos << std::endl;
+        std::cerr << "[DEBUG] Query len: " << rec->queryLen 
+                  << ", Target len: " << rec->refLen << std::endl;
+        
         // Initial validation before any modifications
         verify_cigar_alignment(adjusted_cigar,
                              queryRegionStrand.data(),
@@ -764,6 +775,8 @@ std::string processAlignment(seq_record_t* rec) {
                              rec->currentRecord.rStartPos,
                              rec->queryLen,
                              rec->refLen);
+        
+        std::cerr << "[DEBUG] Initial CIGAR validation passed" << std::endl;
 #endif
 
         // Trim leading and trailing deletions
@@ -782,6 +795,12 @@ std::string processAlignment(seq_record_t* rec) {
         char* adjusted_query_seq_ptr = queryRegionStrand.data();
 
 #if VALIDATE_CIGAR
+        std::cerr << "[DEBUG] Validating CIGAR after trimming deletions" << std::endl;
+        std::cerr << "[DEBUG] New target offset: " << target_offset << std::endl;
+        std::cerr << "[DEBUG] New target start: " << rec->currentRecord.rStartPos << std::endl;
+        std::cerr << "[DEBUG] New target end: " << rec->currentRecord.rEndPos << std::endl;
+        std::cerr << "[DEBUG] Trimmed CIGAR: " << adjusted_cigar << std::endl;
+        
         // Verify alignment after trimming leading/trailing deletions
         verify_cigar_alignment(adjusted_cigar,
                                adjusted_query_seq_ptr,
@@ -790,6 +809,8 @@ std::string processAlignment(seq_record_t* rec) {
                                rec->currentRecord.rStartPos,
                                rec->queryLen,
                                rec->refLen);
+        
+        std::cerr << "[DEBUG] Final CIGAR validation passed" << std::endl;
 #endif
 
         // Recompute identity metrics

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -192,11 +192,11 @@ void verify_cigar_alignment(const std::string& cigar,
                         
                         // Calculate context range for query sequence
                         size_t query_context_start = (q_pos + k >= 5) ? q_pos + k - 5 : 0;
-                        size_t query_context_end = std::min(q_pos + k + 5, query_length - 1);
-                        
+                        size_t query_context_end = std::min(q_pos + k + 5, static_cast<size_t>(query_length - 1));
+                
                         // Calculate context range for target sequence
                         size_t target_context_start = (t_pos + k >= 5) ? t_pos + k - 5 : 0;
-                        size_t target_context_end = std::min(t_pos + k + 5, target_length - 1);
+                        size_t target_context_end = std::min(t_pos + k + 5, static_cast<size_t>(target_length - 1));
                         
                         // Extract context sequences
                         std::string query_context(query_seq + query_context_start, query_seq + query_context_end + 1);

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -414,7 +414,7 @@ std::string adjust_cigar_string(const std::string& cigar,
                 }
             }
             // Early return if we can't swap to prevent further processing
-            return original_cigar;
+            return cigar;
         }
 
         std::swap(ops[ops.size() - 2], ops.back());

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -646,41 +646,41 @@ std::string processAlignment(seq_record_t* rec) {
 
         // Debug output for adjusted sequences
         std::cerr << "[DEBUG] Adjusted positions and sequences:\n"
-                  << "Adjusted target_start: " << target_start << "\n"
-                  << "Adjusted target_end: " << target_end << "\n"
-                  << "Adjusted query_start: " << query_start << "\n"
-                  << "Adjusted query_end: " << query_end << "\n";
+                  << "Adjusted target_start: " << rec->currentRecord.rStartPos << "\n"
+                  << "Adjusted target_end: " << rec->currentRecord.rEndPos << "\n"
+                  << "Adjusted query_start: " << rec->currentRecord.qStartPos << "\n"
+                  << "Adjusted query_end: " << rec->currentRecord.qEndPos << "\n";
 
         // Print reference sequence context
         int ref_context_size = 10;
-        int64_t ref_seq_offset = target_start - rec->refStartPos;
+        int64_t ref_seq_offset = rec->currentRecord.rStartPos - rec->refStartPos;
         std::string ref_context = ref_seq.substr(
             std::max<int64_t>(0, ref_seq_offset - ref_context_size),
             std::min<size_t>(ref_seq.size() - ref_seq_offset + ref_context_size, 2 * ref_context_size)
         );
         std::cerr << "Reference sequence around adjusted target_start (positions "
-                  << target_start - ref_context_size << " to " << target_start + ref_context_size << "):\n"
+                  << rec->currentRecord.rStartPos - ref_context_size << " to " << rec->currentRecord.rStartPos + ref_context_size << "):\n"
                   << ref_context << "\n";
 
         // Print query sequence context
         int query_context_size = 10;
-        int64_t query_seq_offset = query_start - rec->currentRecord.qStartPos;
+        int64_t query_seq_offset = rec->currentRecord.qStartPos - rec->currentRecord.qStartPos;
         std::string query_context = std::string(queryRegionStrand.data()).substr(
             std::max<int64_t>(0, query_seq_offset - query_context_size),
             std::min<size_t>(queryRegionStrand.size() - query_seq_offset + query_context_size, 2 * query_context_size)
         );
         std::cerr << "Query sequence around adjusted query_start (positions "
-                  << query_start - query_context_size << " to " << query_start + query_context_size << "):\n"
+                  << rec->currentRecord.qStartPos - query_context_size << " to " << rec->currentRecord.qStartPos + query_context_size << "):\n"
                   << query_context << "\n";
 
         // Verify the alignment matches in '=' operations using adjusted pointers
         verify_cigar_alignment(adjusted_cigar,
                              adjusted_query_seq_ptr,
                              adjusted_ref_seq_ptr,
-                             query_start,
-                             target_start,
-                             rec->queryTotalLength - query_start,
-                             rec->refTotalLength - target_start);
+                             rec->currentRecord.qStartPos,
+                             rec->currentRecord.rStartPos,
+                             rec->queryLen,
+                             rec->refLen);
 
         // Recompute identity metrics
         int matches, mismatches, insertions, insertion_events, deletions, deletion_events;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -472,8 +472,8 @@ std::string adjust_cigar_string(const std::string& cigar,
     
     // Check if we need to swap leading operations
     if (first_op == '=' && second_op == 'D') {
-        std::cerr << "\n[DEBUG] Considering leading swap of " << first_count << "= with " << second_count << "D" << std::endl;
-        std::cerr << "[DEBUG] Current positions - Query start: " << query_start << ", Target start: " << target_start << std::endl;
+        /* std::cerr << "\n[DEBUG] Considering leading swap of " << first_count << "= with " << second_count << "D" << std::endl;
+        std::cerr << "[DEBUG] Current positions - Query start: " << query_start << ", Target start: " << target_start << std::endl; */
         
         // Check if swapping is valid by verifying sequence matches both before and after
         bool can_swap = true;
@@ -484,9 +484,9 @@ std::string adjust_cigar_string(const std::string& cigar,
             int64_t t_idx = target_start + k; // Don't add second_count here
             
             if (q_idx >= query_seq.size() || t_idx >= target_seq.size()) {
-                std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
+                /* std::cerr << "[DEBUG] Position out of bounds - q_idx: " << q_idx 
                           << " (max: " << query_seq.size() << "), t_idx: " << t_idx 
-                          << " (max: " << target_seq.size() << ")" << std::endl;
+                          << " (max: " << target_seq.size() << ")" << std::endl; */
                 can_swap = false;
                 break;
             }
@@ -499,7 +499,7 @@ std::string adjust_cigar_string(const std::string& cigar,
             }
         }
 
-        std::cerr << "[DEBUG] Leading swap validation - can_swap: " << (can_swap ? "true" : "false") << std::endl;
+        /* std::cerr << "[DEBUG] Leading swap validation - can_swap: " << (can_swap ? "true" : "false") << std::endl; */
         
         if (can_swap) {
             // Don't swap, just convert the = to X since we found they don't match

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -183,11 +183,38 @@ void verify_cigar_alignment(const std::string& cigar,
                         exit(1);
                     }
                     if (q_char != t_char) {
+                        // Print error message
                         std::cerr << "[wfmash::align] Error: Mismatch at position "
                                   << "query pos " << query_start + q_pos + k
                                   << " vs target pos " << target_start + t_pos + k
                                   << ": query char '" << q_char
                                   << "' vs target char '" << t_char << "' in '=' operation of CIGAR.\n";
+                        
+                        // Calculate context range for query sequence
+                        size_t query_context_start = (q_pos + k >= 5) ? q_pos + k - 5 : 0;
+                        size_t query_context_end = std::min(q_pos + k + 5, query_length - 1);
+                        
+                        // Calculate context range for target sequence
+                        size_t target_context_start = (t_pos + k >= 5) ? t_pos + k - 5 : 0;
+                        size_t target_context_end = std::min(t_pos + k + 5, target_length - 1);
+                        
+                        // Extract context sequences
+                        std::string query_context(query_seq + query_context_start, query_seq + query_context_end + 1);
+                        std::string target_context(target_seq + target_context_start, target_seq + target_context_end + 1);
+                        
+                        // Print the alignment state
+                        std::cerr << "[DEBUG] Alignment state at mismatch:\n";
+                        std::cerr << "CIGAR string: " << cigar << "\n";
+                        std::cerr << "Query sequence around mismatch (positions " << query_start + query_context_start
+                                 << "-" << query_start + query_context_end << "):\n"
+                                 << query_context << "\n";
+                        std::cerr << "Target sequence around mismatch (positions " << target_start + target_context_start
+                                 << "-" << target_start + target_context_end << "):\n"
+                                 << target_context << "\n";
+                        std::cerr << "q_pos: " << q_pos << ", t_pos: " << t_pos << ", k: " << k << "\n";
+                        std::cerr << "Query sequence length: " << query_length << ", Target sequence length: " << target_length << "\n";
+                        std::cerr << "Total query start: " << query_start << ", Total target start: " << target_start << "\n";
+                        
                         exit(1);
                     }
                 }

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -9,7 +9,7 @@
 #define COMPUTE_ALIGNMENTS_HPP
 
 // Define this to enable CIGAR validation checks
-#define VALIDATE_CIGAR 0
+#define VALIDATE_CIGAR 1
 
 #include <vector>
 #include <algorithm>

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -309,8 +309,9 @@ void verify_cigar_alignment(const std::string& cigar,
     // Store initial positions for debugging
     int64_t initial_q_pos = 0;
     int64_t initial_t_pos = 0;
-    size_t q_pos = 0;  // position in query sequence
-    size_t t_pos = 0;  // position in target sequence
+    int64_t q_pos = 0;  // position in query sequence
+    int64_t t_pos = 0;  // position in target sequence
+    int64_t cigar_ref_pos = 0;  // track reference position through CIGAR
 
     size_t i = 0;
     while (i < cigar.size()) {
@@ -333,7 +334,8 @@ void verify_cigar_alignment(const std::string& cigar,
                     if (q_pos + k >= query_length || t_pos + k >= target_length) {
                         std::cerr << "[wfmash::align] Error: Position out of bounds during alignment verification "
                                   << "at query pos " << query_start + q_pos + k
-                                  << " vs target pos " << target_start + t_pos + k << "\n";
+                                  << " vs target pos " << target_start + t_pos + k 
+                                  << " (CIGAR ref pos: " << cigar_ref_pos + k << ")\n";
                         exit(1);
                     }
                     if (q_char != t_char) {
@@ -343,6 +345,7 @@ void verify_cigar_alignment(const std::string& cigar,
                                   << " (relative: " << q_pos + k << ")"
                                   << " vs target pos " << target_start + t_pos + k
                                   << " (relative: " << t_pos + k << ")"
+                                  << " (CIGAR ref pos: " << cigar_ref_pos + k << ")"
                                   << ": query char '" << q_char
                                   << "' vs target char '" << t_char << "' in '=' operation of CIGAR.\n";
                         
@@ -376,6 +379,7 @@ void verify_cigar_alignment(const std::string& cigar,
                 }
                 q_pos += op_len;
                 t_pos += op_len;
+                cigar_ref_pos += op_len;
                 break;
             case 'X':  // mismatch
                 q_pos += op_len;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -734,7 +734,8 @@ std::string processAlignment(seq_record_t* rec) {
             return "";
         }
 
-        // Verify the alignment before trimming deletions
+        // Initial validation before any modifications
+        std::cerr << "[DEBUG] Step 1: Performing initial validation of unmodified alignment\n";
         verify_cigar_alignment(adjusted_cigar,
                              queryRegionStrand.data(),
                              ref_seq_ptr,
@@ -753,7 +754,8 @@ std::string processAlignment(seq_record_t* rec) {
         rec->currentRecord.rStartPos = new_coords.first;
         rec->currentRecord.rEndPos = new_coords.second;
 
-        // Verify the alignment after trimming deletions
+        // Verify alignment after trimming leading/trailing deletions
+        std::cerr << "[DEBUG] Step 2: Verifying alignment after trimming leading/trailing deletions\n";
         verify_cigar_alignment(adjusted_cigar,
                              queryRegionStrand.data(),
                              ref_seq_ptr,
@@ -881,7 +883,8 @@ std::string processAlignment(seq_record_t* rec) {
             updated_output += "\n";
         }
 
-        // Verify the alignment matches in '=' operations
+        // Final verification of alignment with adjusted sequences
+        std::cerr << "[DEBUG] Step 3: Performing final validation with adjusted sequences\n";
         verify_cigar_alignment(adjusted_cigar,
                              queryRegionStrand.data(),
                              ref_seq_ptr,

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -8,6 +8,9 @@
 #ifndef COMPUTE_ALIGNMENTS_HPP 
 #define COMPUTE_ALIGNMENTS_HPP
 
+// Define this to enable CIGAR validation checks
+#define VALIDATE_CIGAR 0
+
 #include <vector>
 #include <algorithm>
 #include <fstream>
@@ -752,6 +755,7 @@ std::string processAlignment(seq_record_t* rec) {
             return "";
         }
 
+#if VALIDATE_CIGAR
         // Initial validation before any modifications
         verify_cigar_alignment(adjusted_cigar,
                              queryRegionStrand.data(),
@@ -760,6 +764,7 @@ std::string processAlignment(seq_record_t* rec) {
                              rec->currentRecord.rStartPos,
                              rec->queryLen,
                              rec->refLen);
+#endif
 
         // Trim leading and trailing deletions
         auto [trimmed_cigar, new_coords] = trim_leading_trailing_deletions(
@@ -776,6 +781,7 @@ std::string processAlignment(seq_record_t* rec) {
         char* adjusted_ref_seq_ptr = ref_seq_ptr + target_offset;
         char* adjusted_query_seq_ptr = queryRegionStrand.data();
 
+#if VALIDATE_CIGAR
         // Verify alignment after trimming leading/trailing deletions
         verify_cigar_alignment(adjusted_cigar,
                                adjusted_query_seq_ptr,
@@ -784,7 +790,7 @@ std::string processAlignment(seq_record_t* rec) {
                                rec->currentRecord.rStartPos,
                                rec->queryLen,
                                rec->refLen);
-
+#endif
 
         // Recompute identity metrics
         int matches, mismatches, insertions, insertion_events, deletions, deletion_events;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -596,8 +596,8 @@ std::string processAlignment(seq_record_t* rec) {
         std::string adjusted_cigar = adjust_cigar_string(original_cigar,
                                                        queryRegionStrand.data(),
                                                        ref_seq_ptr,
-                                                       rec->queryStartPos,
-                                                       rec->queryEndPos,
+                                                       rec->currentRecord.qStartPos,
+                                                       rec->currentRecord.qEndPos,
                                                        rec->currentRecord.rStartPos,
                                                        rec->currentRecord.rEndPos);
 

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -805,8 +805,6 @@ std::string processAlignment(seq_record_t* rec) {
         size_t cigar_end = alignment_output.find('\t', cigar_start);
         if (cigar_end == std::string::npos) cigar_end = alignment_output.length();
         std::string original_cigar = alignment_output.substr(cigar_start, cigar_end - cigar_start);
-        std::cerr << "[DEBUG] Original CIGAR: " << original_cigar << std::endl;
-        
         // Adjust the CIGAR string
         std::string adjusted_cigar = adjust_cigar_string(original_cigar,
                                                        queryRegionStrand.data(),
@@ -814,8 +812,6 @@ std::string processAlignment(seq_record_t* rec) {
                                                        rec->currentRecord.qStartPos,
                                                        rec->currentRecord.rStartPos,
                                                        param.target_padding);
-        
-        std::cerr << "[DEBUG] After adjust_cigar_string: " << adjusted_cigar << std::endl;
 
         // Merge any equivalent successive operations
         adjusted_cigar = merge_cigar_operations(adjusted_cigar);
@@ -857,22 +853,14 @@ std::string processAlignment(seq_record_t* rec) {
         char* adjusted_query_seq_ptr = queryRegionStrand.data();
 
 #if VALIDATE_CIGAR
-        std::cerr << "[DEBUG] Validating CIGAR after trimming deletions" << std::endl;
-        std::cerr << "[DEBUG] New target offset: " << target_offset << std::endl;
-        std::cerr << "[DEBUG] New target start: " << rec->currentRecord.rStartPos << std::endl;
-        std::cerr << "[DEBUG] New target end: " << rec->currentRecord.rEndPos << std::endl;
-        std::cerr << "[DEBUG] Trimmed CIGAR: " << adjusted_cigar << std::endl;
-        
         // Verify alignment after trimming leading/trailing deletions
         verify_cigar_alignment(adjusted_cigar,
-                               adjusted_query_seq_ptr,
-                               adjusted_ref_seq_ptr,
-                               rec->queryStartPos,
-                               rec->currentRecord.rStartPos,
-                               rec->queryLen,
-                               rec->refLen);
-        
-        std::cerr << "[DEBUG] Final CIGAR validation passed" << std::endl;
+                             adjusted_query_seq_ptr,
+                             adjusted_ref_seq_ptr,
+                             rec->queryStartPos,
+                             rec->currentRecord.rStartPos,
+                             rec->queryLen,
+                             rec->refLen);
 #endif
 
         // Recompute identity metrics
@@ -1088,18 +1076,6 @@ void worker_thread(uint64_t tid,
         seq_record_t* rec = nullptr;
         if (seq_queue.try_pop(rec)) {
             is_working.store(true);
-            // Debug output for alignment record
-            std::cerr << "\n[DEBUG] Processing alignment record:" << std::endl
-                      << "Query ID: " << rec->currentRecord.qId << std::endl
-                      << "Query start-end: " << rec->currentRecord.qStartPos << "-" << rec->currentRecord.qEndPos << std::endl
-                      << "Query length: " << rec->queryLen << std::endl
-                      << "Query total length: " << rec->queryTotalLength << std::endl
-                      << "Strand: " << (rec->currentRecord.strand == skch::strnd::FWD ? "+" : "-") << std::endl
-                      << "Reference ID: " << rec->currentRecord.refId << std::endl
-                      << "Reference start-end: " << rec->currentRecord.rStartPos << "-" << rec->currentRecord.rEndPos << std::endl
-                      << "Reference length: " << rec->refLen << std::endl
-                      << "Reference total length: " << rec->refTotalLength << std::endl
-                      << "Estimated identity: " << rec->currentRecord.mashmap_estimated_identity << std::endl;
 
             std::string alignment_output = processAlignment(rec);
             

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -347,13 +347,13 @@ std::string adjust_cigar_string(const std::string& cigar,
     
     // Check if we need to swap leading operations
     if (first_op == '=' && second_op == 'D') {
-        // Check if swapping is valid
+        // Check if swapping is valid by verifying sequence matches after the deletion
         bool can_swap = true;
-        for (int k = 0; k < second_count && 
-             (query_start + first_count + k) < query_seq.size() && 
-             (target_start + first_count + k) < target_seq.size(); ++k) {
-            if (query_seq[query_start + first_count + k] != 
-                target_seq[target_start + first_count + k]) {
+        for (int k = 0; k < first_count && 
+             (query_start + k) < query_seq.size() && 
+             (target_start + second_count + k) < target_seq.size(); ++k) {
+            if (query_seq[query_start + k] != 
+                target_seq[target_start + second_count + k]) {
                 can_swap = false;
                 break;
             }

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -709,8 +709,6 @@ std::string processAlignment(seq_record_t* rec) {
         size_t cigar_end = alignment_output.find('\t', cigar_start);
         if (cigar_end == std::string::npos) cigar_end = alignment_output.length();
         std::string original_cigar = alignment_output.substr(cigar_start, cigar_end - cigar_start);
-
-
         // Adjust the CIGAR string
         std::string adjusted_cigar = adjust_cigar_string(original_cigar,
                                                        queryRegionStrand.data(),

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -413,12 +413,12 @@ std::string adjust_cigar_string(const std::string& cigar,
                               << " target=" << target_seq[t_idx] << "\n";
                 }
             }
+            // Early return if we can't swap to prevent further processing
+            return original_cigar;
         }
 
-        if (can_swap) {
-            std::swap(ops[ops.size() - 2], ops.back());
-            std::cerr << "[DEBUG] Swapped trailing 'D' and '=' operations.\n";
-        }
+        std::swap(ops[ops.size() - 2], ops.back());
+        std::cerr << "[DEBUG] Swapped trailing 'D' and '=' operations.\n";
     }
 
     std::cerr << "[DEBUG] Adjusted CIGAR operations:\n";

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -416,8 +416,6 @@ std::string adjust_cigar_string(const std::string& cigar,
                                int64_t query_start,
                                int64_t target_start,
                                uint64_t max_shift) {
-    std::cerr << "[DEBUG] Original CIGAR string: " << cigar << "\n";
-    
     // Find the first two operations
     size_t first_op_end = 0;
     while (first_op_end < cigar.size() && isdigit(cigar[first_op_end])) first_op_end++;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -751,6 +751,18 @@ std::string processAlignment(seq_record_t* rec) {
         
         std::cerr << "[DEBUG] After adjust_cigar_string: " << adjusted_cigar << std::endl;
 
+#if VALIDATE_CIGAR
+        std::cerr << "[DEBUG] Validating CIGAR after adjust_cigar_string" << std::endl;
+        verify_cigar_alignment(adjusted_cigar,
+                             queryRegionStrand.data(),
+                             ref_seq_ptr,
+                             rec->queryStartPos,
+                             rec->currentRecord.rStartPos,
+                             rec->queryLen,
+                             rec->refLen);
+        std::cerr << "[DEBUG] CIGAR validation after adjust_cigar_string passed" << std::endl;
+#endif
+
         // Merge any equivalent successive operations
         adjusted_cigar = merge_cigar_operations(adjusted_cigar);
         std::cerr << "[DEBUG] After merge_cigar_operations: " << adjusted_cigar << std::endl;

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -541,7 +541,10 @@ std::string processAlignment(seq_record_t* rec) {
         for (size_t i = 1; i < fields.size(); ++i) {
             updated_output += "\t" + fields[i];
         }
-        updated_output += "\n";  // Ensure there is a newline at the end
+        // Add a newline only if one is not already present
+        if (!updated_output.empty() && updated_output.back() != '\n') {
+            updated_output += "\n";
+        }
 
         return updated_output;
     }

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -124,7 +124,7 @@ void parse_args(int argc,
 
     args::Group alignment_opts(options_group, "Alignment:");
     args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF file for alignment", {'i', "align-paf"});
-    args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "padding around target sequence [0]", {'E', "target-padding"});
+    args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "padding around target sequence [100]", {'E', "target-padding"});
     args::ValueFlag<std::string> wfa_params(alignment_opts, "vals", 
         "scoring: mismatch, gap1(o,e), gap2(o,e) [6,6,2,26,1]", {'g', "wfa-params"});
 
@@ -484,7 +484,7 @@ void parse_args(int argc,
         }
         align_parameters.target_padding = p;
     } else {
-        align_parameters.target_padding = 0;
+        align_parameters.target_padding = 100;
     }
 
     if (thread_count) {


### PR DESCRIPTION
MashMap doesn't give us precise starts and ends to our mapping. But, we should be able to expand the target region and align the entire query against it to correct for small positional errors. This sets our target-padding `-E` as 100bp by default.