### PR TITLE
modify -H parameter to set minimum hits floor with default 4

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -79,7 +79,7 @@ void parse_args(int argc,
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
     args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {'H', "l1-hits"});
+    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum floor for L1 hits threshold [4]", {'H', "l1-hits"});
     args::ValueFlag<double> max_kmer_freq(mapping_opts, "FLOAT", "filter minimizers occurring > FLOAT of total [0.0002]", {'F', "filter-freq"});
 
     args::Group alignment_opts(options_group, "Alignment:");
@@ -614,9 +614,9 @@ void parse_args(int argc,
     }
 
     if (min_hits) {
-        map_parameters.minimum_hits = args::get(min_hits);
+        map_parameters.minimum_hits = std::max(4, args::get(min_hits));
     } else {
-        map_parameters.minimum_hits = -1; // auto
+        map_parameters.minimum_hits = 4; // minimum floor
     }
 
     if (max_kmer_freq) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -246,7 +246,7 @@ namespace skch
             p.query_list,
             p.target_list)),
         cached_segment_length(p.segLength),
-        cached_minimum_hits(p.minimum_hits > 0 ? p.minimum_hits : Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval))
+        cached_minimum_hits(std::max(p.minimum_hits, Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval)))
           {
               // Initialize sequence names right after creating idManager
               // Important: Apply any prefix filters here to ensure consistent query/target list
@@ -1610,12 +1610,13 @@ namespace skch
                     << " kmerComplexity=" << Q.kmerComplexity << ")\n";*/
 
           //3. Compute L1 windows
-          // Always respect the minimum hits parameter if set
-          int minimumHits = param.minimum_hits > 0 ? 
-              param.minimum_hits : 
-              (Q.len == cached_segment_length ? 
-                  cached_minimum_hits : 
-                  Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval));
+          // Calculate minimum hits, respecting the minimum floor set by param.minimum_hits
+          int minimumHits = Q.len == cached_segment_length ? 
+              cached_minimum_hits : 
+              Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval);
+          
+          // Apply the minimum floor
+          minimumHits = std::max(param.minimum_hits, minimumHits);
 
           // For each "group"
           auto ip_begin = intervalPoints.begin();


### PR DESCRIPTION
This avoids converting each singleton (in sketch) minmer match into a mapping, which leads to memory exhaustion at high divergence mapping. There will be some loss of sensitivity, but my hope is that this will mostly be recovered by mapping chaining.