### PR TITLE
Added checks for apple silicon - build successful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ aligned.paf.output
 all2all.paf
 all2all.paf.output
 all2all-300.paf.output
+*.DS_Store
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,15 +18,32 @@ project(wfmash)
 
 enable_testing()
 
-include(GNUInstallDirs)
+include(GNUInstallDirs) # For CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR etc.
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_STANDARD 17)
-# set(CMAKE_CXX_STANDARD 20) # because of sequenceIds.hpp:101:23: warning: captured structured bindings are a C++20 extension [-Wc++20-extensions]
-set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard is not allowed.
-set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are used.
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+# --- Start: RPATH settings for macOS ---
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH ON) # Enable RPATH generation on macOS.
+                           # This uses @rpath for linking against dylibs in the build tree
+                           # and sets install_name to use @rpath.
 
+  # Set the RPATH for installed targets.
+  # For an executable in ${CMAKE_INSTALL_PREFIX}/bin and libraries in ${CMAKE_INSTALL_PREFIX}/lib,
+  # @executable_path/../${CMAKE_INSTALL_LIBDIR} allows the executable to find the libraries.
+  # ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR} is an absolute path.
+  set(CMAKE_INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR};${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+  # It's also good practice to use the install RPATHs during the build phase.
+  # This helps ensure that targets run correctly from the build directory
+  # and can help catch RPATH issues earlier.
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+endif()
+# --- End: RPATH settings for macOS ---
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(BUILD_STATIC "Build static binary" OFF)
 option(BUILD_DEPS "Build external dependencies (not recommended)" OFF)
@@ -35,10 +52,11 @@ option(PROFILER "Enable profiling" OFF)
 option(ASAN "Use address sanitiser (Debug build only)" OFF)
 option(DISABLE_LTO "Disable IPO/LTO" OFF)
 option(STOP_ON_ERROR "Stop compiling on first error" OFF)
+option(WFA_PNG_AND_TSV "Enable PNG and TSV output for WFA (for debugging/visualization)" OFF)
 
 if (NOT DISABLE_LTO)
-  include(CheckIPOSupported) # adds lto
-  check_ipo_supported(RESULT ipo_supported OUTPUT output) # lto
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT ipo_supported OUTPUT output)
 endif()
 
 if (STOP_ON_ERROR)
@@ -55,12 +73,52 @@ else ()
 endif ()
 
 find_package(PkgConfig REQUIRED)
-# include(FindCURL) # for htslib?
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(LibLZMA REQUIRED)
 find_package(Threads REQUIRED)
 find_package(OpenMP REQUIRED)
