### PR TITLE
Scaffold mapping

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -113,8 +113,8 @@ void parse_args(int argc,
     args::ValueFlag<std::string> query_list(mapping_opts, "FILE", "file containing list of query sequence names", {'A', "query-list"});
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
-    args::ValueFlag<std::string> scaffolding(mapping_opts, "Gap,Len,Dev", 
-        "mapping scaffolding parameters (Gap,Len,Dev) [20k,50k,50k]", {'G', "scaffolding"});
+    args::ValueFlag<std::string> scaffolding(mapping_opts, "G,L,D", 
+        "mapping scaffolding parameters (G,L,D) [20k,50k,50k]", {'S', "scaffolding"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
@@ -740,7 +740,7 @@ void parse_args(int argc,
               << ", l=" << map_parameters.block_length
               << ", c=" << map_parameters.chain_gap
               << ", P=" << map_parameters.max_mapping_length
-              << ", G=" << map_parameters.scaffold_gap << "," 
+              << ", S=" << map_parameters.scaffold_gap << "," 
               << map_parameters.scaffold_min_length << "," 
               << map_parameters.scaffold_max_deviation
               << ", n=" << map_parameters.numMappingsForSegment

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -114,7 +114,7 @@ void parse_args(int argc,
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> scaffolding(mapping_opts, "G,L,D", 
-        "mapping scaffolding parameters (G,L,D) [20k,50k,50k]", {'S', "scaffolding"});
+        "mapping scaffolding parameters (chain-Gap,min-Len,max-Dev) [20k,50k,50k]", {'S', "scaffolding"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -113,9 +113,8 @@ void parse_args(int argc,
     args::ValueFlag<std::string> query_list(mapping_opts, "FILE", "file containing list of query sequence names", {'A', "query-list"});
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
-    args::ValueFlag<std::string> scaffold_gap(mapping_opts, "INT", "max diagonal deviation from super-chains [50k]", {"scaffold-gap"});
-    args::ValueFlag<std::string> super_chain_gap(mapping_opts, "INT", "gap threshold for super-chains [20k]", {"super-chain-gap"}); 
-    args::ValueFlag<std::string> super_block(mapping_opts, "INT", "minimum super block length [50k]", {"super-block"});
+    args::ValueFlag<std::string> scaffolding(mapping_opts, "gap,len,dev", 
+        "mapping scaffolding parameters (gap,len,dev) [20k,50k,50k]", {'S', "scaffolding"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
@@ -368,37 +367,31 @@ void parse_args(int argc,
         align_parameters.chain_gap = 2000;
     }
 
-    if (scaffold_gap) {
-        const int64_t l = wfmash::handy_parameter(args::get(scaffold_gap));
-        if (l < 0) {
-            std::cerr << "[wfmash] ERROR: scaffold gap must be >= 0" << std::endl;
+    if (scaffolding) {
+        std::string params = args::get(scaffolding);
+        std::vector<std::string> values = skch::CommonFunc::split(params, ',');
+        if (values.size() != 3) {
+            std::cerr << "[wfmash] ERROR: scaffolding requires 3 comma-separated values: gap,len,dev" << std::endl;
             exit(1);
         }
-        map_parameters.scaffold_gap = l;
-    } else {
-        map_parameters.scaffold_gap = 50000;
-    }
-
-    if (super_chain_gap) {
-        const int64_t l = wfmash::handy_parameter(args::get(super_chain_gap));
-        if (l < 0) {
-            std::cerr << "[wfmash] ERROR: super chain gap must be >= 0" << std::endl;
+        
+        // Parse in order: gap, length, deviation
+        map_parameters.scaffold_gap = handy_parameter(values[0]);         // gap
+        map_parameters.scaffold_min_length = handy_parameter(values[1]);  // len  
+        map_parameters.scaffold_max_deviation = handy_parameter(values[2]);// dev
+        
+        // Validate the values
+        if (map_parameters.scaffold_gap < 0 || 
+            map_parameters.scaffold_min_length <= 0 || 
+            map_parameters.scaffold_max_deviation < 0) {
+            std::cerr << "[wfmash] ERROR: Invalid scaffolding parameters" << std::endl;
             exit(1);
         }
-        map_parameters.super_chain_gap = l;
     } else {
-        map_parameters.super_chain_gap = 20000;
-    }
-
-    if (super_block) {
-        const int64_t s = handy_parameter(args::get(super_block));
-        if (s <= 0) {
-            std::cerr << "[wfmash] ERROR: super-block must be >0" << std::endl;
-            exit(1);
-        }
-        map_parameters.super_block_length = s;
-    } else {
-        map_parameters.super_block_length = 50000; // Default 50k
+        // Default values
+        map_parameters.scaffold_gap = 20000;          // 20k
+        map_parameters.scaffold_min_length = 50000;   // 50k  
+        map_parameters.scaffold_max_deviation = 50000; // 50k
     }
 
     if (max_mapping_length) {
@@ -747,7 +740,9 @@ void parse_args(int argc,
               << ", l=" << map_parameters.block_length
               << ", c=" << map_parameters.chain_gap
               << ", P=" << map_parameters.max_mapping_length
-              << ", S=" << map_parameters.super_block_length
+              << ", S=" << map_parameters.scaffold_gap << "," 
+              << map_parameters.scaffold_min_length << "," 
+              << map_parameters.scaffold_max_deviation
               << ", n=" << map_parameters.numMappingsForSegment
               << ", p=" << std::fixed << std::setprecision(0) << map_parameters.percentageIdentity * 100 << "%"
               << ", t=" << map_parameters.threads

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -391,9 +391,9 @@ void parse_args(int argc,
         }
     } else {
         // Default values
-        map_parameters.scaffold_gap = 20000;          // 20k
-        map_parameters.scaffold_min_length = 50000;   // 50k  
-        map_parameters.scaffold_max_deviation = 50000; // 50k
+        map_parameters.scaffold_gap = 50000;          // 50k
+        map_parameters.scaffold_min_length = 20000;   // 20k  
+        map_parameters.scaffold_max_deviation = 100000; // 100k
     }
 
     if (max_mapping_length) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -115,6 +115,7 @@ void parse_args(int argc,
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> scaffold_gap(mapping_opts, "INT", "max diagonal deviation from super-chains [50k]", {"scaffold-gap"});
     args::ValueFlag<std::string> super_chain_gap(mapping_opts, "INT", "gap threshold for super-chains [20k]", {"super-chain-gap"}); 
+    args::ValueFlag<std::string> super_block(mapping_opts, "INT", "minimum super block length [50k]", {"super-block"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
@@ -389,9 +390,20 @@ void parse_args(int argc,
         map_parameters.super_chain_gap = 20000;
     }
 
+    if (super_block) {
+        const int64_t s = handy_parameter(args::get(super_block));
+        if (s <= 0) {
+            std::cerr << "[wfmash] ERROR: super-block must be >0" << std::endl;
+            exit(1);
+        }
+        map_parameters.super_block_length = s;
+    } else {
+        map_parameters.super_block_length = 50000; // Default 50k
+    }
+
     if (max_mapping_length) {
         const int64_t l = args::get(max_mapping_length) == "inf" ? std::numeric_limits<int64_t>::max()
-            : wfmash::handy_parameter(args::get(max_mapping_length));
+            : handy_parameter(args::get(max_mapping_length));
         if (l <= 0) {
             std::cerr << "[wfmash] ERROR: max mapping length must be greater than 0." << std::endl;
             exit(1);
@@ -735,6 +747,7 @@ void parse_args(int argc,
               << ", l=" << map_parameters.block_length
               << ", c=" << map_parameters.chain_gap
               << ", P=" << map_parameters.max_mapping_length
+              << ", S=" << map_parameters.super_block_length
               << ", n=" << map_parameters.numMappingsForSegment
               << ", p=" << std::fixed << std::setprecision(0) << map_parameters.percentageIdentity * 100 << "%"
               << ", t=" << map_parameters.threads

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -375,20 +375,19 @@ void parse_args(int argc,
             map_parameters.scaffold_gap = 0;
             map_parameters.scaffold_min_length = 0;
             map_parameters.scaffold_max_deviation = 0;
-            return;
-        }
-        
-        // Parse in order: gap, length, deviation
-        map_parameters.scaffold_gap = handy_parameter(values[0]);         // gap
-        map_parameters.scaffold_min_length = handy_parameter(values[1]);  // len  
-        map_parameters.scaffold_max_deviation = handy_parameter(values[2]);// dev
-        
-        // Validate the values
-        if (map_parameters.scaffold_gap < 0 || 
-            map_parameters.scaffold_min_length <= 0 || 
-            map_parameters.scaffold_max_deviation < 0) {
-            std::cerr << "[wfmash] ERROR: Invalid scaffolding parameters" << std::endl;
-            exit(1);
+        } else {
+            // Parse in order: gap, length, deviation
+            map_parameters.scaffold_gap = handy_parameter(values[0]);         // gap
+            map_parameters.scaffold_min_length = handy_parameter(values[1]);  // len  
+            map_parameters.scaffold_max_deviation = handy_parameter(values[2]);// dev
+            
+            // Validate the values
+            if (map_parameters.scaffold_gap < 0 || 
+                map_parameters.scaffold_min_length <= 0 || 
+                map_parameters.scaffold_max_deviation < 0) {
+                std::cerr << "[wfmash] ERROR: Invalid scaffolding parameters" << std::endl;
+                exit(1);
+            }
         }
     } else {
         // Default values

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -113,8 +113,8 @@ void parse_args(int argc,
     args::ValueFlag<std::string> query_list(mapping_opts, "FILE", "file containing list of query sequence names", {'A', "query-list"});
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
-    args::ValueFlag<std::string> scaffolding(mapping_opts, "gap,len,dev", 
-        "mapping scaffolding parameters (gap,len,dev) [20k,50k,50k]", {'S', "scaffolding"});
+    args::ValueFlag<std::string> scaffolding(mapping_opts, "Gap,Len,Dev", 
+        "mapping scaffolding parameters (Gap,Len,Dev) [20k,50k,50k]", {'G', "scaffolding"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
@@ -740,7 +740,7 @@ void parse_args(int argc,
               << ", l=" << map_parameters.block_length
               << ", c=" << map_parameters.chain_gap
               << ", P=" << map_parameters.max_mapping_length
-              << ", S=" << map_parameters.scaffold_gap << "," 
+              << ", G=" << map_parameters.scaffold_gap << "," 
               << map_parameters.scaffold_min_length << "," 
               << map_parameters.scaffold_max_deviation
               << ", n=" << map_parameters.numMappingsForSegment

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -371,8 +371,11 @@ void parse_args(int argc,
         std::string params = args::get(scaffolding);
         std::vector<std::string> values = skch::CommonFunc::split(params, ',');
         if (values.size() != 3) {
-            std::cerr << "[wfmash] ERROR: scaffolding requires 3 comma-separated values: gap,len,dev" << std::endl;
-            exit(1);
+            // Disable scaffolding if pattern doesn't match
+            map_parameters.scaffold_gap = 0;
+            map_parameters.scaffold_min_length = 0;
+            map_parameters.scaffold_max_deviation = 0;
+            return;
         }
         
         // Parse in order: gap, length, deviation

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -114,7 +114,7 @@ void parse_args(int argc,
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> scaffolding(mapping_opts, "G,L,D", 
-        "mapping scaffolding parameters (chain-Gap,min-Len,max-Dev) [20k,50k,50k]", {'S', "scaffolding"});
+        "homology scaffolding [20k,50k,50k]", {'S', "scaffolding"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2051,7 +2051,7 @@ namespace skch
       };
 
       void filterByScaffolds(MappingResultsVector_t& readMappings,
-                            const MappingResultsVector_t& rawMappings,
+                            const MappingResultsVector_t& mergedMappings,
                             const Parameters& param,
                             progress_meter::ProgressMeter& progress) 
       {
@@ -2060,8 +2060,8 @@ namespace skch
                return;
           }
 
-          // First, generate scaffold mappings ("super-chains") as before.
-          MappingResultsVector_t scaffoldMappings = rawMappings;
+          // Build scaffold mappings from the maximally merged mappings
+          MappingResultsVector_t scaffoldMappings = mergedMappings;
           auto superChains = mergeMappingsInRange(scaffoldMappings, param.scaffold_gap, progress);
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2010,6 +2010,16 @@ namespace skch
           auto readMappings2 = readMappings;
           auto superChains = mergeMappingsInRange(readMappings2, param.super_chain_gap, progress);
 
+          // Filter superchains by length
+          superChains.erase(
+              std::remove_if(superChains.begin(), superChains.end(),
+                  [&](const auto& chain) {
+                      int64_t query_span = chain.queryEndPos - chain.queryStartPos;
+                      int64_t ref_span = chain.refEndPos - chain.refStartPos;
+                      return std::max(query_span, ref_span) < param.super_block_length;
+                  }),
+              superChains.end());
+
           // Create envelopes around super-chains
           std::vector<SuperChainEnvelope> envelopes;
           for (const auto& chain : superChains) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -194,6 +194,10 @@ namespace skch
               
               // A mapping is within the envelope if it's within max_gap distance
               // in both the parallel and perpendicular directions
+              if (parallel_dist <= max_gap && perp_dist <= max_gap) {
+                  std::cerr << "wow! it's within bounds" << std::endl;
+                  std::cerr << "parallel_dist " << parallel_dist << " vs " << max_gap << " and perp_dist " << perp_dist << std::endl;
+              }
               return parallel_dist <= max_gap && perp_dist <= max_gap;
           }
       };
@@ -2045,7 +2049,12 @@ namespace skch
                   [&](const MappingResult& m) {
                       return !std::any_of(envelopes.begin(), envelopes.end(),
                           [&](const SuperChainEnvelope& env) {
-                              return env.contains(m, param.scaffold_gap);
+                              auto b = env.contains(m, param.scaffold_max_deviation);
+                              if (b) {
+                                  std::cerr << "mapping " << m.queryStartPos << "," << m.queryEndPos << " " << m.refStartPos << "," << m.refEndPos << std::endl;
+                                  std::cerr << "within " << env.q_start << "," << env.q_end << " " << env.r_start << "," << env.r_end << std::endl;
+                              }
+                              return b;
                           });
                   }),
               readMappings.end());

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2002,6 +2002,12 @@ namespace skch
 
       void filterMaximallyMerged(MappingResultsVector_t& readMappings, const Parameters& param, progress_meter::ProgressMeter& progress)
       {
+          // Skip scaffolding if parameters are 0
+          if (param.scaffold_gap == 0 && param.scaffold_min_length == 0 && param.scaffold_max_deviation == 0) {
+              filterWeakMappings(readMappings, std::floor(param.block_length / param.segLength));
+              return;
+          }
+
           // Filter weak mappings
           filterWeakMappings(readMappings, std::floor(param.block_length / param.segLength));
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2100,6 +2100,18 @@ namespace skch
                scafGroups[key].push_back(m);
           }
 
+          // Partition raw mappings and scaffold mappings into groups
+          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> rawGroups;
+          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> scafGroups;
+          for (const auto& m : readMappings) {
+               GroupKey key { m.querySeqId, m.refSeqId };
+               rawGroups[key].push_back(m);
+          }
+          for (const auto& m : superChains) {
+               GroupKey key { m.querySeqId, m.refSeqId };
+               scafGroups[key].push_back(m);
+          }
+
           // Helper to compute weighted orientation score for a mapping
           auto computeOrientationScore = [](const MappingResult& m) -> double {
               int64_t q_span = m.queryEndPos - m.queryStartPos;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -229,7 +229,6 @@ namespace skch
           PostProcessResultsFn_t f = nullptr) :
         param(p),
         processMappingResults(f),
-        scafOutstrm(p.outFileName + ".scaf.paf"),
         sketchCutoffs(std::min<double>(p.sketchSize, skch::fixed::ss_table_max) + 1, 1),
         idManager(std::make_unique<SequenceIdManager>(
             p.querySequences,
@@ -526,7 +525,6 @@ namespace skch
         seqno_t totalReadsMapped = 0;
 
         std::ofstream outstrm(param.outFileName);
-        std::ofstream scafOutstrm;
 
         // Get sequence names from ID manager
 
@@ -2034,9 +2032,8 @@ namespace skch
 
           // Write scaffold mappings to separate file
           if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {
-              for (const auto& chain : superChains) {
-                  reportReadMappings(MappingResultsVector_t{chain}, idManager->getSequenceName(chain.querySeqId), scafOutstrm);
-              }
+              std::ofstream scafOutstrm(".scaf.paf");
+              reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
           }
 
           // Create envelopes around super-chains

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2008,17 +2008,13 @@ namespace skch
               return;
           }
 
-          // Filter weak mappings
-          filterWeakMappings(readMappings, std::floor(param.block_length / param.segLength));
-
           // Generate super-chains with relaxed gap constraints
           // copy the read mappings
           auto readMappings2 = readMappings;
           auto superChains = mergeMappingsInRange(readMappings2, param.scaffold_gap, progress);
 
-          // Open scaffold PAF file
-          static std::ofstream scafStrm("scaf.paf");
-          static std::mutex scafMutex;
+          // Filter weak mappings
+          filterWeakMappings(readMappings, std::floor(param.block_length / param.segLength));
 
           // Filter superchains by length
           superChains.erase(
@@ -2029,6 +2025,10 @@ namespace skch
                       return std::max(query_span, ref_span) < param.scaffold_min_length;
                   }),
               superChains.end());
+
+          // Open scaffold PAF file
+          static std::ofstream scafStrm("scaf.paf");
+          static std::mutex scafMutex;
 
           // Write scaffold chains to file
           {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2351,7 +2351,7 @@ namespace skch
                // Compute rotated envelopes for scaffold mappings in this group.
                std::vector<RotatedEnvelope> scaffoldEnvelopes;
                for (const auto& m : groupScaf) {
-                    scaffoldEnvelopes.push_back(computeRotatedEnvelope(m, use_antidiagonal, param));
+                    scaffoldEnvelopes.push_back(computeRotatedEnvelope(m, use_antidiagonal));
                }
                std::sort(scaffoldEnvelopes.begin(), scaffoldEnvelopes.end(),
                          [](const RotatedEnvelope& a, const RotatedEnvelope& b) {
@@ -2362,7 +2362,7 @@ namespace skch
                std::vector<RawEnv> rawEnvs;
                for (size_t i = 0; i < groupRaw.size(); i++) {
                     RawEnv env;
-                    env.env = computeRotatedEnvelope(groupRaw[i], use_antidiagonal, param);
+                    env.env = computeRotatedEnvelope(groupRaw[i], use_antidiagonal);
                     env.index = i;
                     rawEnvs.push_back(env);
                }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2111,13 +2111,12 @@ namespace skch
           }
 
           // Build scaffold mappings from the maximally merged mappings
-          MappingResultsVector_t scaffoldCandidates = mergedMappings;
-          filterScaffoldCandidates(scaffoldCandidates, mergedMappings, param, progress);
+          MappingResultsVector_t scaffoldMappings = mergedMappings;
 
-          // Then merge these candidates with an aggressive gap to create final scaffolds
+          // Merge with aggressive gap to create scaffolds
           Parameters scaffoldParam = param;
           scaffoldParam.chain_gap *= 2;  // More aggressive merging for scaffolds
-          auto superChains = mergeMappingsInRange(scaffoldCandidates, scaffoldParam.chain_gap, progress);
+          auto superChains = mergeMappingsInRange(scaffoldMappings, scaffoldParam.chain_gap, progress);
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 
           // Optionally, write scaffold mappings to file for debugging

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2056,11 +2056,22 @@ namespace skch
 
           // Build a new vector of mappings that pass the scaffold filter.
           MappingResultsVector_t filtered;
+          filtered.reserve(rawEnvs.size());
           for (size_t i = 0; i < rawEnvs.size(); i++) {
                if (keep[i]) {
                     filtered.push_back(readMappings[rawEnvs[i].index]);
+               } else {
+                    std::cerr << "\nDiscarding mapping outside scaffold envelope:"
+                             << "\n  Query: [" << readMappings[rawEnvs[i].index].queryStartPos 
+                             << ", " << readMappings[rawEnvs[i].index].queryEndPos << "]"
+                             << "\n  Target: [" << readMappings[rawEnvs[i].index].refStartPos 
+                             << ", " << readMappings[rawEnvs[i].index].refEndPos << "]"
+                             << "\n  Rotated coords:"
+                             << "\n    u: [" << rawEnvs[i].env.u_start << ", " << rawEnvs[i].env.u_end << "]"
+                             << "\n    v: [" << rawEnvs[i].env.v_min << ", " << rawEnvs[i].env.v_max << "]\n";
                }
           }
+          // Actually replace the input mappings with just the filtered ones
           readMappings = std::move(filtered);
       }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1963,7 +1963,7 @@ namespace skch
 
           // Optionally, write scaffold mappings to file.
           if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {
-               std::ofstream scafOutstrm("scaf.paf");
+               std::ofstream scafOutstrm("scaf.paf", std::ios::app);
                reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
           }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1956,18 +1956,22 @@ namespace skch
       }
 
       // Event types for sweep line algorithm
-      enum EventType { START_SCAF, END_SCAF, START_RAW, END_RAW };
+      enum EventType { START, END };
+      enum MappingType { SCAFFOLD, RAW };
 
       struct Event {
           double u;  // u-coordinate
           EventType type;
+          MappingType mappingType;
           double v_min, v_max;
           size_t id;
           
           bool operator<(const Event& other) const {
               if (u != other.u) return u < other.u;
               // If u-coords are equal, process START before END
-              return type < other.type;
+              if (type != other.type) return type < other.type;
+              // If both are START or both are END, process scaffolds first
+              return mappingType < other.mappingType;
           }
       };
 
@@ -2137,15 +2141,15 @@ namespace skch
                   auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(groupScaf[i]);
                   v_min -= param.scaffold_max_deviation;
                   v_max += param.scaffold_max_deviation;
-                  events.push_back({u_min, START_SCAF, v_min, v_max, i});
-                  events.push_back({u_max, END_SCAF, v_min, v_max, i});
+                  events.push_back(Event{u_min, START, SCAFFOLD, v_min, v_max, i});
+                  events.push_back(Event{u_max, END, SCAFFOLD, v_min, v_max, i});
               }
 
               // Generate events for raw mappings
               for (size_t i = 0; i < groupRaw.size(); i++) {
                   auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(groupRaw[i]);
-                  events.push_back({u_min, START_RAW, v_min, v_max, i});
-                  events.push_back({u_max, END_RAW, v_min, v_max, i});
+                  events.push_back(Event{u_min, START, RAW, v_min, v_max, i});
+                  events.push_back(Event{u_max, END, RAW, v_min, v_max, i});
               }
 
               // Sort events

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2061,8 +2061,14 @@ namespace skch
           }
 
           // Build scaffold mappings from the maximally merged mappings
-          MappingResultsVector_t scaffoldMappings = mergedMappings;
-          auto superChains = mergeMappingsInRange(scaffoldMappings, param.scaffold_gap, progress);
+          // First filter the merged mappings to get high-confidence scaffold candidates
+          MappingResultsVector_t scaffoldCandidates = mergedMappings;
+          filterByScaffolds(scaffoldCandidates, mergedMappings, param, progress);
+
+          // Then merge these candidates with an aggressive gap to create final scaffolds
+          Parameters scaffoldParam = param;
+          scaffoldParam.chain_gap *= 2;  // More aggressive merging for scaffolds
+          auto superChains = mergeMappingsInRange(scaffoldCandidates, scaffoldParam.chain_gap, progress);
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 
           // Optionally, write scaffold mappings to file for debugging

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2064,8 +2064,6 @@ namespace skch
           MappingResultsVector_t scaffoldMappings = mergedMappings;
           auto superChains = mergeMappingsInRange(scaffoldMappings, param.scaffold_gap, progress);
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
-          auto superChains = mergeMappingsInRange(scaffoldMappings, param.scaffold_gap, progress);
-          filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 
           // Optionally, write scaffold mappings to file.
           if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -889,7 +889,7 @@ namespace skch
             }
             else
             {
-                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold);
+                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold, progress);
             }
             filteredMappings.insert(
                 filteredMappings.end(), 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -889,7 +889,7 @@ namespace skch
             }
             else
             {
-                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold, progress);
+                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold);
             }
             filteredMappings.insert(
                 filteredMappings.end(), 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2065,10 +2065,11 @@ namespace skch
           auto superChains = mergeMappingsInRange(scaffoldMappings, param.scaffold_gap, progress);
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 
-          // Optionally, write scaffold mappings to file.
-          if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {
-               std::ofstream scafOutstrm("scaf.paf", std::ios::app);
-               reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
+          // Optionally, write scaffold mappings to file for debugging
+          if (!superChains.empty() && 
+              (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0)) {
+              std::ofstream scafOutstrm("scaf.paf", std::ios::app);
+              reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
           }
 
           // Group mappings by query and reference sequence

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2313,13 +2313,13 @@ namespace skch
                // Generate events for both scaffold and raw envelopes
                for (size_t i = 0; i < scaffoldEnvelopes.size(); i++) {
                     const auto& scaf = scaffoldEnvelopes[i];
-                    events.push_back({scaf.u_start, START, SCAFFOLD, scaf.v_min, scaf.v_max, i});
-                    events.push_back({scaf.u_end, END, SCAFFOLD, scaf.v_min, scaf.v_max, i});
+                    events.push_back(Event{scaf.u_start, START_SCAF, scaf.v_min, scaf.v_max, i});
+                    events.push_back(Event{scaf.u_end, END_SCAF, scaf.v_min, scaf.v_max, i});
                }
                for (size_t i = 0; i < rawEnvs.size(); i++) {
                     const auto& raw = rawEnvs[i].env;
-                    events.push_back({raw.u_start, START, RAW, raw.v_min, raw.v_max, i});
-                    events.push_back({raw.u_end, END, RAW, raw.v_min, raw.v_max, i});
+                    events.push_back(Event{raw.u_start, START_RAW, raw.v_min, raw.v_max, i});
+                    events.push_back(Event{raw.u_end, END_RAW, raw.v_min, raw.v_max, i});
                }
 
                // Sort events by u-coordinate (and type/mapping type for ties)

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -889,7 +889,7 @@ namespace skch
             }
             else
             {
-                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold, progress);
+                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold);
             }
             filteredMappings.insert(
                 filteredMappings.end(), 
@@ -2487,7 +2487,7 @@ namespace skch
                   best_it2->chainPairScore = best_score;
                   best_it2->chainPairId = it->splitMappingId;
               }
-              progress.increment(1);
+              // Remove progress increment from post-processing
           }
 
           // Assign the merged mapping ids

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1955,6 +1955,26 @@ namespace skch
           return std::abs(anti_proj / diag_proj);
       }
 
+      // Event types for sweep line algorithm
+      enum EventType { START, END };
+      enum MappingType { SCAFFOLD, RAW };
+
+      struct Event {
+          double u;  // u-coordinate
+          EventType type;
+          MappingType mappingType;
+          double v_min, v_max;
+          size_t id;
+          
+          bool operator<(const Event& other) const {
+              if (u != other.u) return u < other.u;
+              // If u-coords are equal, process START before END
+              if (type != other.type) return type < other.type;
+              // If both are START or both are END, process scaffolds first
+              return mappingType < other.mappingType;
+          }
+      };
+
       // Helper to determine if a group should use antidiagonal projection
       bool shouldUseAntidiagonal(const std::vector<MappingResult>& mappings) {
           double total_weight = 0.0;
@@ -1964,7 +1984,7 @@ namespace skch
               total_weight += weight;
               weighted_score += weight * computeOrientationScore(m);
           }
-          return (weighted_weight / total_weight) > 1.0;
+          return (weighted_score / total_weight) > 1.0;
       }
 
       struct RotatedEnvelope {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1946,23 +1946,26 @@ namespace skch
        * @return                      Filtered mappings
        */
 
-      // Event types for sweep line algorithm
-      enum EventType { START_SCAF, END_SCAF, START_RAW, END_RAW };
-
-      struct Event {
-          double u;  // u-coordinate
-          EventType type;
-          double v_min, v_max;
-          size_t id;
-          
-          bool operator<(const Event& other) const {
-              if (u != other.u) return u < other.u;
-              // If u-coords are equal, process START before END
-              if (type != other.type) return type < other.type;
-              // If both are START or both are END, process scaffolds first
-              return type < other.type;
+      // Helper to determine if a group should use antidiagonal projection
+      bool shouldUseAntidiagonal(const std::vector<MappingResult>& mappings) {
+          double total_weight = 0.0;
+          double weighted_score = 0.0;
+          for (const auto& m : mappings) {
+              double weight = m.queryEndPos - m.queryStartPos;
+              total_weight += weight;
+              weighted_score += weight * computeOrientationScore(m);
           }
+          return (weighted_score / total_weight) > 1.0;
+      }
+
+      struct RotatedEnvelope {
+          double u_start;
+          double u_end;
+          double v_min;
+          double v_max;
+          bool antidiagonal;
       };
+
 
       // Interval tree node for v-coordinate ranges
       struct Interval {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2440,12 +2440,12 @@ namespace skch
           // Process both merged and non-merged mappings
           if (param.mergeMappings && param.split) {
               filterMaximallyMerged(maximallyMergedMappings, std::floor(param.block_length / param.segLength), progress);
+              // Also apply scaffold filtering to merged mappings
+              filterByScaffolds(maximallyMergedMappings, rawMappings, param, progress);
           } else {
               filterNonMergedMappings(mappings, param, progress);
+              filterByScaffolds(mappings, rawMappings, param, progress);
           }
-
-          // Apply scaffold filtering using raw mappings
-          filterByScaffolds(mappings, rawMappings, param, progress);
 
           // Build dense chain ID mapping
           std::unordered_map<offset_t, offset_t> id_map;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2144,6 +2144,18 @@ namespace skch
           auto superChains = mergeMappingsInRange(scaffoldMappings, scaffoldParam.chain_gap, progress);
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 
+          // Expand scaffold mappings by half the max deviation on each end
+          for (auto& mapping : superChains) {
+              int64_t expansion = param.scaffold_max_deviation / 2;
+              mapping.refStartPos = std::max<int64_t>(0, mapping.refStartPos - expansion);
+              mapping.refEndPos = std::min<int64_t>(idManager->getSequenceLength(mapping.refSeqId), 
+                                                   mapping.refEndPos + expansion);
+              mapping.queryStartPos = std::max<int64_t>(0, mapping.queryStartPos - expansion);
+              mapping.queryEndPos = std::min<int64_t>(mapping.queryLen, mapping.queryEndPos + expansion);
+              mapping.blockLength = std::max(mapping.refEndPos - mapping.refStartPos,
+                                           mapping.queryEndPos - mapping.queryStartPos);
+          }
+
           // Optionally, write scaffold mappings to file for debugging
           if (!superChains.empty() && 
               (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0)) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2008,7 +2008,7 @@ namespace skch
           // Generate super-chains with relaxed gap constraints
           // copy the read mappings
           auto readMappings2 = readMappings;
-          auto superChains = mergeMappingsInRange(readMappings2, param.super_chain_gap, progress);
+          auto superChains = mergeMappingsInRange(readMappings2, param.scaffold_gap, progress);
 
           // Filter superchains by length
           superChains.erase(
@@ -2016,7 +2016,7 @@ namespace skch
                   [&](const auto& chain) {
                       int64_t query_span = chain.queryEndPos - chain.queryStartPos;
                       int64_t ref_span = chain.refEndPos - chain.refStartPos;
-                      return std::max(query_span, ref_span) < param.super_block_length;
+                      return std::max(query_span, ref_span) < param.scaffold_min_length;
                   }),
               superChains.end());
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2160,7 +2160,7 @@ namespace skch
               IntervalTree activeRaws;
 
               for (const auto& event : events) {
-                  if (event.type == START_SCAF) {
+                  if (event.type == START && event.mappingType == SCAFFOLD) {
                       activeScaffolds.insert(event.v_min, event.v_max, event.id);
                       if (activeRaws.hasOverlap(event.v_min, event.v_max)) {
                           // Mark all overlapping raw mappings as kept
@@ -2171,9 +2171,9 @@ namespace skch
                               }
                           }
                       }
-                  } else if (event.type == END_SCAF) {
+                  } else if (event.type == END && event.mappingType == SCAFFOLD) {
                       activeScaffolds.remove(event.v_min, event.v_max, event.id);
-                  } else if (event.type == START_RAW) {
+                  } else if (event.type == START && event.mappingType == RAW) {
                       if (!keep[event.id]) {  // Only process if not already kept
                           if (activeScaffolds.hasOverlap(event.v_min, event.v_max)) {
                               keep[event.id] = true;
@@ -2181,7 +2181,7 @@ namespace skch
                               activeRaws.insert(event.v_min, event.v_max, event.id);
                           }
                       }
-                  } else if (event.type == END_RAW) {
+                  } else if (event.type == END && event.mappingType == RAW) {
                       if (!keep[event.id]) {  // Only remove if we actually inserted it
                           activeRaws.remove(event.v_min, event.v_max, event.id);
                       }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2032,7 +2032,7 @@ namespace skch
 
           // Write scaffold mappings to separate file
           if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {
-              std::ofstream scafOutstrm(".scaf.paf");
+              std::ofstream scafOutstrm("scaf.paf");
               reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
           }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2004,25 +2004,6 @@ namespace skch
        * @param[in]   param           Algorithm parameters
        * @return                      Filtered mappings
        */
-      struct SuperChainEnvelope {
-          seqno_t refSeqId;
-          offset_t q_start, q_end;
-          offset_t r_start, r_end;
-          strand_t strand;
-          
-          bool contains(const MappingResult& m, int64_t max_gap) const {
-              if (m.refSeqId != refSeqId || m.strand != strand) return false;
-              
-              // Check if mapping endpoints are within diagonal band
-              int64_t q_dist_start = std::abs((int64_t)m.queryStartPos - (int64_t)q_start);
-              int64_t r_dist_start = std::abs((int64_t)m.refStartPos - (int64_t)r_start);
-              int64_t q_dist_end = std::abs((int64_t)m.queryEndPos - (int64_t)q_end);
-              int64_t r_dist_end = std::abs((int64_t)m.refEndPos - (int64_t)r_end);
-              
-              return std::abs(q_dist_start - r_dist_start) <= max_gap &&
-                     std::abs(q_dist_end - r_dist_end) <= max_gap;
-          }
-      };
 
       void filterByScaffolds(MappingResultsVector_t& readMappings,
                             const MappingResultsVector_t& rawMappings,

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2156,12 +2156,13 @@ namespace skch
                                            mapping.queryEndPos - mapping.queryStartPos);
           }
 
-          // Optionally, write scaffold mappings to file for debugging
+          /* Optionally, write scaffold mappings to file for debugging
           if (!superChains.empty() && 
               (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0)) {
               std::ofstream scafOutstrm("scaf.paf", std::ios::app);
               reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
           }
+          */
 
           // Group mappings by query and reference sequence
           struct GroupKey {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1983,12 +1983,10 @@ namespace skch
           filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
 
           // Write scaffold mappings to separate file
-          /*
           if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {
               std::ofstream scafOutstrm("scaf.paf");
               reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
           }
-          */
 
           // Create envelopes around super-chains
           std::vector<SuperChainEnvelope> envelopes;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2111,7 +2111,7 @@ namespace skch
                          // Check if the two rectangles intersect
                          if (!(rawEnv.u_end < scafEnv.u_start || rawEnv.u_start > scafEnv.u_end ||
                                rawEnv.v_max < scafEnv.v_min || rawEnv.v_min > scafEnv.v_max)) {
-                             // Print debug info about the match
+                             /* Debug output for envelope matches
                              std::cerr << "\nFound mapping within scaffold envelope:"
                                       << "\nRaw mapping:"
                                       << "\n  Query: [" << groupRaw[rawEnvs[r].index].queryStartPos 
@@ -2129,12 +2129,14 @@ namespace skch
                                       << "\n  Rotated coords:"
                                       << "\n    u: [" << scafEnv.u_start << ", " << scafEnv.u_end << "]"
                                       << "\n    v: [" << scafEnv.v_min << ", " << scafEnv.v_max << "]\n";
+                             */
                              found = true;
                              break;
                          }
                     }
                     keep[r] = found;
                     if (!found) {
+                         /* Debug output for discarded mappings
                          std::cerr << "\nDiscarding mapping outside scaffold envelope:"
                                   << "\n  Query: [" << groupRaw[rawEnvs[r].index].queryStartPos 
                                   << ", " << groupRaw[rawEnvs[r].index].queryEndPos << "]"
@@ -2143,6 +2145,7 @@ namespace skch
                                   << "\n  Rotated coords:"
                                   << "\n    u: [" << rawEnv.u_start << ", " << rawEnv.u_end << "]"
                                   << "\n    v: [" << rawEnv.v_min << ", " << rawEnv.v_max << "]\n";
+                         */
                     }
                }
                // Collect raw mappings that passed for this group.

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -229,6 +229,7 @@ namespace skch
           PostProcessResultsFn_t f = nullptr) :
         param(p),
         processMappingResults(f),
+        scafOutstrm(p.outFileName + ".scaf.paf"),
         sketchCutoffs(std::min<double>(p.sketchSize, skch::fixed::ss_table_max) + 1, 1),
         idManager(std::make_unique<SequenceIdManager>(
             p.querySequences,
@@ -525,6 +526,7 @@ namespace skch
         seqno_t totalReadsMapped = 0;
 
         std::ofstream outstrm(param.outFileName);
+        std::ofstream scafOutstrm;
 
         // Get sequence names from ID manager
 
@@ -2029,6 +2031,13 @@ namespace skch
                       return std::max(query_span, ref_span) < param.scaffold_min_length;
                   }),
               superChains.end());
+
+          // Write scaffold mappings to separate file
+          if (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0) {
+              for (const auto& chain : superChains) {
+                  reportReadMappings(MappingResultsVector_t{chain}, idManager->getSequenceName(chain.querySeqId), scafOutstrm);
+              }
+          }
 
           // Create envelopes around super-chains
           std::vector<SuperChainEnvelope> envelopes;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2006,7 +2006,9 @@ namespace skch
           filterWeakMappings(readMappings, std::floor(param.block_length / param.segLength));
 
           // Generate super-chains with relaxed gap constraints
-          auto superChains = mergeMappingsInRange(readMappings, param.super_chain_gap, progress);
+          // copy the read mappings
+          auto readMappings2 = readMappings;
+          auto superChains = mergeMappingsInRange(readMappings2, param.super_chain_gap, progress);
 
           // Create envelopes around super-chains
           std::vector<SuperChainEnvelope> envelopes;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2029,6 +2029,24 @@ namespace skch
                     if (scaf.u_start > rawEnv.u_end) break; // no u-overlap possible
                     // Check if the raw mapping's vertical range is entirely within the scaffold's envelope.
                     if (rawEnv.v_min >= scaf.v_min && rawEnv.v_max <= scaf.v_max) {
+                         // Print debug info about the match
+                         std::cerr << "\nFound mapping within scaffold envelope:"
+                                  << "\nRaw mapping:"
+                                  << "\n  Query: [" << readMappings[rawEnvs[r].index].queryStartPos 
+                                  << ", " << readMappings[rawEnvs[r].index].queryEndPos << "]"
+                                  << "\n  Target: [" << readMappings[rawEnvs[r].index].refStartPos 
+                                  << ", " << readMappings[rawEnvs[r].index].refEndPos << "]"
+                                  << "\n  Rotated coords:"
+                                  << "\n    u: [" << rawEnv.u_start << ", " << rawEnv.u_end << "]"
+                                  << "\n    v: [" << rawEnv.v_min << ", " << rawEnv.v_max << "]"
+                                  << "\nMatching scaffold:"
+                                  << "\n  Query: [" << superChains[s].queryStartPos 
+                                  << ", " << superChains[s].queryEndPos << "]"
+                                  << "\n  Target: [" << superChains[s].refStartPos 
+                                  << ", " << superChains[s].refEndPos << "]"
+                                  << "\n  Rotated coords:"
+                                  << "\n    u: [" << scaf.u_start << ", " << scaf.u_end << "]"
+                                  << "\n    v: [" << scaf.v_min << ", " << scaf.v_max << "]\n";
                          found = true;
                          break;
                     }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2719,11 +2719,16 @@ namespace skch
        */
 
       void computeChainStatistics(std::vector<MappingResult>::iterator begin, std::vector<MappingResult>::iterator end) {
+          if (begin == end) return;
+
           offset_t chain_start_query = std::numeric_limits<offset_t>::max();
           offset_t chain_end_query = std::numeric_limits<offset_t>::min();
           offset_t chain_start_ref = std::numeric_limits<offset_t>::max();
           offset_t chain_end_ref = std::numeric_limits<offset_t>::min();
           double accumulate_nuc_identity = 0.0;
+          double accumulate_kmer_complexity = 0.0;
+          int total_conserved_sketches = 0;
+          int total_sketch_size = 0;
           int n_in_full_chain = std::distance(begin, end);
 
           for (auto it = begin; it != end; ++it) {
@@ -2732,15 +2737,23 @@ namespace skch
               chain_start_ref = std::min(chain_start_ref, it->refStartPos);
               chain_end_ref = std::max(chain_end_ref, it->refEndPos);
               accumulate_nuc_identity += it->nucIdentity;
+              accumulate_kmer_complexity += it->kmerComplexity;
+              total_conserved_sketches += it->conservedSketches;
+              total_sketch_size += it->sketchSize;
           }
 
           auto chain_nuc_identity = accumulate_nuc_identity / n_in_full_chain;
+          auto chain_kmer_complexity = accumulate_kmer_complexity / n_in_full_chain;
           auto block_length = std::max(chain_end_query - chain_start_query, chain_end_ref - chain_start_ref);
 
           for (auto it = begin; it != end; ++it) {
               it->n_merged = n_in_full_chain;
               it->blockLength = block_length;
               it->blockNucIdentity = chain_nuc_identity;
+              it->kmerComplexity = chain_kmer_complexity;
+              it->conservedSketches = total_conserved_sketches;
+              it->sketchSize = total_sketch_size;
+              it->approxMatches = std::round(chain_nuc_identity * block_length / 100.0);
           }
       }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1956,18 +1956,22 @@ namespace skch
       }
 
       // Event types for sweep line algorithm
-      enum EventType { START_SCAF, END_SCAF, START_RAW, END_RAW };
+      enum EventType { START, END };
+      enum MappingType { SCAFFOLD, RAW };
 
       struct Event {
           double u;  // u-coordinate
           EventType type;
+          MappingType mappingType;
           double v_min, v_max;
           size_t id;
           
           bool operator<(const Event& other) const {
               if (u != other.u) return u < other.u;
               // If u-coords are equal, process START before END
-              return type < other.type;
+              if (type != other.type) return type < other.type;
+              // If both are START or both are END, process scaffolds first
+              return mappingType < other.mappingType;
           }
       };
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1956,22 +1956,18 @@ namespace skch
       }
 
       // Event types for sweep line algorithm
-      enum EventType { START, END };
-      enum MappingType { SCAFFOLD, RAW };
+      enum EventType { START_SCAF, END_SCAF, START_RAW, END_RAW };
 
       struct Event {
           double u;  // u-coordinate
           EventType type;
-          MappingType mappingType;
           double v_min, v_max;
           size_t id;
           
           bool operator<(const Event& other) const {
               if (u != other.u) return u < other.u;
               // If u-coords are equal, process START before END
-              if (type != other.type) return type < other.type;
-              // If both are START or both are END, process scaffolds first
-              return mappingType < other.mappingType;
+              return type < other.type;
           }
       };
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2156,39 +2156,31 @@ namespace skch
               IntervalTree activeRaws;
 
               for (const auto& event : events) {
-                  switch (event.type) {
-                      case START_SCAF:
-                          activeScaffolds.insert(event.v_min, event.v_max, event.id);
-                          if (activeRaws.hasOverlap(event.v_min, event.v_max)) {
-                              // Mark all overlapping raw mappings as kept
-                              for (size_t i = 0; i < groupRaw.size(); i++) {
-                                  auto [_, __, v_min, v_max] = computeRotatedCoords(groupRaw[i]);
-                                  if (!(v_max < event.v_min || v_min > event.v_max)) {
-                                      keep[i] = true;
-                                  }
+                  if (event.type == START_SCAF) {
+                      activeScaffolds.insert(event.v_min, event.v_max, event.id);
+                      if (activeRaws.hasOverlap(event.v_min, event.v_max)) {
+                          // Mark all overlapping raw mappings as kept
+                          for (size_t i = 0; i < groupRaw.size(); i++) {
+                              auto [_, __, v_min, v_max] = computeRotatedCoords(groupRaw[i]);
+                              if (!(v_max < event.v_min || v_min > event.v_max)) {
+                                  keep[i] = true;
                               }
                           }
-                          break;
-
-                      case END_SCAF:
-                          activeScaffolds.remove(event.v_min, event.v_max, event.id);
-                          break;
-
-                      case START_RAW:
-                          if (!keep[event.id]) {  // Only process if not already kept
-                              if (activeScaffolds.hasOverlap(event.v_min, event.v_max)) {
-                                  keep[event.id] = true;
-                              } else {
-                                  activeRaws.insert(event.v_min, event.v_max, event.id);
-                              }
+                      }
+                  } else if (event.type == END_SCAF) {
+                      activeScaffolds.remove(event.v_min, event.v_max, event.id);
+                  } else if (event.type == START_RAW) {
+                      if (!keep[event.id]) {  // Only process if not already kept
+                          if (activeScaffolds.hasOverlap(event.v_min, event.v_max)) {
+                              keep[event.id] = true;
+                          } else {
+                              activeRaws.insert(event.v_min, event.v_max, event.id);
                           }
-                          break;
-
-                      case END_RAW:
-                          if (!keep[event.id]) {  // Only remove if we actually inserted it
-                              activeRaws.remove(event.v_min, event.v_max, event.id);
-                          }
-                          break;
+                      }
+                  } else if (event.type == END_RAW) {
+                      if (!keep[event.id]) {  // Only remove if we actually inserted it
+                          activeRaws.remove(event.v_min, event.v_max, event.id);
+                      }
                   }
               }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2005,21 +2005,53 @@ namespace skch
                double u_end;   // computed from query and reference end
                double v_min;   // lower bound of v, expanded by deviation
                double v_max;   // upper bound of v, expanded by deviation
+               bool antidiagonal; // whether this uses antidiagonal projection
           };
-          auto computeRotatedEnvelope = [&](const MappingResult& m) -> RotatedEnvelope {
+
+          // Helper to compute weighted orientation score for a mapping
+          auto computeOrientationScore = [](const MappingResult& m) -> double {
+              int64_t q_span = m.queryEndPos - m.queryStartPos;
+              int64_t r_span = m.refEndPos - m.refStartPos;
+              double diag_proj = (r_span + q_span) / std::sqrt(2.0);
+              double anti_proj = (r_span - q_span) / std::sqrt(2.0);
+              // Return ratio of antidiagonal to diagonal projection
+              return std::abs(anti_proj / diag_proj);
+          };
+
+          // Helper to determine if a group should use antidiagonal projection
+          auto shouldUseAntidiagonal = [&computeOrientationScore](const std::vector<MappingResult>& mappings) -> bool {
+              double total_weight = 0.0;
+              double weighted_score = 0.0;
+              for (const auto& m : mappings) {
+                  double weight = m.queryEndPos - m.queryStartPos;
+                  total_weight += weight;
+                  weighted_score += weight * computeOrientationScore(m);
+              }
+              return (weighted_score / total_weight) > 1.0; // Use antidiagonal if more "inverted" than "direct"
+          };
+          auto computeRotatedEnvelope = [&](const MappingResult& m, bool use_antidiagonal) -> RotatedEnvelope {
                const double invSqrt2 = 1.0 / std::sqrt(2.0);
-               // Use the same transformation for both orientations.
-               double u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
-               double u_end   = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
-               double v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
-               double v2 = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
-               // For forward mappings, typically u_start <= u_end.
-               // For reverse mappings, they might be nearly equal.
+               double u_start, u_end, v1, v2;
+               
+               if (!use_antidiagonal) {
+                   // Standard diagonal projection
+                   u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
+                   u_end   = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
+                   v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
+                   v2 = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
+               } else {
+                   // Antidiagonal projection
+                   u_start = (m.refStartPos - m.queryStartPos) * invSqrt2;
+                   u_end   = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
+                   v1 = (m.queryStartPos + m.refStartPos) * invSqrt2;
+                   v2 = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
+               }
+               
                double u_min = std::min(u_start, u_end);
                double u_max = std::max(u_start, u_end);
                double v_min = std::min(v1, v2) - param.scaffold_max_deviation;
                double v_max = std::max(v1, v2) + param.scaffold_max_deviation;
-               return { u_min, u_max, v_min, v_max };
+               return { u_min, u_max, v_min, v_max, use_antidiagonal };
           };
 
           // For raw mappings within a group we keep track of their envelope plus index.
@@ -2040,10 +2072,13 @@ namespace skch
                }
                const auto& groupScaf = scafGroups[key];
 
+               // Determine projection type for this group
+               bool use_antidiagonal = shouldUseAntidiagonal(groupScaf);
+               
                // Compute rotated envelopes for scaffold mappings in this group.
                std::vector<RotatedEnvelope> scaffoldEnvelopes;
                for (const auto& m : groupScaf) {
-                    scaffoldEnvelopes.push_back(computeRotatedEnvelope(m));
+                    scaffoldEnvelopes.push_back(computeRotatedEnvelope(m, use_antidiagonal));
                }
                std::sort(scaffoldEnvelopes.begin(), scaffoldEnvelopes.end(),
                          [](const RotatedEnvelope& a, const RotatedEnvelope& b) {
@@ -2053,7 +2088,7 @@ namespace skch
                // Compute envelopes for raw mappings in this group.
                std::vector<RawEnv> rawEnvs;
                for (size_t i = 0; i < groupRaw.size(); i++) {
-                    rawEnvs.push_back({ computeRotatedEnvelope(groupRaw[i]), i });
+                    rawEnvs.push_back({ computeRotatedEnvelope(groupRaw[i], use_antidiagonal), i });
                }
                std::sort(rawEnvs.begin(), rawEnvs.end(),
                          [](const RawEnv& a, const RawEnv& b) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2100,18 +2100,6 @@ namespace skch
                scafGroups[key].push_back(m);
           }
 
-          // Partition raw mappings and scaffold mappings into groups
-          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> rawGroups;
-          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> scafGroups;
-          for (const auto& m : readMappings) {
-               GroupKey key { m.querySeqId, m.refSeqId };
-               rawGroups[key].push_back(m);
-          }
-          for (const auto& m : superChains) {
-               GroupKey key { m.querySeqId, m.refSeqId };
-               scafGroups[key].push_back(m);
-          }
-
           // Helper to compute weighted orientation score for a mapping
           auto computeOrientationScore = [](const MappingResult& m) -> double {
               int64_t q_span = m.queryEndPos - m.queryStartPos;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2309,13 +2309,13 @@ namespace skch
                // Generate events for both scaffold and raw envelopes
                for (size_t i = 0; i < scaffoldEnvelopes.size(); i++) {
                     const auto& scaf = scaffoldEnvelopes[i];
-                    events.push_back(Event{scaf.u_start, START_SCAF, scaf.v_min, scaf.v_max, i});
-                    events.push_back(Event{scaf.u_end, END_SCAF, scaf.v_min, scaf.v_max, i});
+                    events.push_back(Event{scaf.u_start, START, SCAFFOLD, scaf.v_min, scaf.v_max, i});
+                    events.push_back(Event{scaf.u_end, END, SCAFFOLD, scaf.v_min, scaf.v_max, i});
                }
                for (size_t i = 0; i < rawEnvs.size(); i++) {
                     const auto& raw = rawEnvs[i].env;
-                    events.push_back(Event{raw.u_start, START_RAW, raw.v_min, raw.v_max, i});
-                    events.push_back(Event{raw.u_end, END_RAW, raw.v_min, raw.v_max, i});
+                    events.push_back(Event{raw.u_start, START, RAW, raw.v_min, raw.v_max, i});
+                    events.push_back(Event{raw.u_end, END, RAW, raw.v_min, raw.v_max, i});
                }
 
                // Sort events by u-coordinate (and type/mapping type for ties)

--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -223,7 +223,6 @@ namespace skch
             //mark mappings as good
             obj.markGood(bst, secondaryToKeep, dropRand, overlapThreshold);
 
-            progress.increment(std::distance(it, it2));
             it = it2;
           }
 
@@ -301,7 +300,7 @@ namespace skch
        *                                 until we only have secondaryToKeep secondary mappings
        */
       template <typename VecIn>
-      void filterMappings(VecIn &readMappings, int secondaryToKeep, bool dropRand, double overlapThreshold, progress_meter::ProgressMeter& progress)
+      void filterMappings(VecIn &readMappings, int secondaryToKeep, bool dropRand, double overlapThreshold)
       {
           //Apply the main filtering algorithm to ensure the best mappings across complete axis
           liFilterAlgorithm(readMappings, secondaryToKeep, dropRand, overlapThreshold, progress);

--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -300,7 +300,7 @@ namespace skch
        *                                 until we only have secondaryToKeep secondary mappings
        */
       template <typename VecIn>
-      void filterMappings(VecIn &readMappings, int secondaryToKeep, bool dropRand, double overlapThreshold)
+      void filterMappings(VecIn &readMappings, int secondaryToKeep, bool dropRand, double overlapThreshold, progress_meter::ProgressMeter& progress)
       {
           //Apply the main filtering algorithm to ensure the best mappings across complete axis
           liFilterAlgorithm(readMappings, secondaryToKeep, dropRand, overlapThreshold, progress);

--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -301,7 +301,7 @@ namespace skch
        *                                 until we only have secondaryToKeep secondary mappings
        */
       template <typename VecIn>
-      void filterMappings(VecIn &readMappings, uint16_t secondaryToKeep, bool dropRand, double overlapThreshold, progress_meter::ProgressMeter& progress)
+      void filterMappings(VecIn &readMappings, int secondaryToKeep, bool dropRand, double overlapThreshold, progress_meter::ProgressMeter& progress)
       {
           //Apply the main filtering algorithm to ensure the best mappings across complete axis
           liFilterAlgorithm(readMappings, secondaryToKeep, dropRand, overlapThreshold, progress);

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -82,9 +82,9 @@ struct Parameters
     bool world_minimizers;
     uint64_t sparsity_hash_threshold;                 // keep mappings that hash to <= this value
     double overlap_threshold;                         // minimum overlap for a mapping to be considered
-    int64_t scaffold_gap;                            // max diagonal deviation from super-chains
-    int64_t super_chain_gap;                         // gap threshold for merging super-chains
-    int64_t super_block_length = 50000;              // minimum super block length
+    int64_t scaffold_max_deviation;                  // max diagonal deviation from scaffold chains
+    int64_t scaffold_gap;                           // gap threshold for scaffold chaining
+    int64_t scaffold_min_length = 50000;            // minimum scaffold block length
     
     bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -84,7 +84,8 @@ struct Parameters
     double overlap_threshold;                         // minimum overlap for a mapping to be considered
     int64_t scaffold_gap;                            // max diagonal deviation from super-chains
     int64_t super_chain_gap;                         // gap threshold for merging super-chains
-
+    int64_t super_block_length = 50000;              // minimum super block length
+    
     bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //
     int64_t index_by_size = std::numeric_limits<int64_t>::max();  // Target total size of sequences for each index subset

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -82,6 +82,8 @@ struct Parameters
     bool world_minimizers;
     uint64_t sparsity_hash_threshold;                 // keep mappings that hash to <= this value
     double overlap_threshold;                         // minimum overlap for a mapping to be considered
+    int64_t scaffold_gap;                            // max diagonal deviation from super-chains
+    int64_t super_chain_gap;                         // gap threshold for merging super-chains
 
     bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //


### PR DESCRIPTION
We add a higher level merging pass that takes the maximally merged mappings and chains them even more aggressively. The set of resulting "scaffold mappings" are then used to filter the other shorter mappings (those merged only up to our max-mapping-length), keeping only the mappings within a given deviation of the scaffold mappings. The idea is to filter for mappings in a general dominant chain, but not force every mapping to be kept to be chained together. This also resolves a class of under-filtering issues which had been latent in the main branch for months.