### PR TITLE
Lower density minmers

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -79,7 +79,7 @@ void parse_args(int argc,
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
     args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering (higher -p may use more) [3]", {'H', "l1-hits"});
+    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [3]", {'H', "l1-hits"});
     args::ValueFlag<double> max_kmer_freq(mapping_opts, "FLOAT", "filter minimizers occurring > FLOAT of total [0.0002]", {'F', "filter-freq"});
     args::ValueFlag<double> map_sparsification(mapping_opts, "FLOAT", "keep this fraction of mappings [1.0]", {'x', "sparsify"});
 

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -531,7 +531,7 @@ void parse_args(int argc,
             map_parameters.sketchSize = ss;
         } else {
             const double md = 1 - map_parameters.percentageIdentity;
-            double dens = 0.02 * (1 + (md / 0.05));
+            double dens = 0.01 * (1 + (md / 0.1));
             map_parameters.sketchSize = dens * (map_parameters.segLength - map_parameters.kmerSize);
         }
     }

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -79,7 +79,7 @@ void parse_args(int argc,
     args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
     args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
     args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [auto]", {'H', "l1-hits"});
+    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering (higher -p may use more) [3]", {'H', "l1-hits"});
     args::ValueFlag<double> max_kmer_freq(mapping_opts, "FLOAT", "filter minimizers occurring > FLOAT of total [0.0002]", {'F', "filter-freq"});
     args::ValueFlag<double> map_sparsification(mapping_opts, "FLOAT", "keep this fraction of mappings [1.0]", {'x', "sparsify"});
 
@@ -616,7 +616,7 @@ void parse_args(int argc,
     if (min_hits) {
         map_parameters.minimum_hits = args::get(min_hits);
     } else {
-        map_parameters.minimum_hits = -1; // auto
+        map_parameters.minimum_hits = 3; // default minimum
     }
 
     if (max_kmer_freq) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -246,7 +246,7 @@ namespace skch
             p.query_list,
             p.target_list)),
         cached_segment_length(p.segLength),
-        cached_minimum_hits(p.minimum_hits > 0 ? p.minimum_hits : Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval))
+        cached_minimum_hits(std::max(p.minimum_hits, Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval)))
           {
               // Initialize sequence names right after creating idManager
               // Important: Apply any prefix filters here to ensure consistent query/target list
@@ -1611,11 +1611,9 @@ namespace skch
 
           //3. Compute L1 windows
           // Always respect the minimum hits parameter if set
-          int minimumHits = param.minimum_hits > 0 ? 
-              param.minimum_hits : 
-              (Q.len == cached_segment_length ? 
-                  cached_minimum_hits : 
-                  Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval));
+          int minimumHits = (Q.len == cached_segment_length) ?
+              cached_minimum_hits :
+              std::max(param.minimum_hits, Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval));
 
           // For each "group"
           auto ip_begin = intervalPoints.begin();


### PR DESCRIPTION
This reduces the minmer sketch density, which was set extremely high in previous work on improving low-ANI performance of mashmap3.5. We expect this to reduce runtime and memory for high divergence cases. We also set a default L1 hit filter of 3, which can be set higher when we are working at a higher -p setting.