+
+# --- Start: Logic for using Homebrew HTSlib, GSL, and LibDeflate on Apple Silicon ---
+set(WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON FALSE)
+set(WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON FALSE)
+set(WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON FALSE)
+
+if (APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64"))
+    # Check for HTSlib
+    pkg_check_modules(HOMEBREW_HTSLIB QUIET htslib)
+    if(HOMEBREW_HTSLIB_FOUND)
+        set(WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON TRUE)
+        message(STATUS "Apple Silicon: Found Homebrew HTSlib. Will use it.")
+        message(STATUS "  Homebrew HTSlib Includes: ${HOMEBREW_HTSLIB_INCLUDE_DIRS}")
+        message(STATUS "  Homebrew HTSlib Link Libraries: ${HOMEBREW_HTSLIB_LINK_LIBRARIES}")
+    else()
+        message(WARNING "Apple Silicon: Homebrew HTSlib not found via pkg-config. Will try other HTSlib options.")
+    endif()
+
+    # Check for GSL
+    pkg_check_modules(HOMEBREW_GSL QUIET gsl)
+    if(HOMEBREW_GSL_FOUND)
+        set(WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON TRUE)
+        message(STATUS "Apple Silicon: Found Homebrew GSL. Will use it.")
+        message(STATUS "  Homebrew GSL Includes: ${HOMEBREW_GSL_INCLUDE_DIRS}")
+        message(STATUS "  Homebrew GSL Link Libraries: ${HOMEBREW_GSL_LINK_LIBRARIES}")
+    else()
+        message(WARNING "Apple Silicon: Homebrew GSL not found via pkg-config. Will try other GSL options.")
+    endif()
+
+    # Check for LibDeflate
+    pkg_check_modules(HOMEBREW_LIBDEFLATE QUIET libdeflate)
+    if(HOMEBREW_LIBDEFLATE_FOUND)
+        set(WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON TRUE)
+        message(STATUS "Apple Silicon: Found Homebrew LibDeflate. Will use it.")
+        message(STATUS "  Homebrew LibDeflate Includes: ${HOMEBREW_LIBDEFLATE_INCLUDE_DIRS}")
+        message(STATUS "  Homebrew LibDeflate Link Libraries: ${HOMEBREW_LIBDEFLATE_LINK_LIBRARIES}")
+    else()
+        message(WARNING "Apple Silicon: Homebrew LibDeflate not found via pkg-config. Will try other LibDeflate options.")
+    endif()
+endif()
+# --- End: Logic for using Homebrew HTSlib, GSL, and LibDeflate on Apple Silicon ---
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING
@@ -69,38 +127,38 @@ endif()
 
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
-if (${CMAKE_BUILD_TYPE} MATCHES Release) # always builds optimized version
-  SET(CMAKE_CXX_FLAGS_RELEASE  "") # disable default flags
-  # This is the default build for the developers. Note that Debian
-  # packagers should use RelWithDebInfo and the Guix version should
-  # use Generic builds below - fine tune through --tune etc. For
-  # debugging you may want to use the Debug version.
-  # set(EXTRA_FLAGS "-Ofast -march=x86-64-v3 -funroll-all-loops") --- use the --tune option in guix.scm instead
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-parameter")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-parameter")
+
+if (${CMAKE_BUILD_TYPE} MATCHES Release)
+  SET(CMAKE_CXX_FLAGS_RELEASE  "")
+  SET(CMAKE_C_FLAGS_RELEASE  "")
   set(EXTRA_FLAGS "-Ofast -march=native -funroll-all-loops")
-  # ---- The following are for hand profiling only
-  # set(EXTRA_FLAGS "-Ofast -march=native -pipe -msse4.2 -funroll-all-loops") #  -fprofile-generate=../pgo")
-  # set(EXTRA_FLAGS "-O3 -march=native -funroll-all-loops -fprofile-generate=${CMAKE_BINARY_DIR}/../pgo")
-  # set(EXTRA_FLAGS "-O3 -march=native -funroll-all-loops -fprofile-use=${CMAKE_BINARY_DIR}/../pgo")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNDEBUG ${EXTRA_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG ${EXTRA_FLAGS}")
-endif ()
-
-if (${CMAKE_BUILD_TYPE} MATCHES Generic)
-  set(EXTRA_FLAGS "-O3 -funroll-all-loops") # march is handled through --tune, see guix.scm
+elseif (${CMAKE_BUILD_TYPE} MATCHES Generic)
+  set(EXTRA_FLAGS "-O3 -funroll-all-loops")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG ${EXTRA_FLAGS}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNDEBUG ${EXTRA_FLAGS}")
-endif ()
-
-if (${CMAKE_BUILD_TYPE} MATCHES Debug)
+elseif (${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo)
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
+elseif (${CMAKE_BUILD_TYPE} MATCHES Debug)
+  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+  set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
   if (ASAN)
-    # Enable ASan
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address  -fno-omit-frame-pointer -fno-common")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address  -fno-omit-frame-pointer -fno-common")
+    set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer -fno-common")
+    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer -fno-common")
+    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address")
   endif ()
 else ()
