### PR TITLE
query padding

### DIFF
--- a/src/align/include/align_parameters.hpp
+++ b/src/align/include/align_parameters.hpp
@@ -64,6 +64,7 @@ struct Parameters {
     bool disable_chain_patching;                  //Disable alignment patching at chain boundaries
     bool multithread_fasta_input;                 //Multithreaded fasta input
     uint64_t target_padding;                      //Additional padding around target sequence
+    uint64_t query_padding;                       //Additional padding around query sequence
 
 #ifdef WFA_PNG_TSV_TIMING
     // plotting

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -103,8 +103,8 @@ public:
         start_time = std::chrono::high_resolution_clock::now();
         last_file_update = start_time;
         
-        // Check if stderr is a TTY *AND* stdout is not redirected to a file
-        use_progress_bar = isatty(fileno(stderr)) && isatty(fileno(stdout));
+        // Check if stderr is a TTY
+        use_progress_bar = isatty(fileno(stderr));
         
         // For file output, print initial banner with 0% progress
         if (!use_progress_bar) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -294,9 +294,9 @@ void parse_args(int argc,
         align_parameters.wfa_patching_gap_opening_score2 = params[3];
         align_parameters.wfa_patching_gap_extension_score2 = params[4];
     } else {
-        align_parameters.wfa_patching_mismatch_score = 6;
-        align_parameters.wfa_patching_gap_opening_score1 = 6;
-        align_parameters.wfa_patching_gap_extension_score1 = 3;
+        align_parameters.wfa_patching_mismatch_score = 5;
+        align_parameters.wfa_patching_gap_opening_score1 = 8;
+        align_parameters.wfa_patching_gap_extension_score1 = 2;
         align_parameters.wfa_patching_gap_opening_score2 = 24;
         align_parameters.wfa_patching_gap_extension_score2 = 1;
     }

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -126,8 +126,8 @@ void parse_args(int argc,
 
     args::Group alignment_opts(options_group, "Alignment:");
     args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF file for alignment", {'i', "align-paf"});
-    args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "padding around target sequence [100]", {'E', "target-padding"});
-    args::ValueFlag<std::string> query_padding(alignment_opts, "INT", "padding around query sequence [0]", {'U', "query-padding"});
+    args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "padding around target sequence [500]", {'E', "target-padding"});
+    args::ValueFlag<std::string> query_padding(alignment_opts, "INT", "padding around query sequence [500]", {'U', "query-padding"});
     args::ValueFlag<std::string> wfa_params(alignment_opts, "vals", 
         "scoring: mismatch, gap1(o,e), gap2(o,e) [6,6,3,24,1]", {'g', "wfa-params"});
     args::Flag disable_chain_patching(alignment_opts, "", "disable alignment patching at chain boundaries", {"disable-chain-patching"});
@@ -534,7 +534,8 @@ void parse_args(int argc,
         }
         align_parameters.target_padding = p;
     } else {
-        align_parameters.target_padding = 100;
+        // Default to half segment length, capped at 5000
+        align_parameters.target_padding = std::min(map_parameters.segLength / 2, (int64_t)5000);
     }
     
     if (query_padding) {
@@ -545,7 +546,8 @@ void parse_args(int argc,
         }
         align_parameters.query_padding = p;
     } else {
-        align_parameters.query_padding = 0;
+        // Default to half segment length, capped at 5000
+        align_parameters.query_padding = std::min(map_parameters.segLength / 2, (int64_t)5000);
     }
 
     if (thread_count) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -127,6 +127,7 @@ void parse_args(int argc,
     args::Group alignment_opts(options_group, "Alignment:");
     args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF file for alignment", {'i', "align-paf"});
     args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "padding around target sequence [100]", {'E', "target-padding"});
+    args::ValueFlag<std::string> query_padding(alignment_opts, "INT", "padding around query sequence [0]", {'U', "query-padding"});
     args::ValueFlag<std::string> wfa_params(alignment_opts, "vals", 
         "scoring: mismatch, gap1(o,e), gap2(o,e) [6,6,3,24,1]", {'g', "wfa-params"});
     args::Flag disable_chain_patching(alignment_opts, "", "disable alignment patching at chain boundaries", {"disable-chain-patching"});
@@ -534,6 +535,17 @@ void parse_args(int argc,
         align_parameters.target_padding = p;
     } else {
         align_parameters.target_padding = 100;
+    }
+    
+    if (query_padding) {
+        const int64_t p = handy_parameter(args::get(query_padding));
+        if (p < 0) {
+            std::cerr << "[wfmash] ERROR: query padding must be >= 0" << std::endl;
+            exit(1);
+        }
+        align_parameters.query_padding = p;
+    } else {
+        align_parameters.query_padding = 0;
     }
 
     if (thread_count) {


### PR DESCRIPTION
Cleans up mapping chain ends. WIP because we may duplicate some alignment portions mid-chain.