### PR TITLE
Add configurable chunk size for merging fragment mappings

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -2742,6 +2742,21 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
                     return val < m.queryStartPos;
                 });
 
+            // Limit how far we look ahead based on chunk size
+            int64_t accumulated_size = 0;
+            auto chunk_end_it2 = end_it2;
+            
+            for (auto size_it = it + 1; size_it != end_it2; ++size_it) {
+                accumulated_size += (size_it->queryEndPos - size_it->queryStartPos);
+                if (accumulated_size > param.merge_fragment_chunksize) {
+                    chunk_end_it2 = size_it;
+                    break;
+                }
+            }
+            
+            // Use the smaller of the distance-based end and the chunk-size end
+            end_it2 = std::min(end_it2, chunk_end_it2);
+
             // Check mappings within the range
             for (auto it2 = it + 1; it2 != end_it2; ++it2) {
                 if (it2->queryStartPos == it->queryStartPos) continue;

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -85,6 +85,7 @@ struct Parameters
     int64_t scaffold_max_deviation;                  // max diagonal deviation from scaffold chains
     int64_t scaffold_gap;                           // gap threshold for scaffold chaining
     int64_t scaffold_min_length = 50000;            // minimum scaffold block length
+    int64_t merge_fragment_chunksize = 1000000;     // Process this many bp of fragments per merge chunk
     
     bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //


### PR DESCRIPTION
This allows for higher levels of parallelism in merging, which should significantly help our wallclock times.