+    message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+endif ()
+
+if(OpenMP_FOUND AND NOT (${CMAKE_BUILD_TYPE} MATCHES Debug))
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif ()
+endif()
 
 if( NOT DISABLE_LTO AND ipo_supported )
   message(STATUS "IPO / LTO enabled")
@@ -108,12 +166,13 @@ if( NOT DISABLE_LTO AND ipo_supported )
 endif()
 
 if(PROFILER)
-  set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -g") # add debug switch for resolution
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
 endif()
 
-if(GPROF) # for the GNU profiler -- don't use this one
-  set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -g -pg")
+if(GPROF)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -pg")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -pg")
 endif(GPROF)
 
@@ -126,9 +185,15 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_subdirectory(src/common/wflign EXCLUDE_FROM_ALL)
-
-include(ExternalProject)
+# Conditionally add HTSLIB submodule
+if(NOT WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON AND NOT BUILD_DEPS)
+    message(STATUS "HTSLIB: Using submodule from deps/htslib.")
+    add_subdirectory(deps/htslib)
+elseif(WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON)
+    message(STATUS "Apple Silicon: Using Homebrew HTSlib, skipping build of deps/htslib submodule.")
+else() 
+    message(STATUS "HTSLIB: BUILD_DEPS is ON, htslib will be managed by ExternalProject_Add if defined below.")
+endif()
 
 add_subdirectory(deps/WFA2-lib)
 set_target_properties(align_benchmark PROPERTIES EXCLUDE_FROM_ALL 1)
@@ -138,74 +203,47 @@ else()
   set_target_properties(wfa2cpp_static PROPERTIES EXCLUDE_FROM_ALL 1)
 endif()
 
+add_subdirectory(src/common/wflign EXCLUDE_FROM_ALL)
+
 if (BUILD_DEPS)
-  ExternalProject_Add(htslib
-    URL https://github.com/samtools/htslib/releases/download/1.20/htslib-1.20.tar.bz2
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/htslib
-    CONFIGURE_COMMAND autoreconf -i && ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/htslib --disable-libcurl --disable-s3
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) install
-    BUILD_IN_SOURCE 1
-  )
+  include(ExternalProject)
+  if(NOT WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON)
+    ExternalProject_Add(htslib_ext
+      URL https://github.com/samtools/htslib/releases/download/1.20/htslib-1.20.tar.bz2
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/htslib_ext_build
+      CONFIGURE_COMMAND autoreconf -i && ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/htslib_ext_install --disable-libcurl --disable-s3
+      BUILD_COMMAND $(MAKE)
+      INSTALL_COMMAND $(MAKE) install
+      BUILD_IN_SOURCE 1
+    )
+    add_dependencies(wfmash htslib_ext)
+  endif()
 
-  ExternalProject_Add(gsl
-    URL https://mirror.ibcp.fr/pub/gnu/gsl/gsl-2.8.tar.gz
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gsl
-    CONFIGURE_COMMAND ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/gsl
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) install
-    BUILD_IN_SOURCE 1
-  )
+  if(NOT WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON)
+    ExternalProject_Add(gsl_ext
+      URL https://mirror.ibcp.fr/pub/gnu/gsl/gsl-2.8.tar.gz
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gsl_ext_build
+      CONFIGURE_COMMAND ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/gsl_ext_install
+      BUILD_COMMAND $(MAKE)
+      INSTALL_COMMAND $(MAKE) install
+      BUILD_IN_SOURCE 1
+    )
+    add_dependencies(wfmash gsl_ext)
+  endif()
 
