### PR TITLE
2d merge binary search

### DIFF
--- a/src/common/indicators.hpp
+++ b/src/common/indicators.hpp
@@ -1271,11 +1271,11 @@ static inline void erase_line() {
 #else
 
 static inline void show_console_cursor(bool const show) {
-  std::fputs(show ? "\033[?25h" : "\033[?25l", stdout);
+  std::fprintf(stderr, show ? "\033[?25h" : "\033[?25l");
 }
 
 static inline void erase_line() {
-  std::fputs("\r\033[K", stdout);
+  std::fprintf(stderr, "\r\033[K");
 }
 
 #endif

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -106,13 +106,7 @@ public:
         // Check if stderr is a TTY
         use_progress_bar = _use_progress_bar && isatty(fileno(stderr));
         
-        // For file output, print initial banner with 0% progress
-        if (!use_progress_bar) {
-            std::cerr << banner << " [0.0% complete, 0/" << total.load() 
-                      << " units, 0s elapsed]" << std::endl;
-            // Force update of last_file_update to avoid immediate duplicate message
-            last_file_update = std::chrono::high_resolution_clock::now();
-        }
+        // No longer print initial banner here - will be printed explicitly when mapping starts
         
         if (use_progress_bar) {
             // Hide cursor during progress display
@@ -181,6 +175,20 @@ public:
                           << " units, " << elapsed.count() << "s elapsed]" << std::endl;
                 last_file_update = now;
             }
+        }
+    }
+
+    // Method to explicitly print initial progress message
+    void print_progress_explicitly() {
+        if (!use_progress_bar) {
+            auto now = std::chrono::high_resolution_clock::now();
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time);
+            
+            std::cerr << banner << " [0.0% complete, 0/" << total.load() 
+                      << " units, 0s elapsed]" << std::endl;
+            
+            // Update last_file_update to avoid immediate duplicate message
+            last_file_update = now;
         }
     }
 

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -63,9 +63,10 @@ private:
                 auto elapsed_since_update = std::chrono::duration_cast<std::chrono::milliseconds>(
                     curr_time - last_file_update).count();
                 
-                // Update if: 1) 60 seconds have passed, 2) this is the first update, or 3) we're at 100%
-                if ((elapsed_since_update >= file_update_interval || last_progress == 0 || 
-                     curr_progress >= total.load()) && curr_progress != last_progress) {
+                // Update if: 1) 10 seconds have passed, 2) this is the first update, or 3) we're at 100%
+                // Always update every 10 seconds even if progress hasn't changed
+                if (elapsed_since_update >= file_update_interval || last_progress == 0 || 
+                    curr_progress >= total.load()) {
                     
                     auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                         curr_time - start_time).count();
@@ -91,8 +92,8 @@ private:
                 break;
             }
             
-            // Sleep for update interval
-            std::this_thread::sleep_for(std::chrono::milliseconds(update_interval));
+            // Sleep for a shorter interval to ensure we check for time-based updates frequently
+            std::this_thread::sleep_for(std::chrono::milliseconds(std::min(update_interval, static_cast<uint64_t>(500))));
         }
     }
 

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -130,10 +130,10 @@ public:
                 indicators::option::MaxProgress{total},
                 indicators::option::Stream{std::cerr}
             );
-            
-            // Start the update thread
-            update_thread = std::thread(&ProgressMeter::update_progress_thread, this);
         }