-  ExternalProject_Add(libdeflate
-    URL https://github.com/ebiggers/libdeflate/releases/download/v1.20/libdeflate-1.20.tar.gz
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libdeflate
-    CMAKE_ARGS
-      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libdeflate
-      -DCMAKE_BUILD_TYPE=Release
-    BUILD_COMMAND cmake --build . --config Release
-    INSTALL_COMMAND cmake --install . --config Release
-    BUILD_IN_SOURCE 1
-  )
-
-  add_dependencies(wfmash htslib gsl libdeflate)
+  if(NOT WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON)
+    ExternalProject_Add(libdeflate_ext
+      URL https://github.com/ebiggers/libdeflate/releases/download/v1.20/libdeflate-1.20.tar.gz
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libdeflate_ext_build
+      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libdeflate_ext_install -DCMAKE_BUILD_TYPE=Release
+    )
+    add_dependencies(wfmash libdeflate_ext)
+  endif()
 endif()
 
 add_executable(wfmash
   src/common/utils.cpp
   src/interface/main.cpp)
-
-if (BUILD_DEPS)
-  target_include_directories(wfmash PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/htslib/include
-    ${CMAKE_CURRENT_BINARY_DIR}/gsl/include
-    ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/include
-  )
-
-  target_link_libraries(wfmash
-    ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgsl.a
-    ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgslcblas.a
-    ${CMAKE_CURRENT_BINARY_DIR}/htslib/lib/libhts.a
-    ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/lib/libdeflate.a
-  )
-else()
-  #find_package(HTSLIB REQUIRED)
-  #find_package(GSL REQUIRED)
-  #find_package(LibDeflate REQUIRED)
-
-  #target_include_directories(wfmash PRIVATE
-  #  ${HTSLIB_INCLUDE_DIR}
-  #  ${GSL_INCLUDE_DIR}
-  #  ${LIBDEFLATE_INCLUDE_DIR}
-  #)
-
-  target_link_libraries(wfmash
-    gsl
-    gslcblas
-    hts
-    deflate
-  )
-endif()
 
 target_include_directories(wfmash PRIVATE
   src
@@ -215,34 +253,116 @@ target_include_directories(wfmash PRIVATE
   deps/WFA2-lib/bindings/cpp
 )
 
-target_link_libraries(wfmash
+# Add Homebrew include directories if applicable
+if(WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON)
+    target_include_directories(wfmash PRIVATE ${HOMEBREW_HTSLIB_INCLUDE_DIRS})
+endif()
+if(WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON)
+    target_include_directories(wfmash PRIVATE ${HOMEBREW_GSL_INCLUDE_DIRS})
+endif()
+if(WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON)
+    target_include_directories(wfmash PRIVATE ${HOMEBREW_LIBDEFLATE_INCLUDE_DIRS})
+endif()
+
+# Linking logic for dependencies
+if (BUILD_DEPS)
+  # Includes for ExternalProjects (if not already covered by Homebrew logic for Apple Silicon)
+  if(NOT WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON)
+    target_include_directories(wfmash PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/htslib_ext_install/include)
+  endif()
+  if(NOT WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON)
+     target_include_directories(wfmash PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gsl_ext_install/include)
+  endif()
+  if(NOT WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON)
+    target_include_directories(wfmash PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/libdeflate_ext_install/include)
+  endif()
+
+  # Linking for ExternalProjects
+  if(NOT WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON)
+    target_link_libraries(wfmash PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/gsl_ext_install/lib/libgsl.a
+        ${CMAKE_CURRENT_BINARY_DIR}/gsl_ext_install/lib/libgslcblas.a
+    )
+  endif()
+  if(NOT WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON)
+    target_link_libraries(wfmash PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/htslib_ext_install/lib/libhts.a
+    )
+  endif()
+  if(NOT WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON)
+    target_link_libraries(wfmash PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate_ext_install/lib/libdeflate.a
+    )
+  endif()
+else() # BUILD_DEPS is OFF
+  # HTSlib
+  if(WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON)
+    message(STATUS "Apple Silicon (BUILD_DEPS OFF): Linking wfmash against Homebrew HTSlib using LINK_LIBRARIES.")
+    target_link_libraries(wfmash PRIVATE ${HOMEBREW_HTSLIB_LINK_LIBRARIES})
+  elseif(NOT WFMASH_USE_HOMEBREW_HTSLIB_ON_APPLE_SILICON AND TARGET htslib)
+    message(STATUS "(BUILD_DEPS OFF): Linking wfmash against 'htslib' target (from submodule).")
+    target_link_libraries(wfmash PRIVATE htslib)
+  else()
+    message(STATUS "(BUILD_DEPS OFF): Linking wfmash against system 'hts'.")
+    target_link_libraries(wfmash PRIVATE hts) 
+  endif()
+
+  # GSL
+  if(WFMASH_USE_HOMEBREW_GSL_ON_APPLE_SILICON)
+      message(STATUS "Apple Silicon (BUILD_DEPS OFF): Linking wfmash against Homebrew GSL using LINK_LIBRARIES.")
+      target_link_libraries(wfmash PRIVATE ${HOMEBREW_GSL_LINK_LIBRARIES})
+  else()
+      find_package(GSL REQUIRED) 
+      if(GSL_FOUND)
+          message(STATUS "(BUILD_DEPS OFF, Not Apple Silicon or Homebrew GSL not found): Linking wfmash against system GSL.")
+          if(TARGET GSL::gsl AND TARGET GSL::gslcblas)
+            target_link_libraries(wfmash PRIVATE GSL::gsl GSL::gslcblas)
+          else()
+            target_link_libraries(wfmash PRIVATE ${GSL_LIBRARIES})
+          endif()
+      else()
+          message(FATAL_ERROR "System GSL not found, and not using Homebrew GSL. Please install GSL or enable BUILD_DEPS.")
+      endif()
+  endif()
+
+  # LibDeflate
+  if(WFMASH_USE_HOMEBREW_LIBDEFLATE_ON_APPLE_SILICON)
+      message(STATUS "Apple Silicon (BUILD_DEPS OFF): Linking wfmash against Homebrew LibDeflate using LINK_LIBRARIES.")
+      target_link_libraries(wfmash PRIVATE ${HOMEBREW_LIBDEFLATE_LINK_LIBRARIES})
+  else()
+      message(STATUS "(BUILD_DEPS OFF, Not Apple Silicon or Homebrew LibDeflate not found): Linking wfmash against system 'deflate'.")
+      target_link_libraries(wfmash PRIVATE deflate)
+  endif()
+endif()
+
+# Common system libraries for wfmash
+target_link_libraries(wfmash PRIVATE
   m
   pthread
-  rt
-  lzma
-  bz2
-  z
+  # rt # rt is often Linux-specific, ensure it's needed/available on macOS
+  ${LIBLZMA_LIBRARIES}
+  ${BZIP2_LIBRARIES}
+  ${ZLIB_LIBRARIES}
   Threads::Threads
 )
 
-if (PROFILER)
-  target_link_libraries(wfmash profiler)
-endif()
-
+# Link wflign and wfa2cpp (static or shared based on BUILD_STATIC)
 if (BUILD_STATIC)
-  target_link_libraries(wfmash
-    wflign_static
-    wfa2cpp_static
-  )
+  target_link_libraries(wfmash PRIVATE wflign_static wfa2cpp_static)
 else()
-  target_link_libraries(wfmash
-    wflign
-    wfa2cpp
-  )
+  target_link_libraries(wfmash PRIVATE wflign wfa2cpp)
 endif()
 
-# This is to disable tests defined in CTestCustom.cmake:
-configure_file(${CMAKE_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_BINARY_DIR})
+# Link OpenMP using modern imported target
+if(OpenMP_FOUND)
+    target_link_libraries(wfmash PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+set(INVOKE ${CMAKE_BINARY_DIR}/bin/wfmash)
+
+if(EXISTS ${CMAKE_SOURCE_DIR}/CTestCustom.cmake)
+    configure_file(${CMAKE_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_BINARY_DIR})
+endif()
 
 if (ASAN)
   set(INVOKE "ASAN_OPTIONS=detect_leaks=1:symbolize=1:verify_asan_link_order=0 LSAN_OPTIONS=verbosity=0:log_threads=1:suppressions=${CMAKE_SOURCE_DIR}/test/libasan-suppress.txt ${CMAKE_BINARY_DIR}/bin/wfmash")
@@ -256,11 +376,11 @@ endif()
 
 set(REGRESSION_TEST_DIR "test/data/regression")
 
-find_program(WGATOOLS "wgatools") # should be in the path
-if (NOT WGATOOLS) # this is a hack when we add the wgatools path to the Guix shell
+find_program(WGATOOLS "wgatools")
+if (NOT WGATOOLS)
    set(WGATOOLS "env LD_LIBRARY_PATH=$GUIX_PROFILE/lib /wgatools/target/release/wgatools")
 endif()
-MESSAGE(${WGATOOLS})
+MESSAGE(STATUS "WGATOOLS found at: ${WGATOOLS}")
 
 add_test(
   NAME wfmash-time-LPA
@@ -289,37 +409,19 @@ add_test(
 
 add_test(
   NAME wfmash-multi-subset-index
-  COMMAND bash -c "${INVOKE} data/scerevisiae8.fa.gz -t 4 -b 1m -T S288C -W index.idx && ${INVOKE} data/scerevisiae8.fa.gz -t 4 -T S288C -I index.idx -Q Y12 > index.paf && ./scripts/test.sh data/scerevisiae8.fa.gz.fai index.paf 0.9 'Y12\|S288C'"
+  COMMAND bash -c "${INVOKE} data/scerevisiae8.fa.gz -t 4 -b 1m -T S288C -W index.idx && ${INVOKE} data/scerevisiae8.fa.gz -t 4 -T S288C -I index.idx -Q Y12 > index.paf && ./scripts/test.sh data/scerevisiae8.fa.gz.fai index.paf 0.9 'Y12\\|S288C'"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS wfmash DESTINATION bin)
 
 if (BUILD_STATIC)
-
-  install(TARGETS wfa2cpp_static
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-  install(TARGETS wflign_static
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-  install(TARGETS wfa2_static
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS wfa2cpp_static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS wflign_static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS wfa2_static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 else()
-
-  install(TARGETS wfa2cpp
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-  install(TARGETS wflign
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-  install(TARGETS wfa2
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS wfa2cpp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS wflign LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS wfa2 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
 file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/include)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,39 @@ cmake -H. -Bbuild -DBUILD_RETARGETABLE=ON && cmake --build build -- -j 8
 
 This will configure the build without `-march=native`, allowing the binary to be run on different types of machines.
 
+### Building on Apple Silicon
+
+First homebrew must be installed from either the [webpage](https://docs.brew.sh/Installation), or by following the commands below (from the webpage).
+
+```bash
+export HOMEBREW_NO_INSTALL_FROM_API=1
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Once homebrew is installed the dependancies must be installed.
+
+```bash
+brew install htslib
+brew install gsl
+brew install libomp
+brew install llvm
+brew install libdeflate
+brew install zlib
+brew install bzip2
+brew install gcc
+```
+
+Then `wfmash` can be built after exporting the following environmental variables - allowing cmake to see the homebrew libraries.
+
+```bash
+export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:${PKG_CONFIG_PATH}"
+export CC=$(brew --prefix llvm)/bin/clang
+export CXX=$(brew --prefix llvm)/bin/clang++
+export LDFLAGS="-L$(brew --prefix libomp)/lib -L$(brew --prefix llvm)/lib"
+export CPPFLAGS="-I$(brew --prefix libomp)/include -I$(brew --prefix llvm)/include"
+cmake -H. -Bbuild -DBUILD_RETARGETABLE=ON && cmake --build build -- -j 8 > build.txt 2>&1
+```
+
 ### Installing
 
 After building, you can install `wfmash` using:

--- a/src/common/atomic_queue/atomic_queue.h
+++ b/src/common/atomic_queue/atomic_queue.h
@@ -393,13 +393,25 @@ class AtomicQueue2 : public AtomicQueueCommon<AtomicQueue2<T, SIZE, MINIMIZE_CON
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail % size_);
-        return Base::template do_pop_any(states_[index], elements_[index]);
+    #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+        return Base::template do_pop_any<T>(this->states_[index], this->elements_[index]);
+    #else
+        return Base::template do_pop_any<T>(this->states_[index], this->elements_[index]);
+    #endif
+        // return Base::template do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head % size_);
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+    #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+        // Base::template do_push_any<U>(std::forward<U>(element), this->states_[this->index_], this->elements_[this->index_]); // Explicitly specify U
+        Base::template do_push_any<U>(std::forward<U>(element), this->states_[index], this->elements_[index]);
+    #else
+        // Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::template do_push_any<U>(std::forward<U>(element), this->states_[index], this->elements_[index]);
+    #endif
+        // Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
 public:
@@ -521,13 +533,27 @@ class AtomicQueueB2 : public AtomicQueueCommon<AtomicQueueB2<T, A, MAXIMIZE_THRO
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail & (size_ - 1));
-        return Base::template do_pop_any(states_[index], elements_[index]);
+    #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+        // return Base::template do_pop_any<T>(this->states_[this->index_], element); // Explicitly specify T
+        return Base::template do_pop_any<T>(this->states_[index], this->elements_[index]);
+    #else
+        // return Base::template do_pop_any(this->states_[this->index_], element);
+        return Base::template do_pop_any<T>(this->states_[index], this->elements_[index]);
+    #endif
+        // return Base::template do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head & (size_ - 1));
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+    #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+        // Base::template do_push_any<U>(std::forward<U>(element), this->states_[this->index_], this->elements_[this->index_]); // Explicitly specify U
+        Base::template do_push_any<U>(std::forward<U>(element), this->states_[index], this->elements_[index]);
+    #else
+        // Base::template do_push_any(std::forward<U>(element), this->states_[this->index_], this->elements_[this->index_]);
+        Base::template do_push_any<U>(std::forward<U>(element), this->states_[index], this->elements_[index]);
+    #endif
+        // Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
 public:

--- a/src/common/wflign/CMakeLists.txt
+++ b/src/common/wflign/CMakeLists.txt
@@ -81,3 +81,16 @@ set_target_properties(wflign PROPERTIES OUTPUT_NAME wflign)
 
 target_include_directories(wflign_static PRIVATE ${wflign_INCLUDE})
 target_include_directories(wflign PRIVATE ${wflign_INCLUDE})
+
+# Conditionally link wflign libraries against wfa2cpp only on Apple Silicon
+if (APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64"))
+    message(STATUS "Apple Silicon detected: Linking wflign and wflign_static against wfa2cpp.")
+    target_link_libraries(wflign_static PRIVATE wfa2cpp)
+    target_link_libraries(wflign PRIVATE wfa2cpp)
+else()
+    message(STATUS "Not Apple Silicon (or CMAKE_SYSTEM_PROCESSOR not arm64/aarch64): wflign linking to wfa2cpp is SKIPPED based on conditional logic.")
+    # If there was specific linking for other platforms that was working before,
+    # it would go here. Otherwise, leaving this empty means no explicit link to wfa2cpp
+    # is added for non-Apple Silicon builds, matching the original state of this file
+    # before we added the target_link_libraries calls.
+endif()

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -6,6 +6,8 @@
 #include "rkmh.hpp"
 #include "wflign_patch.hpp"
 #include "wflign_git_version.hpp"
+#include <algorithm> // For std::max
+#include <cstdint>   // For int64_t
 
 namespace wflign {
 
@@ -1260,7 +1262,14 @@ void write_merged_alignment(
             // Head patching
             if (query_start > 0 || target_start > 0) {
                 // Calculate how far we need to shift to cover the query, and how far we can safely shift
-                int64_t needed_shift = std::max(0L, static_cast<int64_t>(query_start) - static_cast<int64_t>(target_start));
+                #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+                    // Apple Silicon (ARM64) specific fix
+                    int64_t needed_shift = std::max(0LL, static_cast<int64_t>(query_start) - static_cast<int64_t>(target_start));
+                #else
+                    // Original code for other platforms
+                    int64_t needed_shift = std::max(0L, static_cast<int64_t>(query_start) - static_cast<int64_t>(target_start));
+                #endif
+                // int64_t needed_shift = std::max(0L, static_cast<int64_t>(query_start) - static_cast<int64_t>(target_start));
                 int64_t max_safe_shift = std::min(
                     static_cast<int64_t>(wflign_max_len_minor),
                     static_cast<int64_t>(target_offset)
@@ -1650,7 +1659,14 @@ void write_merged_alignment(
             // Tail patching
             if (query_pos < query_length || target_pos < target_length) {
                 // Calculate how much additional target sequence we need
-                int64_t needed_extension = std::max(0L, static_cast<int64_t>(query_length - query_pos) - static_cast<int64_t>(target_length - target_pos));
+                #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+                    // Apple Silicon (ARM64) specific fix
+                    int64_t needed_extension = std::max(0LL, static_cast<int64_t>(query_length - query_pos) - static_cast<int64_t>(target_length - target_pos));
+                #else
+                    // Original code for other platforms
+                    int64_t needed_extension = std::max(0L, static_cast<int64_t>(query_length - query_pos) - static_cast<int64_t>(target_length - target_pos));
+                #endif
+                // int64_t needed_extension = std::max(0L, static_cast<int64_t>(query_length - query_pos) - static_cast<int64_t>(target_length - target_pos));
     
                 // Calculate how much we can safely extend
                 int64_t max_safe_extension = std::min(

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -175,7 +175,14 @@ namespace skch
       void build(bool compute_seeds, const std::vector<std::string>& target_names = {}, 
                 std::shared_ptr<progress_meter::ProgressMeter> external_progress = nullptr)
       {
-        std::chrono::time_point<std::chrono::system_clock> t0 = skch::Time::now();
+        #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+            // Patched for Apple Silicon:
+            std::chrono::time_point<std::chrono::steady_clock> t0 = skch::Time::now();
+        #else
+            // Original code for other platforms:
+            std::chrono::time_point<std::chrono::system_clock> t0 = skch::Time::now();
+        #endif
+        // std::chrono::time_point<std::chrono::system_clock> t0 = skch::Time::now();
 
         if (compute_seeds) {
           // Calculate total sequence length from id manager
@@ -393,7 +400,16 @@ namespace skch
 
           uint64_t freq_cutoff;
           if (param.max_kmer_freq <= 1.0) {
+            #if defined(__APPLE__) && defined(__MACH__) && (defined(__arm64__) || defined(__aarch64__))
+              // Patched for Apple Silicon (change 1UL to 1ULL to match uint64_t, or use a cast):
+              freq_cutoff = std::max(1ULL, (uint64_t)(total_windows * param.max_kmer_freq));
+              // Alternative patch for Apple Silicon, using static_cast for clarity:
+              // freq_cutoff = std::max(static_cast<uint64_t>(1), (uint64_t)(total_windows * param.max_kmer_freq));
+            #else
+              // Original code for other platforms:
               freq_cutoff = std::max(1UL, (uint64_t)(total_windows * param.max_kmer_freq));
+            #endif
+            //   freq_cutoff = std::max(1UL, (uint64_t)(total_windows * param.max_kmer_freq));
           } else {
               freq_cutoff = (uint64_t)param.max_kmer_freq;
           }


### PR DESCRIPTION
Added checks for apple silicon. Achieved successful build and install on M1 Pro macbook.

We should double check the CMakeLists to ensure that they still build and run correctly on x86 machines.