+        
+        // Always start the update thread, for both progress bar and file output modes
+        update_thread = std::thread(&ProgressMeter::update_progress_thread, this);
     }
 
     ~ProgressMeter() {

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -27,7 +27,7 @@ private:
     
     // Update intervals (milliseconds)
     const uint64_t update_interval = 100;  // For progress bar (TTY)
-    const uint64_t file_update_interval = 60000;  // 60 seconds for file output
+    const uint64_t file_update_interval = 10000;  // 10 seconds for file output (debugging)
     std::chrono::time_point<std::chrono::high_resolution_clock> last_file_update;
 
     void update_progress_thread() {
@@ -110,6 +110,8 @@ public:
         if (!use_progress_bar) {
             std::cerr << banner << " [0.0% complete, 0/" << total.load() 
                       << " units, 0s elapsed]" << std::endl;
+            // Force update of last_file_update to avoid immediate duplicate message
+            last_file_update = std::chrono::high_resolution_clock::now();
         }
         
         if (use_progress_bar) {

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -187,12 +187,8 @@ public:
         }
     }
 
-    // Tracking if we've already printed an initial message
-    std::atomic<bool> initial_message_printed{false};
-    
     // Method to explicitly print initial progress message
     void print_progress_explicitly() {
-        if (!use_progress_bar && !initial_message_printed.exchange(true)) {
         if (!use_progress_bar && !initial_message_printed.exchange(true)) {
             auto now = std::chrono::high_resolution_clock::now();
             auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time);

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -23,6 +23,7 @@ namespace fs = std::filesystem;
 #include <algorithm>
 #include <unordered_set>
 #include <mutex>
+#include <thread>
 #include <sstream>
 #include "taskflow/taskflow.hpp"
 
@@ -752,6 +753,12 @@ namespace skch
                                           output
                                       );
 
+                                      // Print initial progress message for the first fragment
+                                      static std::once_flag first_fragment;
+                                      std::call_once(first_fragment, [&output]() {
+                                          output->progress.print_progress_explicitly();
+                                      });
+                                      
                                       std::vector<IntervalPoint> intervalPoints;
                                       std::vector<L1_candidateLocus_t> l1Mappings;
                                       MappingResultsVector_t l2Mappings;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -589,7 +589,7 @@ namespace skch
                   );
 
               // Build or load index task
-              auto buildIndex_task = subset_flow->emplace([this, target_subset=target_subset, subset_idx, total_subsets=target_subsets.size()]() {
+              auto buildIndex_task = subset_flow->emplace([this, target_subset=target_subset, subset_idx, total_subsets=target_subsets.size(), &target_subsets]() {
                   if (!param.indexFilename.empty()) {
                       // Load existing index
                       std::string indexFilename = param.indexFilename.string();

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2766,7 +2766,7 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
                                     static_cast<double>(ref_dist) * ref_dist;
                     double max_dist_sq = static_cast<double>(max_dist) * max_dist;
                     if (dist_sq < max_dist_sq && dist_sq < best_score && dist_sq < it2.chainPairScore) {
-                        best_it2 = &it2;
+                        best_it2 = group_begin + *idx_it; // Use the actual iterator, not a pointer
                         best_score = dist_sq;
                     }
                 }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -546,15 +546,15 @@ namespace skch
               if(target_subset.empty()) continue;
               
               std::cerr << "[wfmash::mashmap] Processing subset " << (subset_idx + 1) 
-                        << "/" << target_subsets.size() << std::endl;
+                        << "/" << target_subsets.size() << " (mapping)" << std::endl;
               
               // Use a single index filename for all subsets
               std::string indexFilename = param.indexFilename.string();
               
               // Handle index creation
               if (param.create_index_only) {
-                  std::cerr << "[wfmash::mashmap] Creating index for subset " << (subset_idx + 1) 
-                            << "/" << target_subsets.size() << ": " << indexFilename << std::endl;
+                  std::cerr << "[wfmash::mashmap] Processing subset " << (subset_idx + 1) 
+                            << "/" << target_subsets.size() << " (indexing): " << indexFilename << std::endl;
     
                   // Build the index directly
                   refSketch = new skch::Sketch(param, *idManager, target_subset);
@@ -583,8 +583,7 @@ namespace skch
 
               auto progress = std::make_shared<progress_meter::ProgressMeter>(
                   subset_query_length,
-                  "[wfmash::mashmap] mapping subset " + std::to_string(subset_idx + 1) + 
-                  "/" + std::to_string(target_subsets.size()),
+                  "[wfmash::mashmap] mapping",
                   param.use_progress_bar
                   );
 
@@ -648,8 +647,7 @@ namespace skch
                       // Use progress meter for sketching and index building
                       auto sketch_index_progress = std::make_shared<progress_meter::ProgressMeter>(
                           100, // Using 100 as a generic value for percentage-based progress
-                          "[wfmash::mashmap] indexing subset " + std::to_string(subset_idx + 1) + 
-                          "/" + std::to_string(target_subsets.size()),
+                          "[wfmash::mashmap] indexing",
                           param.use_progress_bar);
                   
                       // Build index in memory with progress meter

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2776,12 +2776,6 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
                 intersection_candidates.push_back(std::make_pair(&(*it2), *idx_it));
             }
             
-            // Sort candidates by query position to enable early stopping
-            std::sort(intersection_candidates.begin(), intersection_candidates.end(),
-                [group_begin](const auto& a, const auto& b) {
-                    return (a.first->queryStartPos < b.first->queryStartPos);
-                });
-            
             int64_t best_ref_dist = std::numeric_limits<int64_t>::max();
             
             // Process only mappings in the intersection of query and target bounds

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -754,9 +754,16 @@ namespace skch
                                       );
 
                                       // Print initial progress message for the first fragment
+                                      // and reset the timer when actual work begins
                                       static std::once_flag first_fragment;
                                       std::call_once(first_fragment, [&output]() {
+                                          // Reset the progress meter's start time to now
                                           output->progress.print_progress_explicitly();
+                                          
+                                          // Also reset for progress bar mode
+                                          if (output->progress.use_progress_bar && output->progress.progress_bar) {
+                                              output->progress.start_time = std::chrono::high_resolution_clock::now();
+                                          }
                                       });
                                       
                                       std::vector<IntervalPoint> intervalPoints;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2772,7 +2772,7 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
                 }
             }
             
-            if (best_it2 != group_end && best_it2 != nullptr) {
+            if (best_it2 != group_end) {
                 best_it2->chainPairScore = best_score;
                 best_it2->chainPairId = it->splitMappingId;
             }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2766,8 +2766,8 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
                 target_max, [&group_begin, is_forward](offset_t val, size_t idx) {
                     auto& mapping = *(group_begin + idx);
                     // For forward strand, compare start position
-                    // For reverse strand, compare start position (which is larger in reference coordinates)
-                    return val < (is_forward ? mapping.refStartPos : mapping.refStartPos);
+                    // For reverse strand, compare end position (which is smaller in reference coordinates)
+                    return val < (is_forward ? mapping.refStartPos : mapping.refEndPos);
                 });
             
             // Store both pointers and their positions in the collection


### PR DESCRIPTION
# Two-dimensional search optimization for mergeMappingsInRange

This PR modifies the chain mapping algorithm in `mergeMappingsInRange` with the following changes:

1. Creates an index of mappings sorted by reference position (`target_index`) to enable efficient searching in the reference coordinate space

2. Implements short-circuit fast path for adjacent mappings by first checking if the next mapping in query space is also close in target space before performing binary searches

3. Adds two-dimensional search approach that:
   - Uses binary search to find mappings within range in query space
   - Uses binary search on the target index to find mappings within range in reference space
   - Processes only mappings in the intersection of both ranges

4. Adds early termination condition when processing candidates based on distance metrics

5. Improves distance calculations with better handling of strand orientation