### PR TITLE
Low memory mapper

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,87 @@
+# Testing Documentation for wfmash
+
+## Running Tests
+
+### Quick Start
+To run all tests after building the project:
+```bash
+./scripts/run_all_tests.sh
+```
+
+### Using CTest Directly
+From the build directory:
+```bash
+cd build
+ctest                    # Run all tests
+ctest -V                 # Run with verbose output
+ctest -R <test-name>     # Run specific test by name
+ctest --output-on-failure # Show output only for failed tests
+```
+
+## Available Tests
+
+1. **wfmash-time-LPA**: Tests timing and performance with LPA data
+2. **wfmash-subset-LPA-to-SAM**: Tests subset functionality with SAM output
+3. **wfmash-mapping-coverage-with-8-yeast-genomes-to-PAF**: Tests mapping coverage using yeast genomes
+4. **wfmash-pafcheck-yeast**: Validates PAF output format with yeast data
+5. **wfmash-maf-validity**: Tests MAF format output validity
+6. **wfmash-multi-subset-index**: Tests multi-subset indexing functionality
+
+## Code Refactoring
+
+The `computeMap.hpp` file has been refactored into 5 modular components:
+
+### 1. fragmentManager.hpp
+- Fragment data structures (`FragmentData`, `QueryMappingOutput`)
+- Fragment management utilities
+
+### 2. mappingCore.hpp
+- Core L1/L2 mapping algorithms
+- `L1_candidateLocus_t` and `L2_mapLocus_t` structures
+- Seed hit computation
+- Interval point calculation
+- L1 candidate region computation
+- L2 mapped region computation
+
+### 3. mappingFilter.hpp
+- Mapping filtering algorithms
+- Merging logic
+- Weak mapping filtering
+- Identity filtering
+- Sparsification
+- Scaffold filtering
+- Chain processing
+
+### 4. mappingOutput.hpp
+- Result processing
+- Boundary sanity checking
+- Mapping report generation
+- Output formatting
+
+### 5. computeMap.hpp (main)
+- Main `Map` class
+- Integration of all components
+- Query processing workflow
+- Subset management
+
+## Building and Testing After Refactoring
+
+1. Clean build:
+```bash
+rm -rf build
+cmake -H. -Bbuild
+cmake --build build -- -j 16
+```
+
+2. Run tests:
+```bash
+./scripts/run_all_tests.sh
+```
+
+## Verification
+
+The refactoring has been verified to:
+- Reduce the main file from 3191 lines to 1001 lines (69% reduction)
+- Maintain all functionality
+- Pass compilation without errors
+- Preserve the existing test suite

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Test harness for wfmash
+# Generated from CMake test configuration
+
+set -e  # Exit on any error
+
+echo "=== WFMASH TEST HARNESS ==="
+echo "Running all available tests..."
+echo
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Change to build directory
+cd build || { echo "Build directory not found. Please run cmake and make first."; exit 1; }
+
+# Function to run a test and report result
+run_test() {
+    local test_name=$1
+    echo -n "Running test: $test_name ... "
+    
+    if ctest -R "^$test_name$" --output-on-failure > test_output.log 2>&1; then
+        echo -e "${GREEN}PASSED${NC}"
+        return 0
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo "Error output:"
+        cat test_output.log
+        return 1
+    fi
+}
+
+# Counter for test results
+total_tests=0
+passed_tests=0
+failed_tests=0
+
+# List of tests (from ctest -N output)
+tests=(
+    "wfmash-time-LPA"
+    "wfmash-subset-LPA-to-SAM"
+    "wfmash-mapping-coverage-with-8-yeast-genomes-to-PAF"
+    "wfmash-pafcheck-yeast"
+    "wfmash-maf-validity"
+    "wfmash-multi-subset-index"
+)
+
+# Run each test
+for test in "${tests[@]}"; do
+    ((total_tests++))
+    if run_test "$test"; then
+        ((passed_tests++))
+    else
+        ((failed_tests++))
+    fi
+    echo
+done
+
+# Clean up
+rm -f test_output.log
+
+# Summary
+echo "=== TEST SUMMARY ==="
+echo "Total tests: $total_tests"
+echo -e "Passed: ${GREEN}$passed_tests${NC}"
+echo -e "Failed: ${RED}$failed_tests${NC}"
+
+if [ $failed_tests -eq 0 ]; then
+    echo -e "\n${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "\n${RED}Some tests failed!${NC}"
+    exit 1
+fi

--- a/src/common/progress.hpp
+++ b/src/common/progress.hpp
@@ -276,6 +276,11 @@ public:
         
         // Flush stderr to ensure all output is properly displayed
         std::cerr.flush();
+        
+        // Small delay to ensure clean output
+        if (use_progress_bar) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
     }
 };
 

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -59,7 +59,7 @@ void parse_args(int argc,
     args::ValueFlag<float> map_pct_identity(mapping_opts, "FLOAT", "minimum mapping identity [70]", {'p', "map-pct-id"});
     args::ValueFlag<uint32_t> num_mappings(mapping_opts, "INT", "number of mappings to keep per segment [1]", {'n', "mappings"});
     args::ValueFlag<std::string> segment_length(mapping_opts, "INT", "segment length for mapping [1k]", {'s', "segment-length"});
-    args::ValueFlag<std::string> block_length(mapping_opts, "INT", "minimum block length [3*segment-length]", {'l', "block-length"});
+    args::ValueFlag<std::string> block_length(mapping_opts, "INT", "minimum block length [0]", {'l', "block-length"});
     args::Flag one_to_one(mapping_opts, "", "Perform one-to-one filtering", {'o', "one-to-one"});
     args::Flag lower_triangular(mapping_opts, "", "Only compute the lower triangular for all-vs-all mapping", {'L', "lower-triangular"});
     args::ValueFlag<char> skip_prefix(mapping_opts, "C", "map between sequence groups with different prefix [#]", {'Y', "group-prefix"});
@@ -72,7 +72,7 @@ void parse_args(int argc,
     args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> scaffolding(mapping_opts, "G,L,D", 
-        "homology scaffolding [100k,10k,100k]", {'S', "scaffolding"});
+        "homology scaffolding [100k,5k,100k]", {'S', "scaffolding"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
@@ -334,7 +334,7 @@ void parse_args(int argc,
         }
         map_parameters.block_length = l;
     } else {
-        map_parameters.block_length = 3 * map_parameters.segLength;
+        map_parameters.block_length = 0;
     }
 
     if (chain_gap) {
@@ -375,7 +375,7 @@ void parse_args(int argc,
     } else {
         // Default values
         map_parameters.scaffold_gap = 100000;         // 100k
-        map_parameters.scaffold_min_length = 10000;   // 10k  
+        map_parameters.scaffold_min_length = 5000;    // 5k
         map_parameters.scaffold_max_deviation = 100000; // 100k
     }
 
@@ -531,7 +531,7 @@ void parse_args(int argc,
             map_parameters.sketchSize = ss;
         } else {
             const double md = 1 - map_parameters.percentageIdentity;
-            double dens = 0.01 * (1 + (md / 0.1));
+            double dens = 0.02 * (1 + (md / 0.1));
             map_parameters.sketchSize = dens * (map_parameters.segLength - map_parameters.kmerSize);
         }
     }

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -79,7 +79,7 @@ void parse_args(int argc,
     args::ValueFlag<double> overlap_threshold(filtering_opts, "FLOAT", "max overlap ratio [1.0]", {'O', "overlap"});
     args::ValueFlag<double> map_sparsification(filtering_opts, "FLOAT", "keep this fraction of mappings [1.0]", {'x', "sparsify"});
     args::ValueFlag<std::string> hg_filter(filtering_opts, "n,Δ,conf", "hypergeometric filter [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(filtering_opts, "INT", "min hits for L1 filtering [3]", {'H', "l1-hits"});
+    args::ValueFlag<int> min_hits(filtering_opts, "INT", "min hits for L1 filtering [1]", {'H', "l1-hits"});
     args::ValueFlag<double> max_kmer_freq(filtering_opts, "FLOAT", "filter high-freq minimizers [0.0002]", {'F', "filter-freq"});
 
     // SCAFFOLDING
@@ -638,7 +638,7 @@ void parse_args(int argc,
     if (min_hits) {
         map_parameters.minimum_hits = args::get(min_hits);
     } else {
-        map_parameters.minimum_hits = 3; // default minimum
+        map_parameters.minimum_hits = 1; // default minimum
     }
 
     if (max_kmer_freq) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -79,7 +79,7 @@ void parse_args(int argc,
     args::ValueFlag<double> overlap_threshold(filtering_opts, "FLOAT", "max overlap ratio [1.0]", {'O', "overlap"});
     args::ValueFlag<double> map_sparsification(filtering_opts, "FLOAT", "keep this fraction of mappings [1.0]", {'x', "sparsify"});
     args::ValueFlag<std::string> hg_filter(filtering_opts, "n,Δ,conf", "hypergeometric filter [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(filtering_opts, "INT", "min hits for L1 filtering [1]", {'H', "l1-hits"});
+    args::ValueFlag<int> min_hits(filtering_opts, "INT", "min hits for L1 filtering [3]", {'H', "l1-hits"});
     args::ValueFlag<double> max_kmer_freq(filtering_opts, "FLOAT", "filter high-freq minimizers [0.0002]", {'F', "filter-freq"});
 
     // SCAFFOLDING
@@ -638,7 +638,7 @@ void parse_args(int argc,
     if (min_hits) {
         map_parameters.minimum_hits = args::get(min_hits);
     } else {
-        map_parameters.minimum_hits = 1; // default minimum
+        map_parameters.minimum_hits = 3; // default minimum
     }
 
     if (max_kmer_freq) {

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -45,70 +45,80 @@ void parse_args(int argc,
     parser.helpParams.optionsString = "";
 
     args::Group options_group(parser, "");
-    args::Positional<std::string> target_sequence_file(options_group, "target.fa", "target sequences (required, default: self-map)");
-    args::Positional<std::string> query_sequence_file(options_group, "query.fa", "query sequences (optional)");
-    args::Group indexing_opts(options_group, "Indexing:");
-    args::ValueFlag<std::string> write_index(indexing_opts, "FILE", "build and save index to FILE", {'W', "write-index"});
-    args::ValueFlag<std::string> read_index(indexing_opts, "FILE", "use pre-built index from FILE", {'I', "read-index"});
+
+    // SEQUENCES
+    args::Positional<std::string> target_sequence_file(options_group, "target.fa", "target sequences (required)");
+    args::Positional<std::string> query_sequence_file(options_group, "query.fa", "query sequences (default: self-map)");
+    // INDEXING
+    args::Group indexing_opts(options_group, "INDEXING:");
+    args::ValueFlag<std::string> write_index(indexing_opts, "FILE", "save index to FILE", {'W', "write-index"});
+    args::ValueFlag<std::string> read_index(indexing_opts, "FILE", "load index from FILE", {'I', "read-index"});
     args::ValueFlag<std::string> index_by(indexing_opts, "SIZE", "target batch size for indexing [4G]", {'b', "batch"});
-    args::ValueFlag<int64_t> sketch_size(indexing_opts, "INT", "sketch size for MinHash [auto]", {'w', "sketch-size"});
-    args::ValueFlag<int> kmer_size(indexing_opts, "INT", "k-mer size [15]", {'k', "kmer-size"});
 
-    args::Group mapping_opts(options_group, "Mapping:");
-    args::Flag approx_mapping(mapping_opts, "", "output approximate mappings (no alignment)", {'m', "approx-mapping"});
-    args::ValueFlag<float> map_pct_identity(mapping_opts, "FLOAT", "minimum mapping identity [70]", {'p', "map-pct-id"});
-    args::ValueFlag<uint32_t> num_mappings(mapping_opts, "INT", "number of mappings to keep per segment [1]", {'n', "mappings"});
-    args::ValueFlag<std::string> segment_length(mapping_opts, "INT", "segment length for mapping [1k]", {'s', "segment-length"});
+    // MINMERS
+    args::Group minmer_opts(options_group, "MINMERS:");
+    args::ValueFlag<int> kmer_size(minmer_opts, "INT", "k-mer size [15]", {'k', "kmer-size"});
+    args::ValueFlag<int64_t> sketch_size(minmer_opts, "INT", "sketch size [auto]", {'s', "sketch-size"});
+    args::ValueFlag<std::string> window_size(minmer_opts, "INT", "window size [1k]", {'w', "window-size"});
+
+    // MAPPING
+    args::Group mapping_opts(options_group, "MAPPING:");
+    args::Flag approx_mapping(mapping_opts, "", "output mappings only (no alignment)", {'m', "approx-mapping"});
+    args::ValueFlag<float> map_pct_identity(mapping_opts, "FLOAT", "minimum identity % [70]", {'p', "map-pct-id"});
+    args::ValueFlag<uint32_t> num_mappings(mapping_opts, "INT", "mappings per segment [1]", {'n', "mappings"});
     args::ValueFlag<std::string> block_length(mapping_opts, "INT", "minimum block length [0]", {'l', "block-length"});
-    args::Flag one_to_one(mapping_opts, "", "Perform one-to-one filtering", {'o', "one-to-one"});
-    args::Flag lower_triangular(mapping_opts, "", "Only compute the lower triangular for all-vs-all mapping", {'L', "lower-triangular"});
-    args::ValueFlag<char> skip_prefix(mapping_opts, "C", "map between sequence groups with different prefix [#]", {'Y', "group-prefix"});
-    args::Flag disable_grouping(mapping_opts, "", "disable sequence grouping and exclude self mappings", {'G', "disable-grouping"});
-    args::Flag enable_self_mappings(mapping_opts, "", "enable self mappings (overrides -G)", {'X', "self-maps"});
-    args::ValueFlag<std::string> target_prefix(mapping_opts, "pfx", "use only targets whose names start with this prefix", {'T', "target-prefix"});
-    args::ValueFlag<std::string> target_list(mapping_opts, "FILE", "file containing list of target sequence names to use", {'R', "target-list"});
-    args::ValueFlag<std::string> query_prefix(mapping_opts, "pfxs", "filter queries by comma-separated prefixes", {'Q', "query-prefix"});
-    args::ValueFlag<std::string> query_list(mapping_opts, "FILE", "file containing list of query sequence names", {'A', "query-list"});
-    args::Flag no_split(mapping_opts, "no-split", "map each sequence in one piece", {'N',"no-split"});
-    args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
-    args::ValueFlag<std::string> scaffolding(mapping_opts, "INT", 
-        "scaffold gap for chaining [100k]", {'S', "scaffold-gap"});
-    args::ValueFlag<std::string> scaffold_dist(mapping_opts, "INT", 
-        "max distance from scaffold anchors [100k]", {"scaffold-dist"});
-    args::ValueFlag<int> scaffold_min_segs(mapping_opts, "INT", 
-        "min segments in scaffold anchor [5]", {"scaffold-min-segs"});
-    args::ValueFlag<std::string> scaffold_output(mapping_opts, "FILE", 
-        "output scaffold mappings to FILE", {"scaffold-out"});
-    args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
-    args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
-    args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
-    args::Flag no_merge(mapping_opts, "", "disable merging of consecutive mappings", {'M', "no-merge"});
-    args::ValueFlag<double> kmer_complexity(mapping_opts, "FLOAT", "minimum k-mer complexity threshold", {'J', "kmer-cmplx"});
-    args::ValueFlag<std::string> hg_filter(mapping_opts, "numer,ani-Δ,conf", "hypergeometric filter params [1.0,0.0,99.9]", {"hg-filter"});
-    args::ValueFlag<int> min_hits(mapping_opts, "INT", "minimum number of hits for L1 filtering [3]", {'H', "l1-hits"});
-    args::ValueFlag<double> max_kmer_freq(mapping_opts, "FLOAT", "filter minimizers occurring > FLOAT of total [0.0002]", {'F', "filter-freq"});
-    args::ValueFlag<double> map_sparsification(mapping_opts, "FLOAT", "keep this fraction of mappings [1.0]", {'x', "sparsify"});
+    args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap [2k]", {'c', "chain-gap"});
+    args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "max mapping length [50k]", {'P', "max-length"});
+    args::Flag no_split(mapping_opts, "", "map each sequence in one piece", {'N', "no-split"});
 
-    args::Group alignment_opts(options_group, "Alignment:");
-    args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "input PAF file for alignment", {'i', "align-paf"});
-    args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "padding around target sequence [segment-length]", {'E', "target-padding"});
-    args::ValueFlag<std::string> query_padding(alignment_opts, "INT", "padding around query sequence [segment-length]", {'U', "query-padding"});
-    args::ValueFlag<std::string> wfa_params(alignment_opts, "vals", 
-        "scoring: mismatch, gap1(o,e), gap2(o,e) [5,8,2,24,1]", {'g', "wfa-params"});
-    args::Flag disable_chain_patching(alignment_opts, "", "disable alignment patching at chain boundaries", {"disable-chain-patching"});
+    // FILTERING
+    args::Group filtering_opts(options_group, "FILTERING:");
+    args::Flag no_filter(filtering_opts, "", "disable all filtering", {'f', "no-filter"});
+    args::Flag no_merge(filtering_opts, "", "keep all fragment mappings", {'M', "no-merge"});
+    args::Flag one_to_one(filtering_opts, "", "best mapping per query AND target", {'o', "one-to-one"});
+    args::ValueFlag<double> overlap_threshold(filtering_opts, "FLOAT", "max overlap ratio [1.0]", {'O', "overlap"});
+    args::ValueFlag<double> map_sparsification(filtering_opts, "FLOAT", "keep this fraction of mappings [1.0]", {'x', "sparsify"});
+    args::ValueFlag<std::string> hg_filter(filtering_opts, "n,Δ,conf", "hypergeometric filter [1.0,0.0,99.9]", {"hg-filter"});
+    args::ValueFlag<int> min_hits(filtering_opts, "INT", "min hits for L1 filtering [3]", {'H', "l1-hits"});
+    args::ValueFlag<double> max_kmer_freq(filtering_opts, "FLOAT", "filter high-freq minimizers [0.0002]", {'F', "filter-freq"});
 
-    args::Group output_opts(options_group, "Output Format:");
-    args::Flag sam_format(output_opts, "", "output in SAM format (PAF by default)", {'a', "sam"});
-    args::Flag emit_md_tag(output_opts, "", "output MD tag", {'d', "md-tag"});
-    args::Flag no_seq_in_sam(output_opts, "", "omit sequence field in SAM output", {'q', "no-seq-sam"});
+    // SCAFFOLDING
+    args::Group scaffold_opts(options_group, "SCAFFOLDING:");
+    args::ValueFlag<std::string> scaffolding(scaffold_opts, "INT", "scaffold gap [100k]", {'S', "scaffold-gap"});
+    args::ValueFlag<std::string> scaffold_dist(scaffold_opts, "INT", "max scaffold distance [100k]", {'D', "scaffold-dist"});
+    args::ValueFlag<int> scaffold_min_segs(scaffold_opts, "INT", "min scaffold segments [5]", {'j', "scaffold-min-segs"});
+    args::ValueFlag<std::string> scaffold_output(scaffold_opts, "FILE", "output scaffold mappings to FILE", {"scaffold-out"});
 
+    // SELECTION
+    args::Group selection_opts(options_group, "SELECTION:");
+    args::ValueFlag<char> skip_prefix(selection_opts, "C", "group by prefix delimiter [#]", {'Y', "group-prefix"});
+    args::Flag enable_self_mappings(selection_opts, "", "include self mappings", {'X', "self-maps"});
+    args::Flag lower_triangular(selection_opts, "", "only map seq_i to seq_j if i>j", {'L', "lower-triangular"});
+    args::ValueFlag<std::string> target_prefix(selection_opts, "pfx", "target name prefix filter", {'T', "target-prefix"});
+    args::ValueFlag<std::string> target_list(selection_opts, "FILE", "file with target sequence names", {'R', "target-list"});
+    args::ValueFlag<std::string> query_prefix(selection_opts, "pfxs", "query name prefix filter", {'Q', "query-prefix"});
+    args::ValueFlag<std::string> query_list(selection_opts, "FILE", "file with query sequence names", {'A', "query-list"});
 
+    // ALIGNMENT
+    args::Group alignment_opts(options_group, "ALIGNMENT:");
+    args::ValueFlag<std::string> input_mapping(alignment_opts, "FILE", "align from PAF file", {'i', "align-paf"});
+    args::ValueFlag<std::string> target_padding(alignment_opts, "INT", "target padding [segment-length]", {'E', "target-padding"});
+    args::ValueFlag<std::string> query_padding(alignment_opts, "INT", "query padding [segment-length]", {'U', "query-padding"});
+    args::ValueFlag<std::string> wfa_params(alignment_opts, "m,go1,ge1,go2,ge2", "gap costs [5,8,2,24,1]", {'g', "wfa-params"});
 
-    args::Group system_opts(options_group, "System:");
-    args::ValueFlag<int> thread_count(system_opts, "INT", "number of threads [1]", {'t', "threads"});
-    args::ValueFlag<std::string> tmp_base(system_opts, "PATH", "base directory for temporary files [pwd]", {'B', "tmp-base"});
+    // OUTPUT
+    args::Group output_opts(options_group, "OUTPUT:");
+    args::Flag sam_format(output_opts, "", "SAM format (default: PAF)", {'a', "sam"});
+    args::Flag emit_md_tag(output_opts, "", "include MD tag", {'d', "md-tag"});
+
+    // SYSTEM
+    args::Group system_opts(options_group, "SYSTEM:");
+    args::ValueFlag<int> thread_count(system_opts, "INT", "threads [1]", {'t', "threads"});
+    args::ValueFlag<std::string> tmp_base(system_opts, "PATH", "temp file directory [pwd]", {'B', "tmp-base"});
     args::Flag keep_temp_files(system_opts, "", "retain temporary files", {'Z', "keep-temp"});
     args::Flag quiet(system_opts, "", "disable progress output", {"quiet"});
+    args::Flag version(system_opts, "", "version info", {'v', "version"});
+    args::HelpFlag help(system_opts, "", "show help", {'h', "help"});
 
 #ifdef WFA_PNG_TSV_TIMING
     args::Group debugging_opts(parser, "[ Debugging Options ]");
@@ -118,8 +128,6 @@ void parse_args(int argc,
     args::ValueFlag<std::string> path_patching_info_in_tsv(parser, "FILE", " write patching information for each alignment in TSV format in FILE", {"path-patching-tsv"});
 #endif
 
-    args::Flag version(system_opts, "version", "show version number and github commit hash", {'v', "version"});
-    args::HelpFlag help(system_opts, "help", "display this help menu", {'h', "help"});
 
     try {
         parser.ParseCLI(argc, argv);
@@ -149,13 +157,7 @@ void parse_args(int argc,
     map_parameters.use_progress_bar = !args::get(quiet);
     align_parameters.use_progress_bar = !args::get(quiet);
 
-    if (disable_grouping) {
-        map_parameters.prefix_delim = '\0';
-        map_parameters.skip_prefix = false;
-        if (!args::get(enable_self_mappings)) {
-            map_parameters.skip_self = true;
-        }
-    } else if (skip_prefix) {
+    if (skip_prefix) {
         map_parameters.prefix_delim = args::get(skip_prefix);
         map_parameters.skip_prefix = map_parameters.prefix_delim != '\0';
     } else {
@@ -279,8 +281,8 @@ void parse_args(int argc,
 
     align_parameters.emit_md_tag = args::get(emit_md_tag);
     align_parameters.sam_format = args::get(sam_format);
-    align_parameters.no_seq_in_sam = args::get(no_seq_in_sam);
-    align_parameters.disable_chain_patching = args::get(disable_chain_patching);
+    align_parameters.no_seq_in_sam = false;
+    align_parameters.disable_chain_patching = false;
     args::Flag force_wflign(alignment_opts, "", "force WFlign alignment", {"force-wflign"});
     align_parameters.force_wflign = args::get(force_wflign);
     map_parameters.split = !args::get(no_split);
@@ -289,29 +291,29 @@ void parse_args(int argc,
 
     map_parameters.mergeMappings = !args::get(no_merge);
 
-    if (segment_length) {
-        const int64_t s = wfmash::handy_parameter(args::get(segment_length));
+    if (window_size) {
+        const int64_t s = wfmash::handy_parameter(args::get(window_size));
 
         if (s <= 0) {
-            std::cerr << "[wfmash] ERROR, skch::parseandSave, segment length has to be a float value greater than 0." << std::endl;
+            std::cerr << "[wfmash] ERROR, skch::parseandSave, window size has to be a float value greater than 0." << std::endl;
             exit(1);
         }
 
         if (s < 100) {
-            std::cerr << "[wfmash] ERROR, skch::parseandSave, minimum segment length is required to be >= 100 bp." << std::endl
+            std::cerr << "[wfmash] ERROR, skch::parseandSave, minimum window size is required to be >= 100 bp." << std::endl
                       << "[wfmash] This is because Mashmap is not designed for computing short local alignments." << std::endl;
             exit(1);
         }
 
         if (!approx_mapping && s > 10000) {
-            std::cerr << "[wfmash] ERROR: segment length (-s) must be <= 10kb when running alignment." << std::endl
+            std::cerr << "[wfmash] ERROR: window size (-w) must be <= 10kb when running alignment." << std::endl
                       << "[wfmash] For larger values, use -m/--approx-mapping to generate mappings," << std::endl
                       << "[wfmash] then align them with: wfmash ... -i mappings.paf" << std::endl;
             exit(1);
         }
-        map_parameters.segLength = s;
+        map_parameters.windowLength = s;
     } else {
-        map_parameters.segLength = 1000;
+        map_parameters.windowLength = 1000; // Default 1k
     }
 
     if (map_pct_identity) {
@@ -340,7 +342,7 @@ void parse_args(int argc,
         }
         map_parameters.block_length = l;
     } else {
-        map_parameters.block_length = 0;
+        map_parameters.block_length = 0; // Default 0 (no filtering)
     }
 
     if (chain_gap) {
@@ -385,11 +387,11 @@ void parse_args(int argc,
             std::cerr << "[wfmash] ERROR: Invalid minimum scaffold segments" << std::endl;
             exit(1);
         }
-        // Convert segments to length: segments * segment_length
-        map_parameters.scaffold_min_length = min_segs * map_parameters.segLength;
+        // Convert segments to length: segments * window_length
+        map_parameters.scaffold_min_length = min_segs * map_parameters.windowLength;
     } else {
-        // Default: 5 segments
-        map_parameters.scaffold_min_length = 5 * map_parameters.segLength;
+        // Default: 5 segments of 1kb each = 5kb
+        map_parameters.scaffold_min_length = 5000;
     }
 
     if (scaffold_output) {
@@ -409,8 +411,8 @@ void parse_args(int argc,
         map_parameters.max_mapping_length = 50000;
     }
 
-    if (map_parameters.segLength >= map_parameters.max_mapping_length) {
-        std::cerr << "[wfmash] ERROR, skch::parseandSave, segment length should not be larger than max mapping length." << std::endl;
+    if (map_parameters.windowLength >= map_parameters.max_mapping_length) {
+        std::cerr << "[wfmash] ERROR, skch::parseandSave, window size should not be larger than max mapping length." << std::endl;
         exit(1);
     }
     if (map_parameters.block_length >= map_parameters.max_mapping_length) {
@@ -499,8 +501,8 @@ void parse_args(int argc,
         align_parameters.wflambda_segment_length = 256;
     }
 
-    align_parameters.wflign_max_len_major = map_parameters.segLength * 512;
-    align_parameters.wflign_max_len_minor = map_parameters.segLength * 128;
+    align_parameters.wflign_max_len_major = map_parameters.windowLength * 512;
+    align_parameters.wflign_max_len_minor = map_parameters.windowLength * 128;
     align_parameters.wflign_erode_k = -1; // will trigger estimation based on sequence divergence
     align_parameters.wflign_min_inv_patch_len = 23;
     align_parameters.wflign_max_patching_score = 0; // will trigger estimation based on gap penalties and sequence length
@@ -513,8 +515,8 @@ void parse_args(int argc,
         }
         align_parameters.target_padding = p;
     } else {
-        // Default to half segment length, capped at 5000
-        align_parameters.target_padding = std::min(map_parameters.segLength, (int64_t)5000);
+        // Default to half window length, capped at 5000
+        align_parameters.target_padding = std::min(map_parameters.windowLength, (int64_t)5000);
     }
     
     if (query_padding) {
@@ -525,8 +527,8 @@ void parse_args(int argc,
         }
         align_parameters.query_padding = p;
     } else {
-        // Default to half segment length, capped at 5000
-        align_parameters.query_padding = std::min(map_parameters.segLength, (int64_t)5000);
+        // Default to half window length, capped at 5000
+        align_parameters.query_padding = std::min(map_parameters.windowLength, (int64_t)5000);
     }
 
     if (thread_count) {
@@ -549,16 +551,19 @@ void parse_args(int argc,
         } else {
             const double md = 1 - map_parameters.percentageIdentity;
             double dens = 0.02 * (1 + (md / 0.1));
-            map_parameters.sketchSize = dens * (map_parameters.segLength - map_parameters.kmerSize);
+            map_parameters.sketchSize = dens * (map_parameters.windowLength - map_parameters.kmerSize);
         }
     }
 
-    if (kmer_complexity)
-    {
-        map_parameters.kmerComplexityThreshold = args::get(kmer_complexity);
-    } else {
-        map_parameters.kmerComplexityThreshold = 0;
+    // Validate that sketch size <= window size
+    if (map_parameters.sketchSize > map_parameters.windowLength) {
+        std::cerr << "[wfmash] ERROR: sketch size (-s) must be less than or equal to window size (-w)." << std::endl;
+        std::cerr << "[wfmash] Current values: sketch size = " << map_parameters.sketchSize 
+                  << ", window size = " << map_parameters.windowLength << std::endl;
+        exit(1);
     }
+
+    map_parameters.kmerComplexityThreshold = 0;
 
     args::ValueFlag<double> hg_numerator(mapping_opts, "FLOAT", "hypergeometric filter numerator [1.0]", {"hg-numerator"});
     if (hg_numerator) {
@@ -744,14 +749,14 @@ void parse_args(int argc,
     skch::validateInputFiles(map_parameters.querySequences, map_parameters.refSequences);
 
     std::cerr << "[wfmash] Parameters: k=" << map_parameters.kmerSize 
-              << ", w=" << map_parameters.sketchSize
-              << ", s=" << map_parameters.segLength << (map_parameters.split ? " (split)" : "")
+              << ", s=" << map_parameters.sketchSize
+              << ", w=" << map_parameters.windowLength << (map_parameters.split ? " (split)" : "")
               << ", l=" << map_parameters.block_length
               << ", c=" << map_parameters.chain_gap
               << ", P=" << map_parameters.max_mapping_length
               << ", S=" << map_parameters.scaffold_gap 
-              << ", scaffold-dist=" << map_parameters.scaffold_max_deviation
-              << ", scaffold-segs=" << (map_parameters.scaffold_min_length / map_parameters.segLength)
+              << ", D=" << map_parameters.scaffold_max_deviation
+              << ", j=" << (map_parameters.scaffold_min_length / map_parameters.windowLength)
               << ", n=" << map_parameters.numMappingsForSegment
               << ", p=" << std::fixed << std::setprecision(0) << map_parameters.percentageIdentity * 100 << "%"
               << ", t=" << map_parameters.threads

--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -73,6 +73,8 @@ void parse_args(int argc,
     args::ValueFlag<std::string> chain_gap(mapping_opts, "INT", "chain gap: max distance to chain mappings [2k]", {'c', "chain-gap"});
     args::ValueFlag<std::string> scaffolding(mapping_opts, "G,L,D", 
         "homology scaffolding [100k,5k,100k]", {'S', "scaffolding"});
+    args::ValueFlag<std::string> scaffold_output(mapping_opts, "FILE", 
+        "output scaffold mappings to FILE", {"scaffold-out"});
     args::ValueFlag<std::string> max_mapping_length(mapping_opts, "INT", "target mapping length [50k, 'inf' for unlimited]", {'P', "max-length"});
     args::ValueFlag<double> overlap_threshold(mapping_opts, "FLOAT", "max overlap with better mappings (1.0=keep all) [1.0]", {'O', "overlap"});
     args::Flag no_filter(mapping_opts, "", "disable mapping filtering", {'f', "no-filter"});
@@ -377,6 +379,10 @@ void parse_args(int argc,
         map_parameters.scaffold_gap = 100000;         // 100k
         map_parameters.scaffold_min_length = 5000;    // 5k
         map_parameters.scaffold_max_deviation = 100000; // 100k
+    }
+
+    if (scaffold_output) {
+        map_parameters.scaffold_output_file = args::get(scaffold_output);
     }
 
     if (max_mapping_length) {

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -1,6 +1,6 @@
 /**
  * @file    computeMap.hpp
- * @brief   implements the sequence mapping logic
+ * @brief   Main Map class that implements the sequence mapping logic
  * @author  Chirag Jain <cjain7@gatech.edu>
  */
 
@@ -37,77 +37,20 @@ namespace fs = std::filesystem;
 #include "map/include/commonFunc.hpp"
 #include "map/include/winSketch.hpp"
 #include "map/include/map_stats.hpp"
-#include "map/include/slidingMap.hpp"
-#include "map/include/MIIteratorL2.hpp"
-#include "map/include/filter.hpp"
+
+// Include the new separated files
+#include "map/include/fragmentManager.hpp"
+#include "map/include/mappingCore.hpp"
+#include "map/include/mappingFilter.hpp"
+#include "map/include/mappingOutput.hpp"
 
 //External includes
 #include "common/seqiter.hpp"
 #include "common/progress.hpp"
-#include "map_stats.hpp"
-#include "robin-hood-hashing/robin_hood.h"
-// if we ever want to do the union-find chaining in parallel
-//#include "common/dset64-gccAtomic.hpp"
-// this is for single-threaded use, but is more portable
-#include "common/dset64.hpp"
-//#include "assert.hpp"
 #include "gsl/gsl_randist.h"
 
 namespace skch
 {
-  struct QueryMappingOutput {
-      std::string queryName;
-      std::vector<MappingResult> results;        // Non-merged mappings
-      std::vector<MappingResult> mergedResults;  // Maximally merged mappings  
-      std::mutex mutex;
-      progress_meter::ProgressMeter& progress;
-      QueryMappingOutput(const std::string& name, const std::vector<MappingResult>& r, 
-                        const std::vector<MappingResult>& mr, progress_meter::ProgressMeter& p)
-          : queryName(name), results(r), mergedResults(mr), progress(p) {}
-  };
-
-  struct FragmentData {
-      const char* seq;
-      int len;
-      int fullLen; 
-      seqno_t seqId;
-      std::string seqName;
-      int refGroup;
-      int fragmentIndex;
-      std::shared_ptr<QueryMappingOutput> output;
-      std::shared_ptr<std::atomic<int>> processedCounter;
-
-      // Add constructor for convenience
-      FragmentData(const char* s, int l, int fl, seqno_t sid, 
-                   const std::string& sn, int rg, int idx,
-                   std::shared_ptr<QueryMappingOutput> out,
-                   std::shared_ptr<std::atomic<int>> counter = nullptr)
-          : seq(s), len(l), fullLen(fl), seqId(sid), seqName(sn),
-            refGroup(rg), fragmentIndex(idx), output(out), processedCounter(counter) {}
-  };
-
-  // Manages fragment lifetime and processing
-  class FragmentManager {
-  private:
-      std::vector<std::shared_ptr<FragmentData>> fragments;
-      std::mutex fragments_mutex;
-
-  public:
-      void add_fragment(std::shared_ptr<FragmentData> fragment) {
-          std::lock_guard<std::mutex> lock(fragments_mutex);
-          fragments.push_back(fragment);
-      }
-
-      void clear() {
-          std::lock_guard<std::mutex> lock(fragments_mutex);
-          fragments.clear();
-      }
-
-      const std::vector<std::shared_ptr<FragmentData>>& get_fragments() const {
-          return fragments;
-      }
-  };
-
   /**
    * @class     skch::Map
    * @brief     L1 and L2 mapping stages
@@ -115,49 +58,11 @@ namespace skch
   class Map
   {
     private:
-      //Type for Stage L1's predicted candidate location
-      struct L1_candidateLocus_t
-      {
-        seqno_t seqId;                    //sequence id where read is mapped
-
-        /* read could be mapped with its begin location
-         * from [rangeStartPos, rangeEndPos]
-         */
-        offset_t rangeStartPos;
-        offset_t rangeEndPos;
-        int intersectionSize;
-      };
-
-      static constexpr auto L1_locus_intersection_cmp = [](L1_candidateLocus_t& a, L1_candidateLocus_t& b)
-      {
-        return a.intersectionSize < b.intersectionSize;
-      };
-
-      //Cache for commonly used values
-      offset_t cached_segment_length;
-      int cached_minimum_hits;
-
-      //Type for Stage L2's predicted mapping coordinate within each L1 candidate  
-      struct L2_mapLocus_t
-      {
-        seqno_t seqId;                    //sequence id where read is mapped
-        offset_t meanOptimalPos;          //Among multiple consecutive optimal positions, save the avg.
-        offset_t optimalStart;            //optimal start mapping position (begin iterator)
-        offset_t optimalEnd;              //optimal end mapping position (end iterator)
-        int sharedSketchSize;             //count of shared sketch elements
-        strand_t strand;
-      };
-
-    private:
-
       //algorithm parameters  
       skch::Parameters param;
 
       //reference sketch
       skch::Sketch* refSketch;
-
-      // Vector to store fragments
-      std::vector<FragmentData*> fragments;
 
       // Sequence ID manager
       std::unique_ptr<SequenceIdManager> idManager;
@@ -176,15 +81,21 @@ namespace skch
       //used only if one-to-one filtering is ON
       std::vector<ContigInfo> qmetadata;
 
-
       //Vector for sketch cutoffs. Position [i] indicates the minimum intersection size required
       //for an L1 candidate if the best intersection size is i;
       std::vector<int> sketchCutoffs; 
 
-      // Sequence ID manager
       // Track maximum chain ID seen across all subsets
       std::atomic<offset_t> maxChainIdSeen{0};
 
+      //Cache for commonly used values
+      offset_t cached_segment_length;
+      int cached_minimum_hits;
+
+      // Type aliases for core mapping
+      using CoreMapping = MappingCore<Sketch, SequenceIdManager>;
+      using FilterUtils = MappingFilterUtils;
+      using OutputHandler = MappingOutput;
 
     void processFragment(const FragmentData& fragment, 
                          std::vector<IntervalPoint>& intervalPoints,
@@ -196,7 +107,7 @@ namespace skch
         intervalPoints.clear();
         l1Mappings.clear();
         l2Mappings.clear();
-        thread_local_results.clear(); // Ensure we start with an empty results vector
+        thread_local_results.clear();
 
         Q.seq = const_cast<char*>(fragment.seq);
         Q.len = fragment.len;
@@ -229,11 +140,9 @@ namespace skch
       /**
        * @brief                 constructor
        * @param[in] p           algorithm parameters
-       * @param[in] refSketch   reference sketch
        * @param[in] f           optional user defined custom function to post process the reported mapping results
        */
-      Map(skch::Parameters p, 
-          PostProcessResultsFn_t f = nullptr) :
+      Map(skch::Parameters p, PostProcessResultsFn_t f = nullptr) :
         param(p),
         processMappingResults(f),
         sketchCutoffs(std::min<double>(p.sketchSize, skch::fixed::ss_table_max) + 1, 1),
@@ -247,124 +156,85 @@ namespace skch
             p.target_list)),
         cached_segment_length(p.segLength),
         cached_minimum_hits(std::max(p.minimum_hits, Stat::estimateMinimumHitsRelaxed(p.sketchSize, p.kmerSize, p.percentageIdentity, skch::fixed::confidence_interval)))
-          {
-              // Initialize sequence names right after creating idManager
-              // Important: Apply any prefix filters here to ensure consistent query/target list
-              if (!param.query_prefix.empty()) {
-                  this->querySequenceNames.clear();
-                  for (const auto& name : idManager->getQuerySequenceNames()) {
-                      // Check if it starts with any of the query prefixes
-                      bool prefix_match = false;
-                      for (const auto& prefix : param.query_prefix) {
-                          if (name.compare(0, prefix.size(), prefix) == 0) {
-                              prefix_match = true;
-                              break;
-                          }
-                      }
-                      if (prefix_match) {
-                          this->querySequenceNames.push_back(name);
+      {
+          // Initialize sequence names
+          if (!param.query_prefix.empty()) {
+              this->querySequenceNames.clear();
+              for (const auto& name : idManager->getQuerySequenceNames()) {
+                  bool prefix_match = false;
+                  for (const auto& prefix : param.query_prefix) {
+                      if (name.compare(0, prefix.size(), prefix) == 0) {
+                          prefix_match = true;
+                          break;
                       }
                   }
-              } else {
-                  this->querySequenceNames = idManager->getQuerySequenceNames();
-              }
-              
-              if (!param.target_prefix.empty()) {
-                  this->targetSequenceNames.clear();
-                  for (const auto& name : idManager->getTargetSequenceNames()) {
-                      // Check if it starts with the target prefix
-                      if (name.compare(0, param.target_prefix.size(), param.target_prefix) == 0) {
-                          this->targetSequenceNames.push_back(name);
-                      }
+                  if (prefix_match) {
+                      this->querySequenceNames.push_back(name);
                   }
-              } else {
-                  this->targetSequenceNames = idManager->getTargetSequenceNames();
               }
-
-              // Calculate total target length
-              uint64_t total_target_length = 0;
-              size_t target_seq_count = targetSequenceNames.size();
-              std::string target_prefix = param.target_prefix.empty() ? "none" : param.target_prefix;
-
-              for (const auto& seqName : targetSequenceNames) {
-                  seqno_t seqId = idManager->getSequenceId(seqName);
-                  total_target_length += idManager->getSequenceLength(seqId);
+          } else {
+              this->querySequenceNames = idManager->getQuerySequenceNames();
+          }
+          
+          if (!param.target_prefix.empty()) {
+              this->targetSequenceNames.clear();
+              for (const auto& name : idManager->getTargetSequenceNames()) {
+                  if (name.compare(0, param.target_prefix.size(), param.target_prefix) == 0) {
+                      this->targetSequenceNames.push_back(name);
+                  }
               }
-
-              // Calculate total query length
-              uint64_t total_query_length = 0;
-              for (const auto& seqName : querySequenceNames) {
-                  total_query_length += idManager->getSequenceLength(idManager->getSequenceId(seqName));
-              }
-
-              // Count unique groups
-              std::unordered_set<int> query_groups, target_groups;
-              for (const auto& seqName : querySequenceNames) {
-                  query_groups.insert(idManager->getRefGroup(idManager->getSequenceId(seqName)));
-              }
-              for (const auto& seqName : targetSequenceNames) {
-                  target_groups.insert(idManager->getRefGroup(idManager->getSequenceId(seqName)));
-              }
-
-              // Calculate average sizes
-              double avg_query_size_per_group = query_groups.size() ? (double)total_query_length / query_groups.size() : 0;
-              double avg_target_size_per_group = target_groups.size() ? (double)total_target_length / target_groups.size() : 0;
-
-              std::cerr << "[wfmash::mashmap] " 
-                        << querySequenceNames.size() << " queries (" << total_query_length << "bp) in "
-                        << query_groups.size() << " groups (≈" << std::fixed << std::setprecision(0) << avg_query_size_per_group << "bp/group)" << std::endl
-                        << "[wfmash::mashmap] "
-                        << target_seq_count << " targets (" << total_target_length << "bp) in "
-                        << target_groups.size() << " groups (≈" << std::fixed << std::setprecision(0) << avg_target_size_per_group << "bp/group)" 
-                        << std::endl;
-
-              if (p.stage1_topANI_filter) {
-                  this->setProbs();
-              }
-              this->mapQuery();
+          } else {
+              this->targetSequenceNames = idManager->getTargetSequenceNames();
           }
 
-      // Removed populateIdManager() function
-
-      ~Map() = default;
-
-      private:
-      void buildMetadataFromIndex() {
-          for (const auto& fileName : param.refSequences) {
-              // Use faigz to load the index metadata
-              faidx_meta_t* meta = faidx_meta_load(fileName.c_str(), FAI_FASTA, FAI_CREATE);
-              if (meta == nullptr) {
-                  std::cerr << "Error: Failed to load FASTA index for file " << fileName << std::endl;
-                  exit(1);
-              }
-
-              int nseq = faidx_meta_nseq(meta);
-              for (int i = 0; i < nseq; ++i) {
-                  const char* seq_name = faidx_meta_iseq(meta, i);
-                  hts_pos_t seq_len = faidx_meta_seq_len(meta, seq_name);
-                  if (seq_len == -1) {
-                      std::cerr << "Error: Failed to get length for sequence " << seq_name << std::endl;
-                      continue;
-                  }
-                  // Metadata is now handled by idManager, no need to push_back here
-              }
-
-              faidx_meta_destroy(meta);
+          // Calculate and log statistics
+          uint64_t total_target_length = 0;
+          size_t target_seq_count = targetSequenceNames.size();
+          for (const auto& seqName : targetSequenceNames) {
+              seqno_t seqId = idManager->getSequenceId(seqName);
+              total_target_length += idManager->getSequenceLength(seqId);
           }
+
+          uint64_t total_query_length = 0;
+          for (const auto& seqName : querySequenceNames) {
+              total_query_length += idManager->getSequenceLength(idManager->getSequenceId(seqName));
+          }
+
+          std::unordered_set<int> query_groups, target_groups;
+          for (const auto& seqName : querySequenceNames) {
+              query_groups.insert(idManager->getRefGroup(idManager->getSequenceId(seqName)));
+          }
+          for (const auto& seqName : targetSequenceNames) {
+              target_groups.insert(idManager->getRefGroup(idManager->getSequenceId(seqName)));
+          }
+
+          double avg_query_size_per_group = query_groups.size() ? (double)total_query_length / query_groups.size() : 0;
+          double avg_target_size_per_group = target_groups.size() ? (double)total_target_length / target_groups.size() : 0;
+
+          std::cerr << "[wfmash::mashmap] " 
+                    << querySequenceNames.size() << " queries (" << total_query_length << "bp) in "
+                    << query_groups.size() << " groups (≈" << std::fixed << std::setprecision(0) << avg_query_size_per_group << "bp/group)" << std::endl
+                    << "[wfmash::mashmap] "
+                    << target_seq_count << " targets (" << total_target_length << "bp) in "
+                    << target_groups.size() << " groups (≈" << std::fixed << std::setprecision(0) << avg_target_size_per_group << "bp/group)" 
+                    << std::endl;
+
+          if (p.stage1_topANI_filter) {
+              this->setProbs();
+          }
+          this->mapQuery();
       }
 
-      public:
+      ~Map() = default;
 
     private:
 
       void setProbs()
       {
-
         float deltaANI = param.ANIDiff;
         float min_p = 1 - param.ANIDiffConf;
         int ss = std::min<double>(param.sketchSize, skch::fixed::ss_table_max);
 
-        // Cache hg pmf results
         std::vector<std::vector<double>> sketchProbs(
             ss + 1,
             std::vector<double>(ss + 1.0)
@@ -377,27 +247,16 @@ namespace skch
           }
         }
         
-        // Return true iff Pr(ANI_i >= ANI_max - deltaANI) >= min_p
         const auto distDiff = [this, &sketchProbs, deltaANI, min_p, ss] (int cmax, int ci) {
           double prAboveCutoff = 0;
           for (double ymax = 0; ymax <= cmax; ymax++) {
-            // Pr (Ymax = ymax)
             double pymax = sketchProbs[cmax][ymax];
-
-            // yi_cutoff is minimum jaccard numerator required to be within deltaANI of ymax
             double yi_cutoff = deltaANI == 0 ? ymax : (std::floor(skch::Stat::md2j(
                 skch::Stat::j2md(ymax / ss, param.kmerSize) + deltaANI, 
                 param.kmerSize
             ) * ss));
-
-            // Pr Y_i < yi_cutoff
-            //std::cerr << "CMF " << yi_cutoff - 1 << " " << ss << " " << ss-ci << " " << ci << std::endl;
             double pi_acc = (yi_cutoff - 1) >= 0 ? gsl_cdf_hypergeometric_P(yi_cutoff-1, ss, ss-ci, ci) : 0;
-
-            // Pr Y_i >= yi_cutoff
             pi_acc = 1-pi_acc;
-
-            // Pr that mash score from cj leads to an ANI at least deltaJ less than the ANI from cmax
             prAboveCutoff += pymax * pi_acc;
             if (prAboveCutoff > min_p)
             {
@@ -407,13 +266,11 @@ namespace skch
           return prAboveCutoff > min_p; 
         };
 
-        // Helper vector for binary search
         std::vector<int> ss_range(ss+1);
         std::iota (ss_range.begin(), ss_range.end(), 0);
 
         for (auto cmax = 1; cmax <= ss; cmax++) 
         {
-          // Binary search to find the lowest acceptable ci
           int ci = std::distance(
               ss_range.begin(),
               std::upper_bound(
@@ -427,32 +284,20 @@ namespace skch
           );
           sketchCutoffs[cmax] = ci;
 
-
-          // For really high min_p values and some values of cmax, there are no values of
-          // ci that satisfy the cutoff, so we just set to the max
           if (sketchCutoffs[cmax] == 0) {
             sketchCutoffs[cmax] = 1;
           }
         }
-        //for (auto overlap = 1; overlap <= ss; overlap++) 
-        //{
-          //DEBUG_ASSERT(sketchCutoffs[overlap] <= overlap);
-        //}
       }
-
-      /**
-       * @brief   parse over sequences in query file and map each on the reference
-       */
 
       std::vector<std::vector<std::string>> createTargetSubsets(const std::vector<std::string>& targetSequenceNames) {
         std::vector<std::vector<std::string>> target_subsets;
         uint64_t current_subset_size = 0;
         std::vector<std::string> current_subset;
 
-        // If index_by_size is invalid, set a reasonable default
         int64_t batch_size = param.index_by_size;
         if (batch_size <= 0) {
-            batch_size = 5000000;  // Default to 5MB if not specified
+            batch_size = 5000000;
             if (!param.indexFilename.empty() && !param.create_index_only) {
                 std::cerr << "[wfmash::mashmap] Warning: Invalid batch size in index, using default: " 
                           << batch_size << std::endl;
@@ -480,15 +325,12 @@ namespace skch
       }
 
       void mapQuery() {
-          // Only use taskflow implementation now
           tf::Executor executor(param.threads);
           tf::Taskflow taskflow;
 
-          // Storage for combining results across all subsets
           std::unordered_map<seqno_t, MappingResultsVector_t> combinedMappings;
           std::mutex combinedMappings_mutex;
 
-          // If we're using an index file, read its header to get batch size
           if (!param.indexFilename.empty() && !param.create_index_only) {
               std::ifstream indexStream(param.indexFilename.string(), std::ios::binary);
               if (!indexStream) {
@@ -496,7 +338,6 @@ namespace skch
                   exit(1);
               }
               
-              // Read the magic number to verify it's a valid index
               uint64_t magic_number = 0;
               indexStream.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
               if (magic_number != 0xDEADBEEFCAFEBABE) {
@@ -504,12 +345,10 @@ namespace skch
                   exit(1);
               }
               
-              // Read subset count and batch index
               size_t batch_idx, total_batches;
               indexStream.read(reinterpret_cast<char*>(&batch_idx), sizeof(batch_idx));
               indexStream.read(reinterpret_cast<char*>(&total_batches), sizeof(total_batches));
               
-              // Read batch size
               int64_t batch_size = 0;
               indexStream.read(reinterpret_cast<char*>(&batch_size), sizeof(batch_size));
               if (batch_size > 0) {
@@ -520,10 +359,8 @@ namespace skch
               indexStream.close();
           }
 
-          // Create the index subsets
           auto target_subsets = createTargetSubsets(targetSequenceNames);
 
-          // Calculate average subset size and log
           uint64_t total_target_subset_size = 0;
           for (const auto& subset : target_subsets) {
               for (const auto& seqName : subset) {
@@ -538,10 +375,9 @@ namespace skch
                     << " target subsets (≈" << std::fixed << std::setprecision(0) << avg_subset_size 
                     << "bp/subset)" << std::endl;
 
-          // Flag for whether we're done after creating indices
           bool exit_after_indices = param.create_index_only;
 
-          // Process each subset SERIALLY to control memory
+          // Process each subset serially
           for (size_t subset_idx = 0; subset_idx < target_subsets.size(); ++subset_idx) {
               const auto& target_subset = target_subsets[subset_idx];
               if(target_subset.empty()) continue;
@@ -549,37 +385,23 @@ namespace skch
               std::cerr << "[wfmash::mashmap] Processing subset " << (subset_idx + 1) 
                         << "/" << target_subsets.size() << " (mapping)" << std::endl;
               
-              // Use a single index filename for all subsets
               std::string indexFilename = param.indexFilename.string();
               
-              // Handle index creation
               if (param.create_index_only) {
                   std::cerr << "[wfmash::mashmap] Processing subset " << (subset_idx + 1) 
                             << "/" << target_subsets.size() << " (indexing): " << indexFilename << std::endl;
     
-                  // Build the index directly
                   refSketch = new skch::Sketch(param, *idManager, target_subset);
-    
-                  // Append to the same file for all but the first subset
                   bool append = (subset_idx > 0);
                   refSketch->writeIndex(target_subset, indexFilename, append, subset_idx, target_subsets.size());
-    
-                  // Clean up
                   delete refSketch;
                   refSketch = nullptr;
-                      
-                  // Show completed message for index building
                   std::cerr << "[wfmash::mashmap] index construction completed" << std::endl;
-    
-                  // Continue to next subset without mapping
                   continue;
               }
               
-              // If we're doing mapping, set up the taskflow
               auto subset_flow = std::make_shared<tf::Taskflow>();
 
-              // Initialize progress meter
-              // Calculate total query length for progress meter
               uint64_t subset_query_length = 0;
               for (const auto& queryName : querySequenceNames) {
                   subset_query_length += idManager->getSequenceLength(idManager->getSequenceId(queryName));
@@ -591,26 +413,20 @@ namespace skch
                   param.use_progress_bar
                   );
 
-              // Build or load index task
-              auto buildIndex_task = subset_flow->emplace([this, target_subset=target_subset, subset_idx, total_subsets=target_subsets.size(), &target_subsets]() {
+              auto buildIndex_task = subset_flow->emplace([this, target_subset=target_subset, subset_idx, total_subsets=target_subsets.size()]() {
                   if (!param.indexFilename.empty()) {
-                      // Load existing index
                       std::string indexFilename = param.indexFilename.string();
-                      
-                      // Use static file stream to maintain position between reads
                       static std::ifstream indexStream;
                       static bool index_opened = false;
                       static size_t file_subset_count = 0;
                       
                       if (!index_opened) {
-                          // First read - validate the index file and get metadata
                           indexStream.open(indexFilename, std::ios::binary);
                           if (!indexStream) {
                               std::cerr << "Error: Unable to open index file for reading: " << indexFilename << std::endl;
                               exit(1);
                           }
                           
-                          // Read the magic number to verify it's a valid index
                           uint64_t magic_number = 0;
                           indexStream.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
                           if (magic_number != 0xDEADBEEFCAFEBABE) {
@@ -618,17 +434,14 @@ namespace skch
                               exit(1);
                           }
                           
-                          // Read subset count
                           size_t batch_idx, total_batches;
                           indexStream.read(reinterpret_cast<char*>(&batch_idx), sizeof(batch_idx));
                           indexStream.read(reinterpret_cast<char*>(&total_batches), sizeof(total_batches));
                           
-                          // Store and display subset count
                           file_subset_count = total_batches;
                           std::cerr << "[wfmash::mashmap] Index file contains " << file_subset_count 
                                     << " subsets" << std::endl;
                           
-                          // Read batch size if available
                           int64_t batch_size = 0;
                           indexStream.read(reinterpret_cast<char*>(&batch_size), sizeof(batch_size));
                           if (batch_size > 0) {
@@ -637,49 +450,35 @@ namespace skch
                                         << " from index" << std::endl;
                           }
                           
-                          // Return to beginning of file
                           indexStream.seekg(0, std::ios::beg);
                           index_opened = true;
                       }
                       
-                      // Create sketch from current file position
                       refSketch = new skch::Sketch(param, *idManager, target_subset, &indexStream);
-                      
-                      // Get the number of sequences from the sketch
                       size_t seq_count = refSketch->getSequenceCount();
                   } else {
-                      // Use progress meter for sketching phase
                       auto sketch_index_progress = std::make_shared<progress_meter::ProgressMeter>(
-                          100, // Using 100 as a generic value for percentage-based progress
+                          100,
                           "[wfmash::mashmap] indexing",
                           param.use_progress_bar);
                   
-                      // First stage: sketching sequences
                       if (!sketch_index_progress->is_finished.load()) {
                           sketch_index_progress->reset_timer();
                       }
                       
-                      // Build index in memory with progress meter
                       refSketch = new skch::Sketch(param, *idManager, target_subset, nullptr, sketch_index_progress);
-                      
-                      // Second stage: building index data structures
-                      // Instead of just updating the banner, print a clear message that indexing is done
-                      // and we're now building the index data structures
                       std::cerr << "[wfmash::mashmap] building index data structures..." << std::endl;
                   }
               }).name("build_index_" + std::to_string(subset_idx));
 
-              // Storage for this subset's mappings (only used for ONETOONE mode)
               auto subsetMappings = std::make_shared<std::unordered_map<seqno_t, MappingResultsVector_t>>();
               auto subsetMappings_mutex = std::make_shared<std::mutex>();
 
-              // Create output stream for non-ONETOONE modes
               auto outstream = std::make_shared<std::ofstream>();
               auto outstream_mutex = std::make_shared<std::mutex>();
               
-              // Open output file if we're not in ONETOONE mode (for immediate output)
               if (param.filterMode != filter::ONETOONE) {
-                  bool append = subset_idx > 0;  // Append for all but first subset
+                  bool append = subset_idx > 0;
                   outstream->open(param.outFileName, append ? std::ios::app : std::ios::out);
                   if (!outstream->is_open()) {
                       std::cerr << "Error: Could not open output file for writing: " << param.outFileName << std::endl;
@@ -687,19 +486,16 @@ namespace skch
                   }
               }
 
-              // Process queries using subflows for parallelism
               auto processQueries_task = subset_flow->emplace([this, progress, subsetMappings, subsetMappings_mutex, 
                                                            outstream, outstream_mutex, subset_flow](tf::Subflow& sf) {
                   const auto& fileName = param.querySequences[0];
     
-                  // Load the query file index once and share it
                   faidx_meta_t* query_meta = faidx_meta_load(fileName.c_str(), FAI_FASTA, FAI_CREATE);
                   if (!query_meta) {
                       std::cerr << "Error: Failed to load query FASTA index: " << fileName << std::endl;
                       exit(1);
                   }
                   
-                  // Helper to get thread-local readers
                   auto getThreadLocalReader = [](faidx_meta_t* meta) -> faidx_reader_t* {
                       thread_local faidx_reader_t* reader = nullptr;
                       if (reader == nullptr) {
@@ -711,12 +507,9 @@ namespace skch
                       return reader;
                   };
                   
-                  // Process each query sequence
                   for (const auto& queryName : querySequenceNames) {
-                      // Get a thread-local reader
                       faidx_reader_t* reader = getThreadLocalReader(query_meta);
                       
-                      // Fetch the sequence
                       hts_pos_t seq_len;
                       hts_pos_t seq_total_len = faidx_meta_seq_len(query_meta, queryName.c_str());
                       if (seq_total_len <= 0) {
@@ -730,141 +523,120 @@ namespace skch
                           continue;
                       }
                       
-                      // Create a string from the fetched data (will be copied)
                       std::string sequence(seq_data, seq_len);
-                      free(seq_data); // Free the raw data after copying
+                      free(seq_data);
             
-                          // Create a subflow for each query that processes its fragments in parallel
-                          auto query_task = sf.emplace([&, queryName, sequence](tf::Subflow& query_sf) {
-                              // Set up input/output containers
-                              seqno_t seqId = idManager->getSequenceId(queryName);
-                              auto input = std::make_shared<InputSeqProgContainer>(
-                                  sequence, queryName, seqId, *progress);
-                              auto output = std::make_shared<QueryMappingOutput>(
-                                  queryName, MappingResultsVector_t{}, MappingResultsVector_t{}, *progress);
-                
-                              // Process fragments in parallel using subflows
-                              int refGroup = idManager->getRefGroup(seqId);
-                              int noOverlapFragmentCount = input->len / param.segLength;
+                      auto query_task = sf.emplace([&, queryName, sequence](tf::Subflow& query_sf) {
+                          seqno_t seqId = idManager->getSequenceId(queryName);
+                          auto input = std::make_shared<InputSeqProgContainer>(
+                              sequence, queryName, seqId, *progress);
+                          auto output = std::make_shared<QueryMappingOutput>(
+                              queryName, MappingResultsVector_t{}, MappingResultsVector_t{}, *progress);
+            
+                          int refGroup = idManager->getRefGroup(seqId);
+                          int noOverlapFragmentCount = input->len / param.segLength;
 
-                              // Create a mutex to protect access to output->results
-                              std::mutex results_mutex;
+                          std::mutex results_mutex;
 
-                              // Regular fragments
-                              for(int i = 0; i < noOverlapFragmentCount; i++) {
-                                  query_sf.emplace([&, i]() {
-                                      // Thread-local storage for results
-                                      std::vector<MappingResult> all_fragment_results;
-                                      auto fragment = std::make_shared<FragmentData>(
-                                          &(sequence)[0u] + i * param.segLength,
-                                          static_cast<int>(param.segLength),
-                                          static_cast<int>(input->len),
-                                          seqId,
-                                          queryName,
-                                          refGroup,
-                                          i,
-                                          output
-                                      );
-
-                                      // Print initial progress message for the first fragment
-                                      // and reset the timer when actual work begins
-                                      static std::once_flag first_fragment;
-                                      std::call_once(first_fragment, [&output]() {
-                                          // Reset the progress meter's start time to now
-                                          output->progress.reset_timer();
-                                      });
-                                      
-                                      std::vector<IntervalPoint> intervalPoints;
-                                      std::vector<L1_candidateLocus_t> l1Mappings;
-                                      MappingResultsVector_t l2Mappings;
-                                      QueryMetaData<MinVec_Type> Q;
-                                      processFragment(*fragment, intervalPoints, l1Mappings, l2Mappings, Q, all_fragment_results);
-                                      
-                                      // Safely merge results into output
-                                      if (!all_fragment_results.empty()) {
-                                          std::lock_guard<std::mutex> lock(results_mutex);
-                                          output->results.insert(
-                                              output->results.end(),
-                                              all_fragment_results.begin(),
-                                              all_fragment_results.end()
-                                          );
-                                      }
-                                  });
-                              }
-
-                              // Handle final fragment if needed
-                              if (noOverlapFragmentCount >= 1 && input->len % param.segLength != 0) {
-                                  query_sf.emplace([&]() {
-                                      // Thread-local storage for results
-                                      std::vector<MappingResult> all_fragment_results;
-                                      auto fragment = std::make_shared<FragmentData>(
-                                          &(sequence)[0u] + input->len - param.segLength,
-                                          static_cast<int>(param.segLength),
-                                          static_cast<int>(input->len),
-                                          seqId,
-                                          queryName,
-                                          refGroup,
-                                          noOverlapFragmentCount,
-                                          output
-                                      );
-
-                                      std::vector<IntervalPoint> intervalPoints;
-                                      std::vector<L1_candidateLocus_t> l1Mappings;
-                                      MappingResultsVector_t l2Mappings;
-                                      QueryMetaData<MinVec_Type> Q;
-                                      processFragment(*fragment, intervalPoints, l1Mappings, l2Mappings, Q, all_fragment_results);
-                                      
-                                      // Safely merge results into output
-                                      if (!all_fragment_results.empty()) {
-                                          std::lock_guard<std::mutex> lock(results_mutex);
-                                          output->results.insert(
-                                              output->results.end(),
-                                              all_fragment_results.begin(),
-                                              all_fragment_results.end()
-                                          );
-                                      }
-                                  });
-                              }
-
-                              // Join ensures all fragments complete before finalization
-                              query_sf.join();
-
-                              // After all fragments are processed, set the output results
-                              mappingBoundarySanityCheck(input.get(), output->results);
-                              auto [nonMergedMappings, mergedMappings] = 
-                                  filterSubsetMappings(output->results, output->progress);
-
-                              // Select the appropriate mappings
-                              auto& mappings = param.mergeMappings && param.split ?
-                                    mergedMappings : nonMergedMappings;
-
-                              // Handle based on filter mode
-                              if (param.filterMode == filter::ONETOONE) {
-                                  // For ONETOONE mode, store mappings for later merging across subsets
-                                  std::lock_guard<std::mutex> lock(*subsetMappings_mutex);
-                                  (*subsetMappings)[seqId].insert(
-                                      (*subsetMappings)[seqId].end(),
-                                      std::make_move_iterator(mappings.begin()),
-                                      std::make_move_iterator(mappings.end())
+                          // Regular fragments
+                          for(int i = 0; i < noOverlapFragmentCount; i++) {
+                              query_sf.emplace([&, i]() {
+                                  std::vector<MappingResult> all_fragment_results;
+                                  auto fragment = std::make_shared<FragmentData>(
+                                      &(sequence)[0u] + i * param.segLength,
+                                      static_cast<int>(param.segLength),
+                                      static_cast<int>(input->len),
+                                      seqId,
+                                      queryName,
+                                      refGroup,
+                                      i,
+                                      output
                                   );
-                              } else {
-                                  // For non-ONETOONE modes, write mappings immediately
-                                  std::lock_guard<std::mutex> lock(*outstream_mutex);
-                                  reportReadMappings(mappings, queryName, *outstream);
-                              }
-                          }).name("query_" + queryName);
+
+                                  static std::once_flag first_fragment;
+                                  std::call_once(first_fragment, [&output]() {
+                                      output->progress.reset_timer();
+                                  });
+                                  
+                                  std::vector<IntervalPoint> intervalPoints;
+                                  std::vector<L1_candidateLocus_t> l1Mappings;
+                                  MappingResultsVector_t l2Mappings;
+                                  QueryMetaData<MinVec_Type> Q;
+                                  processFragment(*fragment, intervalPoints, l1Mappings, l2Mappings, Q, all_fragment_results);
+                                  
+                                  if (!all_fragment_results.empty()) {
+                                      std::lock_guard<std::mutex> lock(results_mutex);
+                                      output->results.insert(
+                                          output->results.end(),
+                                          all_fragment_results.begin(),
+                                          all_fragment_results.end()
+                                      );
+                                  }
+                              });
+                          }
+
+                          // Handle final fragment if needed
+                          if (noOverlapFragmentCount >= 1 && input->len % param.segLength != 0) {
+                              query_sf.emplace([&]() {
+                                  std::vector<MappingResult> all_fragment_results;
+                                  auto fragment = std::make_shared<FragmentData>(
+                                      &(sequence)[0u] + input->len - param.segLength,
+                                      static_cast<int>(param.segLength),
+                                      static_cast<int>(input->len),
+                                      seqId,
+                                      queryName,
+                                      refGroup,
+                                      noOverlapFragmentCount,
+                                      output
+                                  );
+
+                                  std::vector<IntervalPoint> intervalPoints;
+                                  std::vector<L1_candidateLocus_t> l1Mappings;
+                                  MappingResultsVector_t l2Mappings;
+                                  QueryMetaData<MinVec_Type> Q;
+                                  processFragment(*fragment, intervalPoints, l1Mappings, l2Mappings, Q, all_fragment_results);
+                                  
+                                  if (!all_fragment_results.empty()) {
+                                      std::lock_guard<std::mutex> lock(results_mutex);
+                                      output->results.insert(
+                                          output->results.end(),
+                                          all_fragment_results.begin(),
+                                          all_fragment_results.end()
+                                      );
+                                  }
+                              });
+                          }
+
+                          query_sf.join();
+
+                          OutputHandler::mappingBoundarySanityCheck(input.get(), output->results, *idManager);
+                          auto [nonMergedMappings, mergedMappings] = 
+                              filterSubsetMappings(output->results, output->progress);
+
+                          auto& mappings = param.mergeMappings && param.split ?
+                                mergedMappings : nonMergedMappings;
+
+                          if (param.filterMode == filter::ONETOONE) {
+                              std::lock_guard<std::mutex> lock(*subsetMappings_mutex);
+                              (*subsetMappings)[seqId].insert(
+                                  (*subsetMappings)[seqId].end(),
+                                  std::make_move_iterator(mappings.begin()),
+                                  std::make_move_iterator(mappings.end())
+                              );
+                          } else {
+                              std::lock_guard<std::mutex> lock(*outstream_mutex);
+                              OutputHandler::reportReadMappings(mappings, queryName, *outstream, *idManager, param, processMappingResults);
+                          }
+                      }).name("query_" + queryName);
                   }
                   
-                  // Clean up the shared index
                   faidx_meta_destroy(query_meta);
               }).name("process_queries");
 
-              // Merge subset results into combined mappings (only for ONETOONE mode)
               auto merge_task = subset_flow->emplace([this,
                                                     subsetMappings,
                                                     &combinedMappings,
                                                     &combinedMappings_mutex]() {
-                  // Only merge results if we're in ONETOONE mode
                   if (param.filterMode == filter::ONETOONE) {
                       std::lock_guard<std::mutex> lock(combinedMappings_mutex);
                       for (auto& [querySeqId, mappings] : *subsetMappings) {
@@ -877,9 +649,7 @@ namespace skch
                   }
               }).name("merge_results");
 
-              // Cleanup task
               auto cleanup_task = subset_flow->emplace([this, outstream]() {
-                  // Close output file if it's open (for non-ONETOONE modes)
                   if (param.filterMode != filter::ONETOONE && outstream->is_open()) {
                       outstream->close();
                   }
@@ -888,30 +658,26 @@ namespace skch
                   refSketch = nullptr;
               }).name("cleanup");
 
-              // Set up dependencies
               buildIndex_task.precede(processQueries_task);
               processQueries_task.precede(merge_task);
               merge_task.precede(cleanup_task);
 
-              // Run this subset's taskflow
               executor.run(*subset_flow).wait();
         
               progress->finish();
           }
 
-          // If we're only creating indices, exit now
           if (exit_after_indices) {
               std::cerr << "[wfmash::mashmap] All indices created successfully. Exiting." << std::endl;
               exit(0);
           }
 
-          // Final results processing (only needed for ONETOONE mode)
+          // Final results processing for ONETOONE mode
           if (param.filterMode == filter::ONETOONE && !exit_after_indices) {
               tf::Taskflow final_flow;
               std::cerr << "[wfmash::mashmap] Processing final one-to-one filtering" << std::endl;
               
               auto final_task = final_flow.emplace([&]() {
-                  // Count total mappings for logging
                   size_t total_mappings = 0;
                   for (auto& [querySeqId, mappings] : combinedMappings) {
                       total_mappings += mappings.size();
@@ -920,7 +686,6 @@ namespace skch
                             << " mappings from " << combinedMappings.size() 
                             << " queries for one-to-one filtering" << std::endl;
                   
-                  // Reorganize mappings by target for reference-based filtering
                   std::unordered_map<seqno_t, MappingResultsVector_t> targetMappings;
                   for (auto& [querySeqId, mappings] : combinedMappings) {
                       for (auto& mapping : mappings) {
@@ -928,20 +693,17 @@ namespace skch
                       }
                   }
                   
-                  // Use a progress meter for the filtering step
                   auto filterProgress = std::make_shared<progress_meter::ProgressMeter>(
                       targetMappings.size(), 
                       "[wfmash::mashmap] One-to-one reference filtering",
                       param.use_progress_bar);
                   
-                  // Filter mappings by reference
                   std::unordered_map<seqno_t, MappingResultsVector_t> finalMappings;
                   for (auto& [targetSeqId, mappings] : targetMappings) {
                       MappingResultsVector_t filteredMappings;
-                      filterByGroup(mappings, filteredMappings, param.numMappingsForSegment - 1, 
-                                   true, *idManager, *filterProgress);
+                      FilterUtils::filterByGroup(mappings, filteredMappings, param.numMappingsForSegment - 1, 
+                                   true, *idManager, param, *filterProgress);
                       
-                      // Organize by query ID for output
                       for (auto& mapping : filteredMappings) {
                           finalMappings[mapping.querySeqId].push_back(mapping);
                       }
@@ -949,12 +711,11 @@ namespace skch
                   }
                   filterProgress->finish();
                   
-                  // Write the final filtered mappings
                   std::ofstream outstrm(param.outFileName);
                   size_t final_mapping_count = 0;
                   for (auto& [querySeqId, mappings] : finalMappings) {
                       std::string queryName = idManager->getSequenceName(querySeqId);
-                      reportReadMappings(mappings, queryName, outstrm);
+                      OutputHandler::reportReadMappings(mappings, queryName, outstrm, *idManager, param, processMappingResults);
                       final_mapping_count += mappings.size();
                   }
                   
@@ -963,2008 +724,247 @@ namespace skch
               });
               
               executor.run(final_flow).wait();
-          } else if (!exit_after_indices) {
-              // For non-ONETOONE modes, we've already written all results
-          }
-          // Final flow execution is now handled inside the conditional block above
-      }
-
-
-
-      /**
-       * @brief               helper to main mapping function
-       * @details             filters mappings with fewer than the target number of merged base mappings
-       * @param[in]   input   mappings
-       * @return              void
-       */
-      void filterWeakMappings(MappingResultsVector_t &readMappings, int64_t min_count)
-      {
-          readMappings.erase(
-              std::remove_if(readMappings.begin(),
-                           readMappings.end(),
-                           [&](MappingResult &e){
-                               // Check if mapping is at the beginning or end of the sequence
-                               bool is_boundary_mapping = 
-                                   e.queryStartPos < param.segLength || // Beginning of query
-                                   e.queryEndPos > e.queryLen - param.segLength || // End of query
-                                   e.refStartPos < param.segLength || // Beginning of reference
-                                   e.refEndPos > this->idManager->getSequenceLength(e.refSeqId) - param.segLength; // End of reference
-                               
-                                if (is_boundary_mapping) {
-                                    // More lenient criteria for boundary mappings
-                                    return e.blockLength < param.block_length / 2 || 
-                                           e.n_merged < min_count / 2;
-                                } else {
-                                    // Standard criteria for non-boundary mappings
-                                    return e.blockLength < param.block_length || 
-                                           e.n_merged < min_count;
-                                }
-                           }),
-              readMappings.end());
-      }
-
-      /**
-       * @brief               helper to main mapping function
-       * @details             filters mappings whose identity and query/ref length don't agree
-       * @param[in]   input   mappings
-       * @return              void
-       */
-      void filterFalseHighIdentity(MappingResultsVector_t &readMappings)
-      {
-          readMappings.erase(
-              std::remove_if(readMappings.begin(),
-                             readMappings.end(),
-                             [&](MappingResult &e){
-                                 int64_t q_l = (int64_t)e.queryEndPos - (int64_t)e.queryStartPos;
-                                 int64_t r_l = (int64_t)e.refEndPos - (int64_t)e.refStartPos;
-                                 uint64_t delta = std::abs(r_l - q_l);
-                                 double len_id_bound = (1.0 - (double)delta/(((double)q_l+r_l)/2));
-                                 return len_id_bound < std::min(0.7, std::pow(param.percentageIdentity,3));
-                             }),
-              readMappings.end());
-      }
-
-      /**
-       * @brief               helper to main mapping function
-       * @details             filters mappings whose split ids aren't to be kept
-       * @param[in]   input   mappings
-       * @param[in]   input
-       * @return              void
-       */
-      void filterFailedSubMappings(MappingResultsVector_t &readMappings,
-                                   const robin_hood::unordered_set<offset_t>& kept_chains)
-      {
-          readMappings.erase(
-              std::remove_if(readMappings.begin(),
-                             readMappings.end(),
-                             [&](MappingResult &e){
-                                 return kept_chains.count(e.splitMappingId) == 0;
-                             }),
-              readMappings.end());
-      }
-
-      /**
-       * @brief               helper to main mapping function
-       * @details             filters mappings by hash value
-       * @param[in]   input   mappings
-       * @param[in]   input
-       * @return              void
-       */
-      void sparsifyMappings(MappingResultsVector_t &readMappings)
-      {
-          if (param.sparsity_hash_threshold < std::numeric_limits<uint64_t>::max()) {
-              readMappings.erase(
-                  std::remove_if(readMappings.begin(),
-                                 readMappings.end(),
-                                 [&](MappingResult &e){
-                                     return e.hash() > param.sparsity_hash_threshold;
-                                 }),
-                  readMappings.end());
           }
       }
 
       /**
-       * @brief                    helper to main filtering function
-       * @details                  filters mappings by group
-       * @param[in]   input        unfiltered mappings
-       * @param[in]   output       filtered mappings
-       * @param[in]   n_mappings   num mappings per segment
-       * @param[in]   filter_ref   use Filter::ref instead of Filter::query
-       * @return                   void
+       * @brief Map single query fragment through L1 and L2 stages
        */
-      void filterByGroup(
-          MappingResultsVector_t &unfilteredMappings,
-          MappingResultsVector_t &filteredMappings,
-          int n_mappings,
-          bool filter_ref,
-          const SequenceIdManager& idManager,
-          progress_meter::ProgressMeter& progress)
+      template<typename Q_Info, typename IPVec, typename L1Vec, typename VecOut>
+      void mapSingleQueryFrag(Q_Info &Q, IPVec& intervalPoints, L1Vec& l1Mappings, VecOut &l2Mappings)
       {
-        filteredMappings.reserve(unfilteredMappings.size());
-
-        std::sort(unfilteredMappings.begin(), unfilteredMappings.end(), [](const auto& a, const auto& b) 
-            { return std::tie(a.refSeqId, a.refStartPos) < std::tie(b.refSeqId, b.refStartPos); });
-        auto subrange_begin = unfilteredMappings.begin();
-        auto subrange_end = unfilteredMappings.begin();
-        if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) 
-        {
-          std::vector<skch::MappingResult> tmpMappings;
-          while (subrange_end != unfilteredMappings.end())
-          {
-            if (param.skip_prefix)
-            {
-              int currGroup = idManager.getRefGroup(subrange_begin->refSeqId);
-              subrange_end = std::find_if_not(subrange_begin, unfilteredMappings.end(), [this, currGroup, &idManager] (const auto& candidate) {
-                  return currGroup == idManager.getRefGroup(candidate.refSeqId);
-              });
-            }
-            else
-            {
-              subrange_end = unfilteredMappings.end();
-            }
-            tmpMappings.insert(
-                tmpMappings.end(), 
-                std::make_move_iterator(subrange_begin), 
-                std::make_move_iterator(subrange_end));
-            std::sort(tmpMappings.begin(), tmpMappings.end(), [](const auto& a, const auto& b) 
-                { return std::tie(a.queryStartPos, a.refSeqId, a.refStartPos) < std::tie(b.queryStartPos, b.refSeqId, b.refStartPos); });
-            if (filter_ref)
-            {
-                skch::Filter::ref::filterMappings(tmpMappings, idManager, n_mappings, param.dropRand, param.overlap_threshold);
-            }
-            else
-            {
-                skch::Filter::query::filterMappings(tmpMappings, n_mappings, param.dropRand, param.overlap_threshold, progress);
-            }
-            filteredMappings.insert(
-                filteredMappings.end(), 
-                std::make_move_iterator(tmpMappings.begin()), 
-                std::make_move_iterator(tmpMappings.end()));
-            tmpMappings.clear();
-            subrange_begin = subrange_end;
-          }
+#ifdef ENABLE_TIME_PROFILE_L1_L2
+        auto t0 = skch::Time::now();
+#endif
+        //L1 Mapping
+        doL1Mapping(Q, intervalPoints, l1Mappings);
+        if (l1Mappings.size() == 0) {
+          return;
         }
-        //Sort the mappings by query (then reference) position
-        std::sort(
-            filteredMappings.begin(), filteredMappings.end(),
-            [](const MappingResult &a, const MappingResult &b) {
-                return std::tie(a.queryStartPos, a.refSeqId, a.refStartPos, a.strand) 
-                    < std::tie(b.queryStartPos, b.refSeqId, b.refStartPos, b.strand);
-            });
-      }
 
+#ifdef ENABLE_TIME_PROFILE_L1_L2
+        std::chrono::duration<double> timeSpentL1 = skch::Time::now() - t0;
+        auto t1 = skch::Time::now();
+#endif
 
-      /**
-       * @brief               main mapping function given an input read
-       * @details             this function is run in parallel by multiple threads
-       * @param[in]   input   input read details
-       * @return              output object containing the mappings
-       */
-
-
-      /**
-       * @brief                       routine to handle mapModule's output of mappings
-       * @param[in] output            mapping output object
-       * @param[in] allReadMappings   vector to store mappings of all reads (optional use depending on filter)
-       * @param[in] totalReadsMapped  counter to track count of reads mapped
-       * @param[in] outstrm           outstream stream object
-       */
-      template <typename Vec>
-      void mapModuleHandleOutput(MapModuleOutput* output,
-                                 Vec &allReadMappings,
-                                 seqno_t &totalReadsMapped,
-                                 std::ofstream &outstrm) {
-
-          if(output->readMappings.size() > 0)
-            totalReadsMapped++;
-
-          if (param.filterMode == filter::ONETOONE)
+        auto l1_begin = l1Mappings.begin();
+        auto l1_end = l1Mappings.begin();
+        while (l1_end != l1Mappings.end())
+        {
+          if (param.skip_prefix)
           {
-            //Save for another filtering round
-            allReadMappings.insert(allReadMappings.end(), output->readMappings.begin(), output->readMappings.end());
+            int currGroup = this->idManager->getRefGroup(l1_begin->seqId);
+            l1_end = std::find_if_not(l1_begin, l1Mappings.end(), [this, currGroup] (const auto& candidate) {
+                return currGroup == this->idManager->getRefGroup(candidate.seqId);
+            });
           }
           else
           {
-            //Report mapping
-            reportReadMappings(output->readMappings, output->qseqName, outstrm);
+            l1_end = l1Mappings.end();
           }
 
-          delete output;
+          if (param.stage1_topANI_filter)
+          {
+            std::make_heap(l1_begin, l1_end, L1_locus_intersection_cmp);
+          }
+          doL2Mapping(Q, l1_begin, l1_end, l2Mappings);
+
+          l1_begin = l1_end;
         }
 
-      /**
-       * @brief                       Filter non-merged mappings
-       * @param[in/out] readMappings  Mappings computed by Mashmap
-       * @param[in]     param         Algorithm parameters
-       */
-      void filterNonMergedMappings(MappingResultsVector_t &readMappings, const Parameters& param, progress_meter::ProgressMeter& progress)
-      {
-          if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {
-              MappingResultsVector_t filteredMappings;
-              filterByGroup(readMappings, filteredMappings, param.numMappingsForSegment - 1, false, *idManager, progress);
-              readMappings = std::move(filteredMappings);
-          }
+        std::sort(l2Mappings.begin(), l2Mappings.end(), [](const auto& a, const auto& b) 
+            { return std::tie(a.refSeqId, a.refStartPos) < std::tie(b.refSeqId, b.refStartPos); });
+
+        int32_t chain_id = maxChainIdSeen.fetch_add(1, std::memory_order_relaxed);
+        int32_t chain_length = l2Mappings.size();
+        int32_t chain_pos = 1;
+        for (auto& mapping : l2Mappings) {
+            mapping.chain_id = chain_id;
+            mapping.chain_length = chain_length;
+            mapping.chain_pos = chain_pos++;
+        }
+
+#ifdef ENABLE_TIME_PROFILE_L1_L2
+        {
+          std::chrono::duration<double> timeSpentL2 = skch::Time::now() - t1;
+          std::chrono::duration<double> timeSpentMappingFragment = skch::Time::now() - t0;
+
+          std::cerr << Q.seqId << " " << Q.len
+            << " " << timeSpentL1.count()
+            << " " << timeSpentL2.count()
+            << " " << timeSpentMappingFragment.count()
+            << "\n";
+        }
+#endif
       }
 
       /**
-       * @brief                   map the parsed query sequence (L1 and L2 mapping)
-       * @param[in]   Q           metadata about query sequence
-       * @param[in]   outstrm     outstream stream where mappings will be reported
-       * @param[out]  l2Mappings  Mapping results in the L2 stage
-       */
-      template<typename Q_Info, typename IPVec, typename L1Vec, typename VecOut>
-        void mapSingleQueryFrag(Q_Info &Q, IPVec& intervalPoints, L1Vec& l1Mappings, VecOut &l2Mappings)
-        {
-#ifdef ENABLE_TIME_PROFILE_L1_L2
-          auto t0 = skch::Time::now();
-#endif
-          //L1 Mapping
-          doL1Mapping(Q, intervalPoints, l1Mappings);
-          if (l1Mappings.size() == 0) {
-            return;
-          }
-
-#ifdef ENABLE_TIME_PROFILE_L1_L2
-          std::chrono::duration<double> timeSpentL1 = skch::Time::now() - t0;
-          auto t1 = skch::Time::now();
-#endif
-
-          auto l1_begin = l1Mappings.begin();
-          auto l1_end = l1Mappings.begin();
-          while (l1_end != l1Mappings.end())
-          {
-            if (param.skip_prefix)
-            {
-              int currGroup = this->idManager->getRefGroup(l1_begin->seqId);
-              l1_end = std::find_if_not(l1_begin, l1Mappings.end(), [this, currGroup] (const auto& candidate) {
-                  return currGroup == this->idManager->getRefGroup(candidate.seqId);
-              });
-            }
-            else
-            {
-              l1_end = l1Mappings.end();
-            }
-
-            //Sort L1 windows based on intersection size if using hg filter
-            if (param.stage1_topANI_filter)
-            {
-              std::make_heap(l1_begin, l1_end, L1_locus_intersection_cmp);
-            }
-            doL2Mapping(Q, l1_begin, l1_end, l2Mappings);
-
-            // Set beginning of next range
-            l1_begin = l1_end;
-          }
-
-          // Sort output mappings
-          std::sort(l2Mappings.begin(), l2Mappings.end(), [](const auto& a, const auto& b) 
-              { return std::tie(a.refSeqId, a.refStartPos) < std::tie(b.refSeqId, b.refStartPos); });
-
-          // Add chain information
-          // All mappings in this batch form a chain
-          int32_t chain_id = maxChainIdSeen.fetch_add(1, std::memory_order_relaxed);
-          int32_t chain_length = l2Mappings.size();
-          int32_t chain_pos = 1;
-          for (auto& mapping : l2Mappings) {
-              mapping.chain_id = chain_id;
-              mapping.chain_length = chain_length;
-              mapping.chain_pos = chain_pos++;
-          }
-
-#ifdef ENABLE_TIME_PROFILE_L1_L2
-          {
-            std::chrono::duration<double> timeSpentL2 = skch::Time::now() - t1;
-            std::chrono::duration<double> timeSpentMappingFragment = skch::Time::now() - t0;
-
-            std::cerr << Q.seqId << " " << Q.len
-              << " " << timeSpentL1.count()
-              << " " << timeSpentL2.count()
-              << " " << timeSpentMappingFragment.count()
-              << "\n";
-          }
-#endif
-        }
-
-      template <typename Q_Info>
-        void getSeedHits(Q_Info &Q)
-        {
-          Q.minmerTableQuery.reserve(param.sketchSize + 1);
-          CommonFunc::sketchSequence(Q.minmerTableQuery, Q.seq, Q.len, param.kmerSize, param.alphabetSize, param.sketchSize, Q.seqId);
-          if(Q.minmerTableQuery.size() == 0) {
-            Q.sketchSize = 0;
-            return;
-          }
-
-#ifdef DEBUG
-          int orig_len = Q.minmerTableQuery.size();
-#endif
-          const double max_hash_01 = (long double)(Q.minmerTableQuery.back().hash) / std::numeric_limits<hash_t>::max();
-          Q.kmerComplexity = (double(Q.minmerTableQuery.size()) / max_hash_01) / ((Q.len - param.kmerSize + 1)*2);
-
-          // Removed frequent kmer filtering
-
-          Q.sketchSize = Q.minmerTableQuery.size();
-#ifdef DEBUG
-          std::cerr << "INFO, wfmash::mashmap, read id " << Q.seqId << ", minmer count = " << Q.minmerTableQuery.size() << ", bad minmers = " << orig_len - Q.sketchSize << "\n";
-#endif
-        } 
-
-
-      /**
-       * @brief       Find candidate regions for a read using level 1 (seed-hits) mapping
-       * @details     The count of hits that should occur within a region on the reference is 
-       *              determined by the threshold similarity
-       *              The resulting start and end target offsets on reference is (are) an 
-       *              overestimate of the mapped region. Computing better bounds is left for
-       *              the following L2 stage.
-       * @param[in]   Q                         query sequence details 
-       * @param[out]  l1Mappings                all the read mapping locations
-       */
-      template <typename Q_Info, typename Vec>
-        void getSeedIntervalPoints(Q_Info &Q, Vec& intervalPoints)
-        {
-
-#ifdef DEBUG
-          std::cerr<< "INFO, wfmash::mashmap, read id " << Q.seqId << ", minmer count = " << Q.minmerTableQuery.size() << " " << Q.len << "\n";
-#endif
-
-          //For invalid query (example : just NNNs), we may be left with 0 sketch size
-          //Ignore the query in this case
-          if(Q.minmerTableQuery.size() == 0)
-            return;
-
-          // Priority queue for sorting interval points
-          using IP_const_iterator = std::vector<IntervalPoint>::const_iterator;
-          std::vector<boundPtr<IP_const_iterator>> pq;
-          pq.reserve(Q.sketchSize);
-          constexpr auto heap_cmp = [](const auto& a, const auto& b) {return b < a;};
-
-          for(auto it = Q.minmerTableQuery.begin(); it != Q.minmerTableQuery.end(); it++)
-          {
-            //Check if hash value exists in the reference lookup index
-            const auto seedFind = refSketch->minmerPosLookupIndex.find(it->hash);
-
-            if(seedFind != refSketch->minmerPosLookupIndex.end())
-            {
-              pq.emplace_back(boundPtr<IP_const_iterator> {seedFind->second.cbegin(), seedFind->second.cend()});
-            }
-          }
-          std::make_heap(pq.begin(), pq.end(), heap_cmp);
-
-          while(!pq.empty())
-          {
-            const IP_const_iterator ip_it = pq.front().it;
-            //const auto& ref = this->sketch_metadata[ip_it->seqId];
-            const auto& ref_name = this->idManager->getSequenceName(ip_it->seqId);
-            //const auto& ref_len = this->idManager.getSeqLen(ip_it->seqId);
-            bool skip_mapping = false;
-            int queryGroup = idManager->getRefGroup(Q.seqId);
-            int targetGroup = idManager->getRefGroup(ip_it->seqId);
-
-            if (param.skip_self && queryGroup == targetGroup) skip_mapping = true;
-            if (param.skip_prefix && queryGroup == targetGroup) skip_mapping = true;
-            if (param.lower_triangular && Q.seqId <= ip_it->seqId) skip_mapping = true;
-    
-            if (!skip_mapping) {
-              intervalPoints.push_back(*ip_it);
-            }
-            std::pop_heap(pq.begin(), pq.end(), heap_cmp);
-            pq.back().it++;
-            if (pq.back().it >= pq.back().end) 
-            {
-              pq.pop_back();
-            }
-            else
-            {
-              std::push_heap(pq.begin(), pq.end(), heap_cmp);
-            }
-          }
-
-#ifdef DEBUG
-          std::cerr << "INFO, wfmash::mashmap, read id " << Q.seqId << ", Count of seed hits in the reference = " << intervalPoints.size() / 2 << "\n";
-#endif
-        }
-
-
-      template <typename Q_Info, typename IP_iter, typename Vec2>
-        void computeL1CandidateRegions(
-            Q_Info &Q, 
-            IP_iter ip_begin, 
-            IP_iter ip_end, 
-            int minimumHits, 
-            Vec2 &l1Mappings)
-        {
-#ifdef DEBUG
-          std::cerr << "INFO, skch::Map:computeL1CandidateRegions, read id " << Q.seqId << std::endl;
-#endif
-
-          int overlapCount = 0;
-          int strandCount = 0;
-          int bestIntersectionSize = 0;
-          std::vector<L1_candidateLocus_t> localOpts;
-
-          // Keep track of all minmer windows that intersect with [i, i+windowLen]
-          int windowLen = std::max<offset_t>(0, Q.len - param.segLength);
-          auto trailingIt = ip_begin;
-          auto leadingIt = ip_begin;
-
-          // Group together local sketch intersection maximums that are within clusterLen of eachother
-          //
-          // Since setting up the L2 window [i, j] requires aggregating minmer windows over
-          // [i-segLength, i), we might as well group L2 windows together which are closer than
-          // segLength  
-          int clusterLen = param.segLength;
-
-          // Used to keep track of how many minmer windows for a particular hash are currently "open"
-          // Only necessary when windowLen != 0.
-          std::unordered_map<hash_t, int> hash_to_freq;
-
-          if (param.stage1_topANI_filter) {
-            double maxJaccard = refSketch->hgNumerator / static_cast<double>(Q.sketchSize);
-            double cutoff_j = Stat::md2j(1 - param.percentageIdentity + param.ANIDiff, param.kmerSize);
-            int minIntersectionSize = std::max(
-                static_cast<int>(cutoff_j * Q.sketchSize),
-                minimumHits);
-
-            while (leadingIt != ip_end)
-            {
-              // Catch the trailing iterator up to the leading iterator - windowLen
-              while (
-                  trailingIt != ip_end 
-                  && ((trailingIt->seqId == leadingIt->seqId && trailingIt->pos <= leadingIt->pos - windowLen)
-                    || trailingIt->seqId < leadingIt->seqId))
-              {
-                if (trailingIt->side == side::CLOSE) {
-                  if (windowLen != 0)
-                    hash_to_freq[trailingIt->hash]--;
-                  if (windowLen == 0 || hash_to_freq[trailingIt->hash] == 0) {
-                    overlapCount--;
-                  }
-                }
-                trailingIt++;
-              }
-              auto currentPos = leadingIt->pos;
-              while (leadingIt != ip_end && leadingIt->pos == currentPos) {
-                if (leadingIt->side == side::OPEN) {
-                  if (windowLen == 0 || hash_to_freq[leadingIt->hash] == 0) {
-                    overlapCount++;
-                  }
-                  if (windowLen != 0)
-                    hash_to_freq[leadingIt->hash]++;
-                }
-                leadingIt++;
-              }
-
-              //DEBUG_ASSERT(overlapCount >= 0, windowLen, trailingIt->seqId, trailingIt->pos, leadingIt->seqId, leadingIt->pos);
-              //DEBUG_ASSERT(windowLen != 0 || overlapCount <= Q.sketchSize, windowLen, trailingIt->seqId, trailingIt->pos, leadingIt->seqId, leadingIt->pos);
-
-              //Is this sliding window the best we have so far?
-              bestIntersectionSize = std::max(bestIntersectionSize, overlapCount);
-            }
-
-            // Only go back through to find local opts if we know that there are some that are 
-            // large enough
-            if (bestIntersectionSize < minIntersectionSize) 
-            {
-              return;
-            } else 
-            {
-              minimumHits = std::max(
-                  sketchCutoffs[
-                    int(std::min(bestIntersectionSize, Q.sketchSize) 
-                      / std::max<double>(1, param.sketchSize / skch::fixed::ss_table_max))
-                  ],
-                  minIntersectionSize);
-            }
-          } 
-          
-          // Clear freq dict, as there will be left open CLOSE points at the end of the last seq
-          // that we never got to
-          hash_to_freq.clear();
-
-          // Since there can be more than sketchSize windows that overlap w/ [i, i+windowLen]
-          // cap the best intersection size 
-          bestIntersectionSize = std::min(bestIntersectionSize, Q.sketchSize);
-
-          bool in_candidate = false;
-          L1_candidateLocus_t l1_out = {};
-          trailingIt = ip_begin;
-          leadingIt = ip_begin;
-
-          // Keep track of 3 consecutive points so that we can track local optimums
-          overlapCount = 0;
-          int prevOverlap = 0;
-          int prevPrevOverlap = 0;
-
-          // Need to keep track of two positions, as the previous one will be the local optimum
-          SeqCoord prevPos;
-          SeqCoord currentPos{leadingIt->seqId, leadingIt->pos};
-
-
-          while (leadingIt != ip_end)
-          {
-            prevPrevOverlap = prevOverlap;
-            prevOverlap = overlapCount;
-
-            //TODO LEADING it should only hit opens
-            // We should only iterate through a new window when we come across an OPEN,
-            // right now, this basically happens since every CLOSE should be an OPEN.
-            // This doesn't invalidate the logic, just potentially wastes time
-            while (
-                trailingIt != ip_end 
-                && ((trailingIt->seqId == leadingIt->seqId && trailingIt->pos <= leadingIt->pos - windowLen)
-                  || trailingIt->seqId < leadingIt->seqId))
-            {
-              if (trailingIt->side == side::CLOSE) {
-                if (windowLen != 0)
-                  hash_to_freq[trailingIt->hash]--;
-                if (windowLen == 0 || hash_to_freq[trailingIt->hash] == 0) {
-                  overlapCount--;
-                }
-              }
-              trailingIt++;
-            }
-            if (leadingIt->pos != currentPos.pos) {
-              prevPos = currentPos;
-              currentPos = SeqCoord{leadingIt->seqId, leadingIt->pos};
-            }
-            while (leadingIt != ip_end && leadingIt->pos == currentPos.pos) 
-            {
-              if (leadingIt->side == side::OPEN) {
-                if (windowLen == 0 || hash_to_freq[leadingIt->hash] == 0) {
-                  overlapCount++;
-                }
-                if (windowLen != 0)
-                  hash_to_freq[leadingIt->hash]++;
-              }
-              leadingIt++;
-            }
-          if ( prevOverlap >= minimumHits
-              //&& prevOverlap > overlapCount && prevOverlap >= prevPrevOverlap)
-          ) {
-            if (l1_out.seqId != prevPos.seqId && in_candidate) {
-              localOpts.push_back(l1_out);
-              l1_out = {};
-              in_candidate = false;
-            }
-            if (!in_candidate) {
-              l1_out.rangeStartPos = prevPos.pos - windowLen;
-              l1_out.rangeEndPos = prevPos.pos - windowLen;
-              l1_out.seqId = prevPos.seqId;
-              l1_out.intersectionSize = prevOverlap;
-              in_candidate = true;
-            } else {
-              if (param.stage2_full_scan) {
-                l1_out.intersectionSize = std::max(l1_out.intersectionSize, prevOverlap);
-                l1_out.rangeEndPos = prevPos.pos - windowLen;
-              }
-              else if (l1_out.intersectionSize < prevOverlap) {
-                l1_out.intersectionSize = prevOverlap;
-                l1_out.rangeStartPos = prevPos.pos - windowLen;
-                l1_out.rangeEndPos = prevPos.pos - windowLen;
-              }
-            }
-          } 
-          else {
-            if (in_candidate) {
-              localOpts.push_back(l1_out);
-              l1_out = {};
-            }
-            in_candidate = false;
-          }
-        }
-        if (in_candidate) {
-          localOpts.push_back(l1_out);
-        }
-        
-
-        // Join together proximal local opts
-        for (auto& l1_out : localOpts) 
-        {
-          if (l1Mappings.empty() 
-              || l1_out.seqId != l1Mappings.back().seqId 
-              || l1_out.rangeStartPos > l1Mappings.back().rangeEndPos + clusterLen) 
-          {
-            l1Mappings.push_back(l1_out); 
-          } 
-          else 
-          {
-            l1Mappings.back().rangeEndPos = l1_out.rangeEndPos;
-            l1Mappings.back().intersectionSize = std::max(l1_out.intersectionSize, l1Mappings.back().intersectionSize);
-          }
-        }
-      }
-
-
-      /**
-       * @brief       Find candidate regions for a read using level 1 (seed-hits) mapping
-       * @details     The count of hits that should occur within a region on the reference is
-       *              determined by the threshold similarity
-       *              The resulting start and end target offsets on reference is (are) an
-       *              overestimate of the mapped region. Computing better bounds is left for
-       *              the following L2 stage.
-       * @param[in]   Q                         query sequence details
-       * @param[out]  l1Mappings                all the read mapping locations
+       * @brief Execute L1 mapping stage
        */
       template <typename Q_Info, typename IPVec, typename L1Vec>
-        void doL1Mapping(Q_Info &Q, IPVec& intervalPoints, L1Vec& l1Mappings)
-        {
-          //1. Compute the minmers
-          getSeedHits(Q);
+      void doL1Mapping(Q_Info &Q, IPVec& intervalPoints, L1Vec& l1Mappings)
+      {
+        //1. Compute the minmers
+        CoreMapping::getSeedHits(Q, param);
 
-          //Catch all NNNNNN case
-          if (Q.sketchSize == 0 || Q.kmerComplexity < param.kmerComplexityThreshold) {
-            /*std::cerr << "[DEBUG] Skipping " << Q.seqName 
-                      << " (sketchSize=" << Q.sketchSize
-                      << " kmerComplexity=" << Q.kmerComplexity 
-                      << " threshold=" << param.kmerComplexityThreshold << ")\n";*/
-            return;
-          }
-
-          //2. Compute windows and sort
-          getSeedIntervalPoints(Q, intervalPoints);
-
-          /*std::cerr << "[DEBUG] L1 found " << intervalPoints.size() 
-                    << " interval points for " << Q.seqName 
-                    << " (sketchSize=" << Q.sketchSize
-                    << " kmerComplexity=" << Q.kmerComplexity << ")\n";*/
-
-          //3. Compute L1 windows
-          // Always respect the minimum hits parameter if set
-          int minimumHits = (Q.len == cached_segment_length) ?
-              cached_minimum_hits :
-              std::max(param.minimum_hits, Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval));
-
-          // For each "group"
-          auto ip_begin = intervalPoints.begin();
-          auto ip_end = intervalPoints.begin();
-          while (ip_end != intervalPoints.end())
-          {
-            if (param.skip_prefix)
-            {
-              int currGroup = this->idManager->getRefGroup(ip_begin->seqId);
-              ip_end = std::find_if_not(ip_begin, intervalPoints.end(), [this, currGroup] (const auto& ip) {
-                  return currGroup == this->idManager->getRefGroup(ip.seqId);
-              });
-            }
-            else
-            {
-              ip_end = intervalPoints.end();
-            }
-            computeL1CandidateRegions(Q, ip_begin, ip_end, minimumHits, l1Mappings);
-
-            ip_begin = ip_end;
-          }
+        //Catch all NNNNNN case
+        if (Q.sketchSize == 0 || Q.kmerComplexity < param.kmerComplexityThreshold) {
+          return;
         }
 
+        //2. Compute windows and sort
+        CoreMapping::getSeedIntervalPoints(Q, intervalPoints, refSketch, *idManager, param);
 
-      /**
-       * @brief     Build metadata and reference groups for sequences
-       * @details   Read FAI files, sort sequences, and assign groups
-       */
-      void buildRefGroups() {
-          std::vector<std::tuple<std::string, size_t, offset_t>> seqInfoWithIndex;
-          size_t totalSeqs = 0;
+        //3. Compute L1 windows
+        int minimumHits = (Q.len == cached_segment_length) ?
+            cached_minimum_hits :
+            std::max(param.minimum_hits, Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, skch::fixed::confidence_interval));
 
-          for (const auto& fileName : param.refSequences) {
-              // Use faigz to load the index metadata
-              faidx_meta_t* meta = faidx_meta_load(fileName.c_str(), FAI_FASTA, FAI_CREATE);
-              if (meta == nullptr) {
-                  std::cerr << "Error: Unable to load FASTA index for file: " << fileName << std::endl;
-                  exit(1);
-              }
-
-              int nseq = faidx_meta_nseq(meta);
-              for (int i = 0; i < nseq; ++i) {
-                  const char* seq_name = faidx_meta_iseq(meta, i);
-                  hts_pos_t seq_length = faidx_meta_seq_len(meta, seq_name);
-                  
-                  seqInfoWithIndex.emplace_back(seq_name, totalSeqs++, seq_length);
-              }
-              
-              faidx_meta_destroy(meta);
+        // For each "group"
+        auto ip_begin = intervalPoints.begin();
+        auto ip_end = intervalPoints.begin();
+        while (ip_end != intervalPoints.end())
+        {
+          if (param.skip_prefix)
+          {
+            int currGroup = this->idManager->getRefGroup(ip_begin->seqId);
+            ip_end = std::find_if_not(ip_begin, intervalPoints.end(), [this, currGroup] (const auto& ip) {
+                return currGroup == this->idManager->getRefGroup(ip.seqId);
+            });
           }
-
-          std::sort(seqInfoWithIndex.begin(), seqInfoWithIndex.end());
-
-          std::vector<int> refGroups(totalSeqs);
-          // Removed as sketch_metadata is no longer used
-          int currentGroup = 0;
-          std::string prevPrefix;
-
-          for (const auto& [seqName, originalIndex, seqLength] : seqInfoWithIndex) {
-              std::string currPrefix = seqName.substr(0, seqName.find_last_of(param.prefix_delim));
-              
-              if (currPrefix != prevPrefix) {
-                  currentGroup++;
-                  prevPrefix = currPrefix;
-              }
-
-              refGroups[originalIndex] = currentGroup;
-              // Metadata is now handled by idManager, no need to push_back here
+          else
+          {
+            ip_end = intervalPoints.end();
           }
+          CoreMapping::computeL1CandidateRegions(Q, ip_begin, ip_end, minimumHits, param, sketchCutoffs, l1Mappings);
 
-          // Removed refIdGroup swap as it's no longer needed
-
-          if (totalSeqs == 0) {
-              std::cerr << "[wfmash::mashmap] ERROR: No sequences indexed!" << std::endl;
-              exit(1);
-          }
+          ip_begin = ip_end;
+        }
       }
 
       /**
-       * @brief                                 Revise L1 candidate regions to more precise locations
-       * @param[in]   Q                         query sequence information
-       * @param[in]   l1Mappings                candidate regions for query sequence found at L1
-       * @param[out]  l2Mappings                Mapping results in the L2 stage
+       * @brief Execute L2 mapping stage
        */
       template <typename Q_Info, typename L1_Iter, typename VecOut>
-        void doL2Mapping(Q_Info &Q, L1_Iter l1_begin, L1_Iter l1_end, VecOut &l2Mappings)
-        {
-          ///2. Walk the read over the candidate regions and compute the jaccard similarity with minimum s sketches
-          std::vector<L2_mapLocus_t> l2_vec;
-          double bestJaccardNumerator = 0;
-          auto loc_iterator = l1_begin;
-          while (loc_iterator != l1_end)
-          {
-            L1_candidateLocus_t& candidateLocus = *loc_iterator;
-
-            if (param.stage1_topANI_filter)
-            {
-              // Use the global Jaccard numerator here
-              double jaccardSimilarity = refSketch->hgNumerator / Q.sketchSize;
-              double mash_dist = Stat::j2md(jaccardSimilarity, param.kmerSize);
-              double cutoff_ani = std::max(0.0, (1 - mash_dist) - param.ANIDiff);
-              double cutoff_j = Stat::md2j(1 - cutoff_ani, param.kmerSize);
-
-              double candidateJaccard = static_cast<double>(candidateLocus.intersectionSize) / Q.sketchSize;
-
-              if (candidateJaccard < cutoff_j) 
-              {
-                break;
-              }
-            }
-
-            l2_vec.clear();
-            /*std::cerr << "[DEBUG] L2 mapping for " << Q.seqName 
-                      << " candidateLocus=[" << candidateLocus.rangeStartPos 
-                      << "," << candidateLocus.rangeEndPos 
-                      << "] intersectionSize=" << candidateLocus.intersectionSize << "\n";*/
-            computeL2MappedRegions(Q, candidateLocus, l2_vec);
-
-            for (auto& l2 : l2_vec) 
-            {
-              //Compute mash distance using calculated jaccard
-              float mash_dist = Stat::j2md(1.0 * l2.sharedSketchSize/Q.sketchSize, param.kmerSize);
-
-              float nucIdentity = (1 - mash_dist);
-              //float nucIdentityUpperBound = getANIUBfromJaccardNum(Q.sketchSize, l2.sharedSketchSize);
-              float nucIdentityUpperBound = 1 - Stat::md_lower_bound(mash_dist, Q.sketchSize, param.kmerSize, skch::fixed::confidence_interval);
-
-              //Report the alignment if it passes our identity threshold and,
-              // if we are in all-vs-all mode, it isn't a self-mapping,
-              // and if we are self-mapping, the query is shorter than the target
-              const auto& ref = this->idManager->getContigInfo(l2.seqId);
-              if((param.keep_low_pct_id && nucIdentityUpperBound >= param.percentageIdentity)
-                  || nucIdentity >= param.percentageIdentity)
-              {
-                //Track the best jaccard numerator
-                bestJaccardNumerator = std::max<double>(bestJaccardNumerator, l2.sharedSketchSize);
-
-                MappingResult res;
-
-                //Save the output
-                {
-                  res.queryLen = Q.len;
-                  res.refStartPos = l2.meanOptimalPos;
-                  res.refEndPos = l2.meanOptimalPos + Q.len;
-                  res.queryStartPos = 0;
-                  res.queryEndPos = Q.len;
-                  res.refSeqId = l2.seqId;
-                  res.querySeqId = Q.seqId;
-                  res.nucIdentity = nucIdentity;
-                  res.nucIdentityUpperBound = nucIdentityUpperBound;
-                  res.sketchSize = Q.sketchSize;
-                  res.conservedSketches = l2.sharedSketchSize;
-                  res.blockLength = std::max(res.refEndPos - res.refStartPos, res.queryEndPos - res.queryStartPos);
-                  res.approxMatches = std::round(res.nucIdentity * res.blockLength / 100.0);
-                  res.strand = l2.strand; 
-                  res.kmerComplexity = Q.kmerComplexity;
-
-                  res.selfMapFilter = ((param.skip_self || param.skip_prefix) && Q.fullLen > ref.len);
-
-                } 
-                l2Mappings.push_back(res);
-              }
-            }
-
-            if (param.stage1_topANI_filter) 
-            {
-              std::pop_heap(l1_begin, l1_end, L1_locus_intersection_cmp); 
-              l1_end--; //"Pop back" 
-            }
-            else 
-            {
-              loc_iterator++;
-            }
-          }
-          //std::cerr << "For an segment with " << l1Mappings.size()
-            //<< " L1 mappings "
-            //<< " there were " << l2Mappings.size() << " L2 mappings\n";
-        }
-
-      /**
-       * @brief                                 Find optimal mapping within an L1 candidate
-       * @param[in]   Q                         query sequence information
-       * @param[in]   candidateLocus            L1 candidate location
-       * @param[out]  l2_out                    L2 mapping inside L1 candidate
-       */
-      template <typename Q_Info, typename Vec>
-        void computeL2MappedRegions(Q_Info &Q,
-            L1_candidateLocus_t &candidateLocus,
-            Vec &l2_vec_out)
-        {
-#ifdef DEBUG
-          //std::cerr << "INFO, skch::Map:computeL2MappedRegions, read id " << Q.seqName << "_" << Q.startPos << std::endl; 
-#endif
-           
-          auto& minmerIndex = refSketch->minmerIndex;
-
-          //candidateLocus.rangeStartPos -= param.segLength;
-          //candidateLocus.rangeEndPos += param.segLength;
-          
-          // Get first potential mashimizer
-          const MinmerInfo first_minmer = MinmerInfo {0, candidateLocus.rangeStartPos - param.segLength - 1, 0, candidateLocus.seqId, 0};
-
-          //const MinmerInfo first_minmer = MinmerInfo {0, candidateLocus.seqId, -1, 0, 0};
-          auto firstOpenIt = std::lower_bound(minmerIndex.begin(), minmerIndex.end(), first_minmer); 
-
-          // Keeps track of the lowest end position
-          std::vector<skch::MinmerInfo> slidingWindow;
-          slidingWindow.reserve(Q.sketchSize);
-
-          // Used to make a min-heap
-          constexpr auto heap_cmp = [](const skch::MinmerInfo& l, const skch::MinmerInfo& r) {return l.wpos_end > r.wpos_end;};
-
-          // windowIt keeps track of the end of window
-          auto windowIt = firstOpenIt;
-
-          // Keep track of all minmer windows that intersect with [i, i+windowLen]
-          int windowLen = std::max<offset_t>(0, Q.len - param.segLength);
-
-          // Used to keep track of how many minmer windows for a particular hash are currently "open"
-          // Only necessary when windowLen != 0.
-          std::unordered_map<hash_t, int> hash_to_freq;
-          
-          // slideMap tracks the S(A or B) and S(A) and S(B)
-          SlideMapper<Q_Info> slideMap(Q);
-
-          offset_t beginOptimalPos = 0;
-          offset_t lastOptimalPos = 0;
-          int bestSketchSize = 1;
-          int bestIntersectionSize = 0;
-          bool in_candidate = false;
-          L2_mapLocus_t l2_out = {};
-
-          // Set up the window
-          while (windowIt != minmerIndex.end() && windowIt->seqId == candidateLocus.seqId && windowIt->wpos < candidateLocus.rangeStartPos) 
-          {
-            if (windowIt->wpos_end > candidateLocus.rangeStartPos) 
-            {
-              if (windowLen > 0) 
-              {
-                hash_to_freq[windowIt->hash]++;
-              }
-              if (windowLen == 0 || hash_to_freq[windowIt->hash] == 1) {
-                slidingWindow.push_back(*windowIt);
-                std::push_heap(slidingWindow.begin(), slidingWindow.end(), heap_cmp);
-                slideMap.insert_minmer(*windowIt);
-              }
-            }
-            windowIt++;
-          }
-
-          while (windowIt != minmerIndex.end() && windowIt->seqId == candidateLocus.seqId && windowIt->wpos <= candidateLocus.rangeEndPos + windowLen) 
-          {
-            int prev_strand_votes = slideMap.strand_votes;
-            bool inserted = false;
-            while (!slidingWindow.empty() && slidingWindow.front().wpos_end <= windowIt->wpos - windowLen) {
-
-              // Remove minmer from end-ordered heap
-              if (windowLen > 0) 
-              {
-                hash_to_freq[slidingWindow.front().hash]--;
-              }
-              if (windowLen == 0 || hash_to_freq[slidingWindow.front().hash] == 0) {
-                // Remove minmer from  sorted window
-                slideMap.delete_minmer(slidingWindow.front());
-                std::pop_heap(slidingWindow.begin(), slidingWindow.end(), heap_cmp);
-                slidingWindow.pop_back();
-              }
-
-            }
-            inserted = true;
-            if (windowLen > 0) 
-            {
-              hash_to_freq[windowIt->hash]++;
-            }
-            if (windowLen == 0 || hash_to_freq[windowIt->hash] == 1) {
-              slideMap.insert_minmer(*windowIt);
-              slidingWindow.push_back(*windowIt);
-              std::push_heap(slidingWindow.begin(), slidingWindow.end(), heap_cmp);
-            } else {
-              windowIt++;
-              continue;
-            }
-
-            bestIntersectionSize = std::max(bestIntersectionSize, slideMap.intersectionSize);
-
-            //Is this sliding window the best we have so far?
-            if (slideMap.sharedSketchElements > bestSketchSize)
-            {
-              // Get rid of all candidates seen so far
-              l2_vec_out.clear();
-
-              in_candidate = true;
-              bestSketchSize = slideMap.sharedSketchElements;
-              l2_out.sharedSketchSize = slideMap.sharedSketchElements;
-
-              //Save the position
-              l2_out.optimalStart = windowIt->wpos - windowLen;
-              l2_out.optimalEnd = windowIt->wpos - windowLen;
-            }
-            else if(slideMap.sharedSketchElements == bestSketchSize)
-            {
-              if (!in_candidate) {
-                l2_out.sharedSketchSize = slideMap.sharedSketchElements;
-
-                //Save the position
-                l2_out.optimalStart = windowIt->wpos - windowLen;
-              }
-
-              in_candidate = true;
-              //Still save the position
-              l2_out.optimalEnd = windowIt->wpos - windowLen;
-            } else {
-              if (in_candidate) {
-                // Save and reset
-                l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
-                l2_out.seqId = windowIt->seqId;
-                l2_out.strand = prev_strand_votes >= 0 ? strnd::FWD : strnd::REV;
-                if (l2_vec_out.empty() 
-                    || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
-                {
-                  l2_vec_out.push_back(l2_out);
-                }
-                else 
-                {
-                  l2_vec_out.back().optimalEnd = l2_out.optimalEnd;
-                  l2_vec_out.back().meanOptimalPos = (l2_vec_out.back().optimalStart + l2_vec_out.back().optimalEnd) / 2;
-                }
-                l2_out = L2_mapLocus_t();
-              }
-              in_candidate = false;
-            }
-            if (inserted) {
-              windowIt++;
-            }
-          }
-          if (in_candidate) {
-            // Save and reset
-            l2_out.meanOptimalPos =  (l2_out.optimalStart + l2_out.optimalEnd) / 2;
-            l2_out.seqId = std::prev(windowIt)->seqId;
-            l2_out.strand = slideMap.strand_votes >= 0 ? strnd::FWD : strnd::REV;
-            if (l2_vec_out.empty() 
-                || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
-            {
-              l2_vec_out.push_back(l2_out);
-            }
-            else 
-            {
-              l2_vec_out.back().optimalEnd = l2_out.optimalEnd;
-              l2_vec_out.back().meanOptimalPos = (l2_vec_out.back().optimalStart + l2_vec_out.back().optimalEnd) / 2;
-            }
-          }
-        }
-
-
-      /**
-       * @brief                       Merge the consecutive fragment mappings reported in each query
-       * @param[in/out] readMappings  Mappings computed by Mashmap (L2 stage) for a read
-       */
-      template <typename VecIn>
-        void expandMappings(VecIn &readMappings, int expansion)
-        {
-            for (auto& m : readMappings) {
-                m.refStartPos -= expansion;
-                m.refEndPos += expansion;
-                m.queryStartPos -= expansion;
-                m.queryEndPos += expansion;
-            }
-        }
-
-      void processMappingFragment(std::vector<MappingResult>::iterator start, std::vector<MappingResult>::iterator end) {
-          auto& fragment = *start; // We'll update the first mapping in the fragment
-
-          //std::cerr << "Processing fragment" << std::endl;
-          // Compute fragment information
-          for (auto it = start; it != end; ++it) {
-              //std::cerr << "Merging " << it->queryStartPos << " " << it->queryEndPos << " " 
-              //          << it->refStartPos << " " << it->refEndPos << " " << it->nucIdentity
-              //          << " " << (it->strand == strnd::FWD ? "+" : "-") << std::endl;
+      void doL2Mapping(Q_Info &Q, L1_Iter l1_begin, L1_Iter l1_end, VecOut &l2Mappings)
+      {
+        std::vector<L2_mapLocus_t> l2_vec;
+        double bestJaccardNumerator = 0;
+        auto loc_iterator = l1_begin;
         
-              fragment.queryStartPos = std::min(fragment.queryStartPos, it->queryStartPos);
-              fragment.refStartPos = std::min(fragment.refStartPos, it->refStartPos);
-              fragment.queryEndPos = std::max(fragment.queryEndPos, it->queryEndPos);
-              fragment.refEndPos = std::max(fragment.refEndPos, it->refEndPos);
-          }
-
-          fragment.blockLength = std::max(fragment.refEndPos - fragment.refStartPos, fragment.queryEndPos - fragment.queryStartPos);
-          //fragment.blockLength = fragment.queryEndPos - fragment.queryStartPos;
-                                          
-          fragment.approxMatches = std::round(fragment.nucIdentity * fragment.blockLength / 100.0);
-
-          fragment.n_merged = std::distance(start, end);
-
-          // Calculate mean nucleotide identity
-          fragment.nucIdentity = std::accumulate(start, end, 0.0,
-                                                 [](double sum, const MappingResult& e) { return sum + e.nucIdentity; }
-              ) / fragment.n_merged;
-
-          // Calculate mean kmer complexity
-          fragment.kmerComplexity = std::accumulate(start, end, 0.0,
-                                                    [](double sum, const MappingResult& e) { return sum + e.kmerComplexity; }
-              ) / fragment.n_merged;
-
-          // Mark other mappings in this fragment for discard
-          std::for_each(std::next(start), end, [](MappingResult& e) { e.discard = 1; });
-      }
-
-      void adjustConsecutiveMappings(std::vector<MappingResult>::iterator begin_maping,
-                                     std::vector<MappingResult>::iterator end_mapping,
-                                     const int threshold) {
-
-          if (std::distance(begin_maping, end_mapping) < 2) return;
-
-          //for (size_t i = 1; i < mappings.size(); ++i) {
-          for (auto it = std::next(begin_maping); it != end_mapping; ++it) {
-              auto& prev = *std::prev(it);
-              auto& curr = *it;
-
-              // Check if mappings are on the same reference sequence
-              if (prev.refSeqId != curr.refSeqId
-                  || prev.strand != curr.strand) continue;
-
-              // Calculate gaps
-              int query_gap = curr.queryStartPos - prev.queryEndPos;
-              int ref_gap = curr.refStartPos - prev.refEndPos;
-
-              // Check if both gaps are >0 and within the threshold
-              if (query_gap > 0 && ref_gap > 0 && query_gap <= threshold && ref_gap <= threshold) {
-                  // Calculate midpoints
-                  int query_mid = (prev.queryEndPos + curr.queryStartPos) / 2;
-                  int ref_mid = (prev.refEndPos + curr.refStartPos) / 2;
-
-                  // Adjust the mappings
-                  prev.queryEndPos = query_mid;
-                  prev.refEndPos = ref_mid;
-                  curr.queryStartPos = query_mid;
-                  curr.refStartPos = ref_mid;
-
-                  // Update block lengths
-                  prev.blockLength = std::max(prev.refEndPos - prev.refStartPos, 
-                                              prev.queryEndPos - prev.queryStartPos);
-                  curr.blockLength = std::max(curr.refEndPos - curr.refStartPos, 
-                                              curr.queryEndPos - curr.queryStartPos);
-
-                  // Update approximate matches
-                  prev.approxMatches = std::round(prev.nucIdentity * prev.blockLength / 100.0);
-                  curr.approxMatches = std::round(curr.nucIdentity * curr.blockLength / 100.0);
-              }
-          }
-      }
-
-      double axis_weighted_euclidean_distance(int64_t dx, int64_t dy, double w = 0.5) {
-          double euclidean = std::sqrt(dx*dx + dy*dy);
-          double axis_factor = 1.0 - (2.0 * std::min(std::abs(dx), std::abs(dy))) / (std::abs(dx) + std::abs(dy));
-          return euclidean * (1.0 + w * axis_factor);
-      }
-
-      /**
-       * @brief                       Filter maximally merged mappings
-       * @param[in]   readMappings    Merged mappings computed by Mashmap
-       * @param[in]   param           Algorithm parameters
-       * @return                      Filtered mappings
-       */
-
-      // Helper to compute orientation score for a mapping
-      double computeOrientationScore(const MappingResult& m) {
-          int64_t q_span = m.queryEndPos - m.queryStartPos;
-          int64_t r_span = m.refEndPos - m.refStartPos;
-          double diag_proj = (r_span + q_span) / std::sqrt(2.0);
-          double anti_proj = (r_span - q_span) / std::sqrt(2.0);
-          return std::abs(anti_proj / diag_proj);
-      }
-
-      // Event types for sweep line algorithm
-      enum EventType { START, END };
-      enum MappingType { SCAFFOLD, RAW };
-
-      struct Event {
-          double u;  // u-coordinate
-          EventType type;
-          MappingType mappingType;
-          double v_min, v_max;
-          size_t id;
-          
-          bool operator<(const Event& other) const {
-              if (u != other.u) return u < other.u;
-              // If u-coords are equal, process START before END
-              if (type != other.type) return type < other.type;
-              // If both are START or both are END, process scaffolds first
-              return mappingType < other.mappingType;
-          }
-      };
-
-      // Helper to determine if a group should use antidiagonal projection
-      bool shouldUseAntidiagonal(const std::vector<MappingResult>& mappings) {
-          double total_weight = 0.0;
-          double weighted_score = 0.0;
-          for (const auto& m : mappings) {
-              double weight = m.queryEndPos - m.queryStartPos;
-              total_weight += weight;
-              weighted_score += weight * computeOrientationScore(m);
-          }
-          return (weighted_score / total_weight) > 1.0;
-      }
-
-      struct RotatedEnvelope {
-          double u_start;
-          double u_end;
-          double v_min;
-          double v_max;
-          bool antidiagonal;
-      };
-
-
-      // Interval tree node for v-coordinate ranges
-      struct Interval {
-          double low, high;
-          size_t id;
-          
-          bool operator<(const Interval& other) const {
-              return low < other.low;
-          }
-      };
-
-      class IntervalTree {
-          std::set<Interval> intervals;
-
-      public:
-          void insert(double low, double high, size_t id) {
-              intervals.insert({low, high, id});
-          }
-
-          void remove(double low, double high, size_t id) {
-              intervals.erase({low, high, id});
-          }
-
-          // Returns vector of IDs of all intervals that overlap [low, high]
-          std::vector<size_t> findOverlapping(double low, double high) const {
-              std::vector<size_t> result;
-              
-              // Find first interval that could overlap
-              auto it = intervals.upper_bound({low, 0, 0});
-              if (it != intervals.begin()) --it;
-              
-              // Collect all overlapping intervals
-              while (it != intervals.end() && it->low <= high) {
-                  if (!(it->high < low || it->low > high)) {
-                      result.push_back(it->id);
-                  }
-                  ++it;
-              }
-              return result;
-          }
-
-          bool hasOverlap(double low, double high) const {
-              auto it = intervals.upper_bound({low, 0, 0});
-              if (it != intervals.begin()) --it;
-              
-              while (it != intervals.end() && it->low <= high) {
-                  if (!(it->high < low || it->low > high)) {
-                      return true;
-                  }
-                  ++it;
-              }
-              return false;
-          }
-      };
-
-      RotatedEnvelope computeRotatedEnvelope(const MappingResult& m, bool use_antidiagonal) {
-          const double invSqrt2 = 1.0 / std::sqrt(2.0);
-          double u_start, u_end, v1, v2;
-               
-          if (!use_antidiagonal) {
-              // Standard diagonal projection
-              u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
-              u_end   = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
-              v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
-              v2 = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
-          } else {
-              // Antidiagonal projection
-              u_start = (m.refStartPos - m.queryStartPos) * invSqrt2;
-              u_end   = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
-              v1 = (m.queryStartPos + m.refStartPos) * invSqrt2;
-              v2 = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
-          }
-               
-          double u_min = std::min(u_start, u_end);
-          double u_max = std::max(u_start, u_end);
-          double v_min = std::min(v1, v2) - param.scaffold_max_deviation;
-          double v_max = std::max(v1, v2) + param.scaffold_max_deviation;
-          return { u_min, u_max, v_min, v_max, use_antidiagonal };
-      }
-
-      // Helper to check if an envelope fits within scaffold bounds
-      bool envelopeFits(const RotatedEnvelope& env, const RotatedEnvelope& scaffold) {
-          return env.u_start >= scaffold.u_start && env.u_end <= scaffold.u_end &&
-                 env.v_min >= scaffold.v_min && env.v_max <= scaffold.v_max;
-      }
-
-      // Helper to compute rotated coordinates for a mapping
-      std::tuple<double, double, double, double> computeRotatedCoords(const MappingResult& m, bool use_antidiagonal) {
-          const double invSqrt2 = 1.0 / std::sqrt(2.0);
-          double u_start, u_end, v1, v2;
-          
-          if (!use_antidiagonal) {
-              u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
-              u_end = (m.queryEndPos + m.refEndPos) * invSqrt2;
-              v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
-              v2 = (m.refEndPos - m.queryEndPos) * invSqrt2;
-          } else {
-              u_start = (m.refStartPos - m.queryStartPos) * invSqrt2;
-              u_end = (m.refEndPos - m.queryEndPos) * invSqrt2;
-              v1 = (m.queryStartPos + m.refStartPos) * invSqrt2;
-              v2 = (m.queryEndPos + m.refEndPos) * invSqrt2;
-          }
-          
-          return std::make_tuple(
-              std::min(u_start, u_end),
-              std::max(u_start, u_end),
-              std::min(v1, v2),
-              std::max(v1, v2)
-          );
-      }
-
-      void filterScaffoldCandidates(MappingResultsVector_t& scaffoldCandidates,
-                                    const MappingResultsVector_t& mergedMappings,
-                                    const Parameters& param,
-                                    progress_meter::ProgressMeter& progress) 
-      {
-          robin_hood::unordered_set<offset_t> acceptedChains;
-          RotatedEnvelope scaffoldEnvelope;
-          // Group mappings by query and reference sequence
-          struct GroupKey {
-              seqno_t querySeqId;
-              seqno_t refSeqId;
-              bool operator==(const GroupKey &other) const {
-                  return querySeqId == other.querySeqId && refSeqId == other.refSeqId;
-              }
-          };
-          struct GroupKeyHash {
-              std::size_t operator()(const GroupKey &k) const {
-                  auto h1 = std::hash<seqno_t>()(k.querySeqId);
-                  auto h2 = std::hash<seqno_t>()(k.refSeqId);
-                  return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
-              }
-          };
-
-          // Partition mappings into groups
-          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> groups;
-          for (const auto& m : scaffoldCandidates) {
-              GroupKey key { m.querySeqId, m.refSeqId };
-              groups[key].push_back(m);
-          }
-
-          // First process maximal merged mappings to identify accepted chains
-          for (const auto& mergedMapping : mergedMappings) {
-              RotatedEnvelope env = computeRotatedEnvelope(mergedMapping, shouldUseAntidiagonal({mergedMapping}));
-              if (envelopeFits(env, scaffoldEnvelope)) {
-                  acceptedChains.insert(mergedMapping.splitMappingId);
-              }
-          }
-
-          // Process each group with plane sweep, skipping accepted chains
-          MappingResultsVector_t filteredMappings;
-          for (const auto& kv : groups) {
-              const auto& group = kv.second;
-              
-              // Skip processing if all mappings in this group belong to accepted chains
-              bool all_accepted = std::all_of(group.begin(), group.end(),
-                  [&acceptedChains](const MappingResult& m) {
-                      return acceptedChains.count(m.splitMappingId) > 0;
-                  });
-              
-              if (all_accepted) {
-                  // Add all mappings from accepted chains to filtered results
-                  filteredMappings.insert(filteredMappings.end(), group.begin(), group.end());
-                  continue;
-              }
-
-              bool use_antidiagonal = shouldUseAntidiagonal(group);
-              std::vector<bool> keep(group.size(), false);
-
-              // Mark mappings from accepted chains as kept
-              for (size_t i = 0; i < group.size(); i++) {
-                  if (acceptedChains.count(group[i].splitMappingId) > 0) {
-                      keep[i] = true;
-                  }
-              }
-
-              // Process remaining mappings with plane sweep
-              IntervalTree activeRaws;
-              
-              // First pass - collect all raw mappings that don't overlap with scaffolds
-              for (size_t i = 0; i < group.size(); i++) {
-                  if (!keep[i]) {  // Skip already kept mappings
-                      auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(group[i], use_antidiagonal);
-                      activeRaws.insert(v_min, v_max, i);
-                  }
-              }
-
-              // Second pass - find overlaps between raw mappings
-              for (size_t i = 0; i < group.size(); i++) {
-                  if (!keep[i]) {  // Skip already kept mappings
-                      auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(group[i], use_antidiagonal);
-                      
-                      // Find all raw mappings that overlap with this one
-                      auto overlapping = activeRaws.findOverlapping(v_min, v_max);
-                      
-                      // Keep the mapping with the highest nucleotide identity
-                      bool is_best = true;
-                      for (auto other_id : overlapping) {
-                          if (other_id != i && group[other_id].nucIdentity > group[i].nucIdentity) {
-                              is_best = false;
-                              break;
-                          }
-                      }
-                      
-                      if (is_best) {
-                          keep[i] = true;
-                      }
-                  }
-              }
-
-              // Collect mappings that passed filtering
-              for (size_t i = 0; i < group.size(); i++) {
-                  if (keep[i]) {
-                      filteredMappings.push_back(group[i]);
-                  }
-              }
-          }
-
-          // Replace input with filtered results
-          scaffoldCandidates = std::move(filteredMappings);
-      }
-
-      void filterByScaffolds(MappingResultsVector_t& readMappings,
-                            const MappingResultsVector_t& mergedMappings,
-                            const Parameters& param,
-                            progress_meter::ProgressMeter& progress) 
-      {
-          // If scaffold filtering is disabled, do nothing.
-          if (param.scaffold_gap == 0 && param.scaffold_min_length == 0 && param.scaffold_max_deviation == 0) {
-              return;
-          }
-
-          // Build scaffold mappings from the maximally merged mappings
-          MappingResultsVector_t scaffoldMappings = mergedMappings;
-
-          // Merge with aggressive gap to create scaffolds
-          Parameters scaffoldParam = param;
-          scaffoldParam.chain_gap *= 2;  // More aggressive merging for scaffolds
-          auto superChains = mergeMappingsInRange(scaffoldMappings, scaffoldParam.chain_gap, progress);
-          filterMaximallyMerged(superChains, std::floor(param.scaffold_min_length / param.segLength), progress);
-
-          // Expand scaffold mappings by half the max deviation on each end
-          for (auto& mapping : superChains) {
-              int64_t expansion = param.scaffold_max_deviation / 2;
-              mapping.refStartPos = std::max<int64_t>(0, mapping.refStartPos - expansion);
-              mapping.refEndPos = std::min<int64_t>(idManager->getSequenceLength(mapping.refSeqId),
-                                                   mapping.refEndPos + expansion);
-              mapping.queryStartPos = std::max<int64_t>(0, mapping.queryStartPos - expansion);
-              mapping.queryEndPos = std::min<int64_t>(mapping.queryLen, mapping.queryEndPos + expansion);
-              mapping.blockLength = std::max(mapping.refEndPos - mapping.refStartPos,
-                                           mapping.queryEndPos - mapping.queryStartPos);
-          }
-
-          /* Optionally, write scaffold mappings to file for debugging
-          if (!superChains.empty() &&
-              (param.scaffold_gap > 0 || param.scaffold_min_length > 0 || param.scaffold_max_deviation > 0)) {
-              std::ofstream scafOutstrm("scaf.paf", std::ios::app);
-              reportReadMappings(superChains, idManager->getSequenceName(superChains.front().querySeqId), scafOutstrm);
-          }
-          */
-
-          // Group mappings by query and reference sequence
-          struct GroupKey {
-              seqno_t querySeqId;
-              seqno_t refSeqId;
-              bool operator==(const GroupKey &other) const {
-                  return querySeqId == other.querySeqId && refSeqId == other.refSeqId;
-              }
-          };
-          struct GroupKeyHash {
-              std::size_t operator()(const GroupKey &k) const {
-                  auto h1 = std::hash<seqno_t>()(k.querySeqId);
-                  auto h2 = std::hash<seqno_t>()(k.refSeqId);
-                  return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
-              }
-          };
-
-          // Partition raw mappings and scaffold mappings into groups
-          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> rawGroups;
-          std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> scafGroups;
-          for (const auto& m : readMappings) {
-               GroupKey key { m.querySeqId, m.refSeqId };
-               rawGroups[key].push_back(m);
-          }
-          for (const auto& m : superChains) {
-               GroupKey key { m.querySeqId, m.refSeqId };
-               scafGroups[key].push_back(m);
-          }
-
-          // Helper to compute weighted orientation score for a mapping
-          auto computeOrientationScore = [](const MappingResult& m) -> double {
-              int64_t q_span = m.queryEndPos - m.queryStartPos;
-              int64_t r_span = m.refEndPos - m.refStartPos;
-              double diag_proj = (r_span + q_span) / std::sqrt(2.0);
-              double anti_proj = (r_span - q_span) / std::sqrt(2.0);
-              return std::abs(anti_proj / diag_proj);
-          };
-
-          // Process each group with 2D sweep
-          MappingResultsVector_t filteredMappings;
-          for (const auto& kv : rawGroups) {
-              const GroupKey& key = kv.first;
-              const auto& groupRaw = kv.second;
-              
-              if (scafGroups.find(key) == scafGroups.end()) {
-                  continue;  // No scaffold mappings for this group
-              }
-              const auto& groupScaf = scafGroups[key];
-
-              // Determine projection type for this group
-              bool use_antidiagonal = shouldUseAntidiagonal(groupScaf);
-
-              // Generate events for both scaffold and raw mappings
-              std::vector<Event> events;
-              std::vector<bool> keep(groupRaw.size(), false);
-
-              // Helper to compute rotated coordinates
-              auto computeRotatedCoords = [use_antidiagonal](const MappingResult& m) {
-                  const double invSqrt2 = 1.0 / std::sqrt(2.0);
-                  double u_start, u_end, v1, v2;
-                  
-                  if (!use_antidiagonal) {
-                      u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
-                      u_end = (m.queryEndPos + m.refEndPos) * invSqrt2;
-                      v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
-                      v2 = (m.refEndPos - m.queryEndPos) * invSqrt2;
-                  } else {
-                      u_start = (m.refStartPos - m.queryStartPos) * invSqrt2;
-                      u_end = (m.refEndPos - m.queryEndPos) * invSqrt2;
-                      v1 = (m.queryStartPos + m.refStartPos) * invSqrt2;
-                      v2 = (m.queryEndPos + m.refEndPos) * invSqrt2;
-                  }
-                  
-                  return std::make_tuple(
-                      std::min(u_start, u_end),
-                      std::max(u_start, u_end),
-                      std::min(v1, v2),
-                      std::max(v1, v2)
-                  );
-              };
-
-              // Generate events for scaffolds
-              for (size_t i = 0; i < groupScaf.size(); i++) {
-                  auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(groupScaf[i]);
-                  v_min -= param.scaffold_max_deviation;
-                  v_max += param.scaffold_max_deviation;
-                  events.push_back(Event{u_min, START, SCAFFOLD, v_min, v_max, i});
-                  events.push_back(Event{u_max, END, SCAFFOLD, v_min, v_max, i});
-              }
-
-              // Generate events for raw mappings
-              for (size_t i = 0; i < groupRaw.size(); i++) {
-                  auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(groupRaw[i]);
-                  events.push_back(Event{u_min, START, RAW, v_min, v_max, i});
-                  events.push_back(Event{u_max, END, RAW, v_min, v_max, i});
-              }
-
-              // Sort events
-              std::sort(events.begin(), events.end());
-
-              // Process events with two active sets
-              IntervalTree activeScaffolds;
-              IntervalTree activeRaws;
-
-              for (const auto& event : events) {
-                  if (event.type == START && event.mappingType == SCAFFOLD) {
-                      activeScaffolds.insert(event.v_min, event.v_max, event.id);
-                      // Get all overlapping raw mappings efficiently
-                      auto overlapping = activeRaws.findOverlapping(event.v_min, event.v_max);
-                      for (auto raw_id : overlapping) {
-                          keep[raw_id] = true;
-                      }
-                  } else if (event.type == END && event.mappingType == SCAFFOLD) {
-                      activeScaffolds.remove(event.v_min, event.v_max, event.id);
-                  } else if (event.type == START && event.mappingType == RAW) {
-                      if (!keep[event.id]) {  // Only process if not already kept
-                          if (activeScaffolds.hasOverlap(event.v_min, event.v_max)) {
-                              keep[event.id] = true;
-                          } else {
-                              activeRaws.insert(event.v_min, event.v_max, event.id);
-                          }
-                      }
-                  } else if (event.type == END && event.mappingType == RAW) {
-                      if (!keep[event.id]) {  // Only remove if we actually inserted it
-                          activeRaws.remove(event.v_min, event.v_max, event.id);
-                      }
-                  }
-              }
-
-              // Collect mappings that passed filtering
-              for (size_t i = 0; i < groupRaw.size(); i++) {
-                  if (keep[i]) {
-                      filteredMappings.push_back(groupRaw[i]);
-                  }
-              }
-          }
-
-          // Replace original mappings with filtered ones
-          readMappings = std::move(filteredMappings);
-
-          // For raw mappings within a group we keep track of their envelope plus index.
-
-          // Interval tree node for v-coordinate ranges
-          struct Interval {
-              double low, high;
-              size_t id;
-              
-              bool operator<(const Interval& other) const {
-                  return low < other.low;
-              }
-          };
-
-          class IntervalTree {
-              std::set<Interval> intervals;
-
-          public:
-              void insert(double low, double high, size_t id) {
-                  intervals.insert({low, high, id});
-              }
-
-              void remove(double low, double high, size_t id) {
-                  intervals.erase({low, high, id});
-              }
-
-              bool hasOverlap(double low, double high) const {
-                  // Find first interval that could overlap
-                  auto it = intervals.upper_bound({low, 0, 0});
-                  if (it != intervals.begin()) --it;
-                  
-                  // Check all potentially overlapping intervals
-                  while (it != intervals.end() && it->low <= high) {
-                      if (!(it->high < low || it->low > high)) {
-                          return true;
-                      }
-                      ++it;
-                  }
-                  return false;
-              }
-          };
-
-          struct RawEnv {
-               RotatedEnvelope env;
-               size_t index; // index within the group vector
-          };
-
-          // --- Process Each Group Separately ---
-          for (auto& kv : rawGroups) {
-               const GroupKey &key = kv.first;
-               auto& groupRaw = kv.second;
-               if (scafGroups.find(key) == scafGroups.end()) {
-                   // No scaffold mappings available for this (query, ref, strand) group.
-                   continue;
-               }
-               const auto& groupScaf = scafGroups[key];
-
-               // Determine projection type for this group
-               bool use_antidiagonal = shouldUseAntidiagonal(groupScaf);
-               
-               // Compute rotated envelopes for scaffold mappings in this group.
-               std::vector<RotatedEnvelope> scaffoldEnvelopes;
-               for (const auto& m : groupScaf) {
-                    scaffoldEnvelopes.push_back(computeRotatedEnvelope(m, use_antidiagonal));
-               }
-               std::sort(scaffoldEnvelopes.begin(), scaffoldEnvelopes.end(),
-                         [](const RotatedEnvelope& a, const RotatedEnvelope& b) {
-                               return a.u_start < b.u_start;
-                         });
-
-               // Compute envelopes for raw mappings in this group.
-               std::vector<RawEnv> rawEnvs;
-               for (size_t i = 0; i < groupRaw.size(); i++) {
-                    RawEnv env;
-                    env.env = computeRotatedEnvelope(groupRaw[i], use_antidiagonal);
-                    env.index = i;
-                    rawEnvs.push_back(env);
-               }
-               std::sort(rawEnvs.begin(), rawEnvs.end(),
-                         [](const RawEnv& a, const RawEnv& b) {
-                               return a.env.u_start < b.env.u_start;
-                         });
-
-               // --- 2D Sweep-Line with Interval Tree ---
-               std::vector<Event> events;
-               IntervalTree activeScaffolds;
-               std::vector<bool> keep(rawEnvs.size(), false);
-
-               // Generate events for both scaffold and raw envelopes
-               for (size_t i = 0; i < scaffoldEnvelopes.size(); i++) {
-                    const auto& scaf = scaffoldEnvelopes[i];
-                    events.push_back(Event{scaf.u_start, START, SCAFFOLD, scaf.v_min, scaf.v_max, i});
-                    events.push_back(Event{scaf.u_end, END, SCAFFOLD, scaf.v_min, scaf.v_max, i});
-               }
-               for (size_t i = 0; i < rawEnvs.size(); i++) {
-                    const auto& raw = rawEnvs[i].env;
-                    events.push_back(Event{raw.u_start, START, RAW, raw.v_min, raw.v_max, i});
-                    events.push_back(Event{raw.u_end, END, RAW, raw.v_min, raw.v_max, i});
-               }
-
-               // Sort events by u-coordinate (and type/mapping type for ties)
-               std::sort(events.begin(), events.end());
-
-               // Process events in order
-               for (const auto& event : events) {
-                    if (event.mappingType == SCAFFOLD) {
-                         if (event.type == START) {
-                              activeScaffolds.insert(event.v_min, event.v_max, event.id);
-                         } else {
-                              activeScaffolds.remove(event.v_min, event.v_max, event.id);
-                         }
-                    } else { // RAW mapping
-                         if (event.type == START) {
-                              // Check if this raw mapping overlaps any active scaffold
-                              if (activeScaffolds.hasOverlap(event.v_min, event.v_max)) {
-                                   /* Debug output for envelope matches
-                                   std::cerr << "\nFound mapping within scaffold envelope:"
-                                            << "\nRaw mapping:"
-                                            << "\n  Query: [" << groupRaw[event.id].queryStartPos 
-                                            << ", " << groupRaw[event.id].queryEndPos << "]"
-                                            << "\n  Target: [" << groupRaw[event.id].refStartPos 
-                                            << ", " << groupRaw[event.id].refEndPos << "]"
-                                            << "\n  Rotated coords:"
-                                            << "\n    u: [" << rawEnvs[event.id].env.u_start 
-                                            << ", " << rawEnvs[event.id].env.u_end << "]"
-                                            << "\n    v: [" << event.v_min << ", " << event.v_max << "]\n";
-                                   */
-                                   keep[event.id] = true;
-                              } else {
-                                   /* Debug output for discarded mappings
-                                   std::cerr << "\nDiscarding mapping outside scaffold envelope:"
-                                            << "\n  Query: [" << groupRaw[event.id].queryStartPos 
-                                            << ", " << groupRaw[event.id].queryEndPos << "]"
-                                            << "\n  Target: [" << groupRaw[event.id].refStartPos 
-                                            << ", " << groupRaw[event.id].refEndPos << "]"
-                                            << "\n  Rotated coords:"
-                                            << "\n    u: [" << rawEnvs[event.id].env.u_start 
-                                            << ", " << rawEnvs[event.id].env.u_end << "]"
-                                            << "\n    v: [" << event.v_min << ", " << event.v_max << "]\n";
-                                   */
-                              }
-                         }
-                    }
-               }
-               // Collect raw mappings that passed for this group.
-               for (size_t i = 0; i < rawEnvs.size(); i++) {
-                    if (keep[i])
-                         filteredMappings.push_back(groupRaw[rawEnvs[i].index]);
-               }
-          }
-          readMappings = std::move(filteredMappings);
-      }
-
-      void filterMaximallyMerged(MappingResultsVector_t& readMappings,
-                                 const int64_t min_mapping_count,
-                                 progress_meter::ProgressMeter& progress)
-      {
-          // Just keep basic filtering
-          filterWeakMappings(readMappings, min_mapping_count);
-
-          // Apply group filtering if necessary
-          if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {
-              MappingResultsVector_t groupFilteredMappings;
-              filterByGroup(readMappings, groupFilteredMappings, param.numMappingsForSegment - 1, false, *idManager, progress);
-              readMappings = std::move(groupFilteredMappings);
-          }
-
-          if (param.filterLengthMismatches) {
-              filterFalseHighIdentity(readMappings);
-          }
-          
-          sparsifyMappings(readMappings);
-      }
-
-/**
- * @brief Merge mappings within a specified range using optimized grouping and binary search.
- * @param readMappings Vector of MappingResult objects to be merged.
- * @param max_dist Maximum distance for merging in query and reference space.
- * @param progress Progress meter for tracking progress.
- * @return Vector of maximally merged mappings.
- */
-template <typename VecIn>
-VecIn mergeMappingsInRange(VecIn &readMappings,
-                           int max_dist,
-                           progress_meter::ProgressMeter& progress) {
-    // Early return if splitting is disabled or insufficient mappings
-    if (!param.split || readMappings.size() < 2) return readMappings;
-
-    // Step 1: Sort by refSeqId, strand, queryStartPos, and refStartPos
-    std::sort(readMappings.begin(), readMappings.end(),
-        [](const MappingResult &a, const MappingResult &b) {
-            return std::tie(a.refSeqId, a.strand, a.queryStartPos, a.refStartPos)
-                 < std::tie(b.refSeqId, b.strand, b.queryStartPos, b.refStartPos);
-        });
-
-    // Assign unique splitMappingId and initialize fields
-    for (auto it = readMappings.begin(); it != readMappings.end(); ++it) {
-        it->splitMappingId = std::distance(readMappings.begin(), it);
-        it->discard = 0;
-        it->chainPairScore = std::numeric_limits<double>::max();
-        it->chainPairId = std::numeric_limits<int64_t>::min();
-    }
-
-    // Set up union-find data structure for efficient merging
-    std::vector<dsets::DisjointSets::Aint> ufv(readMappings.size());
-    // This initializes everything
-    auto disjoint_sets = dsets::DisjointSets(ufv.data(), ufv.size());
-
-    // Step 2: Process each group (same refSeqId and strand)
-    auto group_begin = readMappings.begin();
-    while (group_begin != readMappings.end()) {
-        auto group_end = std::find_if_not(group_begin, readMappings.end(),
-            [refSeqId = group_begin->refSeqId, strand = group_begin->strand](const MappingResult &m) {
-                return m.refSeqId == refSeqId && m.strand == strand;
-            });
-
-        // Process mappings within the group
-        for (auto it = group_begin; it != group_end; ++it) {
-            if (it->chainPairScore != std::numeric_limits<double>::max()) {
-                disjoint_sets.unite(it->splitMappingId, it->chainPairId);
+        while (loc_iterator != l1_end)
+        {
+          L1_candidateLocus_t& candidateLocus = *loc_iterator;
+
+          if (param.stage1_topANI_filter)
+          {
+            double jaccardSimilarity = refSketch->hgNumerator / Q.sketchSize;
+            double mash_dist = Stat::j2md(jaccardSimilarity, param.kmerSize);
+            double cutoff_ani = std::max(0.0, (1 - mash_dist) - param.ANIDiff);
+            double cutoff_j = Stat::md2j(1 - cutoff_ani, param.kmerSize);
+            double candidateJaccard = static_cast<double>(candidateLocus.intersectionSize) / Q.sketchSize;
+
+            if (candidateJaccard < cutoff_j) 
+            {
+              break;
             }
-            double best_score = std::numeric_limits<double>::max();
-            auto best_it2 = group_end;
+          }
 
-            // Step 3: Use binary search to find range within max_dist
-            auto end_it2 = std::upper_bound(it + 1, group_end, it->queryEndPos + max_dist,
-                [](offset_t val, const MappingResult &m) {
-                    return val < m.queryStartPos;
-                });
+          l2_vec.clear();
+          CoreMapping::computeL2MappedRegions(Q, candidateLocus, l2_vec, refSketch, param);
 
-            // Check mappings within the range
-            for (auto it2 = it + 1; it2 != end_it2; ++it2) {
-                if (it2->queryStartPos == it->queryStartPos) continue;
-                int64_t query_dist = it2->queryStartPos - it->queryEndPos;
-                int64_t ref_dist = (it->strand == strnd::FWD) ? 
-                                   it2->refStartPos - it->refEndPos : 
-                                   it->refStartPos - it2->refEndPos;
-                // Check if the distance is within acceptable range
-                if (query_dist <= max_dist && ref_dist >= -param.segLength/5 && ref_dist <= max_dist) {
-                    double dist_sq = static_cast<double>(query_dist) * query_dist + 
-                                     static_cast<double>(ref_dist) * ref_dist;
-                    double max_dist_sq = static_cast<double>(max_dist) * max_dist;
-                    if (dist_sq < max_dist_sq && dist_sq < best_score && dist_sq < it2->chainPairScore) {
-                        best_it2 = it2;
-                        best_score = dist_sq;
-                    }
-                }
+          for (auto& l2 : l2_vec) 
+          {
+            float mash_dist = Stat::j2md(1.0 * l2.sharedSketchSize/Q.sketchSize, param.kmerSize);
+            float nucIdentity = (1 - mash_dist);
+            float nucIdentityUpperBound = 1 - Stat::md_lower_bound(mash_dist, Q.sketchSize, param.kmerSize, skch::fixed::confidence_interval);
+
+            const auto& ref = this->idManager->getContigInfo(l2.seqId);
+            if((param.keep_low_pct_id && nucIdentityUpperBound >= param.percentageIdentity)
+                || nucIdentity >= param.percentageIdentity)
+            {
+              bestJaccardNumerator = std::max<double>(bestJaccardNumerator, l2.sharedSketchSize);
+
+              MappingResult res;
+              {
+                res.queryLen = Q.len;
+                res.refStartPos = l2.meanOptimalPos;
+                res.refEndPos = l2.meanOptimalPos + Q.len;
+                res.queryStartPos = 0;
+                res.queryEndPos = Q.len;
+                res.refSeqId = l2.seqId;
+                res.querySeqId = Q.seqId;
+                res.nucIdentity = nucIdentity;
+                res.nucIdentityUpperBound = nucIdentityUpperBound;
+                res.sketchSize = Q.sketchSize;
+                res.conservedSketches = l2.sharedSketchSize;
+                res.blockLength = std::max(res.refEndPos - res.refStartPos, res.queryEndPos - res.queryStartPos);
+                res.approxMatches = std::round(res.nucIdentity * res.blockLength / 100.0);
+                res.strand = l2.strand; 
+                res.kmerComplexity = Q.kmerComplexity;
+                res.selfMapFilter = ((param.skip_self || param.skip_prefix) && Q.fullLen > ref.len);
+              } 
+              l2Mappings.push_back(res);
             }
-            if (best_it2 != group_end) {
-                best_it2->chainPairScore = best_score;
-                best_it2->chainPairId = it->splitMappingId;
-            }
+          }
+
+          if (param.stage1_topANI_filter) 
+          {
+            std::pop_heap(l1_begin, l1_end, L1_locus_intersection_cmp); 
+            l1_end--;
+          }
+          else 
+          {
+            loc_iterator++;
+          }
         }
-        group_begin = group_end;
-    }
-
-    // Assign merged mapping IDs using union-find
-    for (auto &mapping : readMappings) {
-        mapping.splitMappingId = disjoint_sets.find(mapping.splitMappingId);
-    }
-
-    // Sort by merged splitMappingId, queryStartPos, and refStartPos
-    std::sort(readMappings.begin(), readMappings.end(),
-        [](const MappingResult &a, const MappingResult &b) {
-            return std::tie(a.splitMappingId, a.queryStartPos, a.refStartPos)
-                 < std::tie(b.splitMappingId, b.queryStartPos, b.refStartPos);
-        });
-
-    // Step 4: Create maximally merged mappings
-    MappingResultsVector_t maximallyMergedMappings;
-    for (auto it = readMappings.begin(); it != readMappings.end();) {
-        // Find the end of the current chain
-        auto it_end = std::find_if(it, readMappings.end(), 
-            [splitId = it->splitMappingId](const MappingResult &e) {
-                return e.splitMappingId != splitId;
-            });
-
-        // Process chain into fragments respecting max_mapping_length
-        auto fragment_start = it;
-        while (fragment_start != it_end) {
-            MappingResult mergedMapping = *fragment_start;
-            auto fragment_end = fragment_start;
-            auto next = std::next(fragment_end);
-           
-            // Always try to merge enough mappings to satisfy minimum block length
-            offset_t current_length = fragment_start->queryEndPos - fragment_start->queryStartPos;
-            
-            while (next != it_end) {
-                offset_t potential_length = next->queryEndPos - fragment_start->queryStartPos;
-                if (potential_length > param.max_mapping_length) break;
-                fragment_end = next;
-                current_length = potential_length;
-                next = std::next(next);
-            }
-
-            // Set merged mapping properties
-            mergedMapping.queryStartPos = fragment_start->queryStartPos;
-            mergedMapping.queryEndPos = fragment_end->queryEndPos;
-
-            // Handle reference coordinates based on strand
-            if (mergedMapping.strand == strnd::FWD) {
-                // Forward strand - use first mapping's start and last mapping's end
-                mergedMapping.refStartPos = fragment_start->refStartPos;
-                mergedMapping.refEndPos = fragment_end->refEndPos;
-            } else {
-                // Reverse strand - use last mapping's start (highest coordinate) and first mapping's end (lowest coordinate)
-                mergedMapping.refStartPos = fragment_end->refStartPos;
-                mergedMapping.refEndPos = fragment_start->refEndPos;
-            }
-            mergedMapping.blockLength = std::max(
-                mergedMapping.refEndPos - mergedMapping.refStartPos,
-                mergedMapping.queryEndPos - mergedMapping.queryStartPos
-            );
-
-            // Calculate averages for merged fragment
-            double totalNucIdentity = 0.0;
-            double totalKmerComplexity = 0.0;
-            int totalConservedSketches = 0;
-            int totalSketchSize = 0;
-            int fragment_size = 0;
-            for (auto subIt = fragment_start; subIt != std::next(fragment_end); ++subIt) {
-                totalNucIdentity += subIt->nucIdentity;
-                totalKmerComplexity += subIt->kmerComplexity;
-                totalConservedSketches += subIt->conservedSketches;
-                totalSketchSize += subIt->sketchSize;
-                fragment_size++;
-            }
-            mergedMapping.n_merged = fragment_size;
-            mergedMapping.nucIdentity = totalNucIdentity / fragment_size;
-            mergedMapping.kmerComplexity = totalKmerComplexity / fragment_size;
-            mergedMapping.conservedSketches = totalConservedSketches;
-            mergedMapping.sketchSize = totalSketchSize;
-            mergedMapping.blockNucIdentity = mergedMapping.nucIdentity;
-            mergedMapping.approxMatches = std::round(mergedMapping.nucIdentity * mergedMapping.blockLength / 100.0);
-            mergedMapping.discard = 0;
-            mergedMapping.overlapped = false;
-            mergedMapping.chainPairScore = std::numeric_limits<double>::max();
-            mergedMapping.chainPairId = std::numeric_limits<int64_t>::min();
-
-            maximallyMergedMappings.push_back(mergedMapping);
-
-            // Move to next fragment
-            fragment_start = std::next(fragment_end);
-        }
-
-        processChainWithSplits(it, it_end);
-
-        // Move to next chain
-        it = it_end;
-    }
-
-    // Step 5: Remove discarded mappings from readMappings
-    readMappings.erase(
-        std::remove_if(readMappings.begin(), readMappings.end(), 
-                       [](const MappingResult& e) { return e.discard == 1; }),
-        readMappings.end()
-    );
-
-    return maximallyMergedMappings;
-}
-      /**
-       * @brief Process a chain of mappings, potentially splitting it into smaller fragments
-       * @param begin Iterator to the start of the chain
-       * @param end Iterator to the end of the chain
-       */
-      void processChainWithSplits(std::vector<MappingResult>::iterator begin, std::vector<MappingResult>::iterator end) {
-          if (begin == end) return;
-
-          std::vector<bool> is_cuttable(std::distance(begin, end), true);
-          
-          // Mark positions that are not cuttable (near discontinuities)
-          for (auto it = std::next(begin); it != end; ++it) {
-              auto prev = std::prev(it);
-              if (it->queryStartPos - prev->queryEndPos > param.segLength / 5 ||
-                  it->refStartPos - prev->refEndPos > param.segLength / 5) {
-                  is_cuttable[std::distance(begin, prev)] = false;
-                  is_cuttable[std::distance(begin, it)] = false;
-              }
-          }
-
-          adjustConsecutiveMappings(begin, end, param.segLength);
-
-          auto fragment_start = begin;
-          offset_t accumulate_length = 0;
-
-          for (auto it = begin; it != end; ++it) {
-              accumulate_length += it->queryEndPos - it->queryStartPos;
-              
-              if (accumulate_length >= param.max_mapping_length && is_cuttable[std::distance(begin, it)]) {
-                  // Process the fragment up to this point
-                  processMappingFragment(fragment_start, std::next(it));
-                  
-                  // Start a new fragment
-                  fragment_start = std::next(it);
-                  accumulate_length = 0;
-              }
-          }
-
-          // Process any remaining fragment
-          if (fragment_start != end) {
-              processMappingFragment(fragment_start, end);
-          }
-
-          // Compute and assign chain statistics
-          computeChainStatistics(begin, end);
       }
 
       /**
-       * @brief Compute and assign chain statistics to all mappings in the chain
-       * @param begin Iterator to the start of the chain
-       * @param end Iterator to the end of the chain
+       * @brief Filter mappings for a subset before aggregation
        */
-      /**
-       * @brief Filter mappings within a subset before aggregation
-       * @param mappings Mappings to filter
-       * @param param Algorithm parameters
-       */
-      std::pair<MappingResultsVector_t, MappingResultsVector_t> filterSubsetMappings(MappingResultsVector_t& mappings, progress_meter::ProgressMeter& progress) {
+      std::pair<MappingResultsVector_t, MappingResultsVector_t> filterSubsetMappings(
+          MappingResultsVector_t& mappings, 
+          progress_meter::ProgressMeter& progress) 
+      {
           if (mappings.empty()) return {MappingResultsVector_t(), MappingResultsVector_t()};
 
-          // Make a copy of the raw mappings for scaffolding
           MappingResultsVector_t rawMappings = mappings;
           
-          // Only merge once and keep both versions
-          auto maximallyMergedMappings = mergeMappingsInRange(mappings, param.chain_gap, progress);
+          auto maximallyMergedMappings = FilterUtils::mergeMappingsInRange(mappings, param.chain_gap, param, progress);
 
-          // Process both merged and non-merged mappings
           if (param.mergeMappings && param.split) {
-              filterMaximallyMerged(maximallyMergedMappings, std::floor(param.block_length / param.segLength), progress);
-              // Also apply scaffold filtering to merged mappings
-              filterByScaffolds(maximallyMergedMappings, rawMappings, param, progress);
+              FilterUtils::filterWeakMappings(maximallyMergedMappings, 
+                  std::floor(param.block_length / param.segLength), param, *idManager);
+              
+              if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {
+                  MappingResultsVector_t groupFilteredMappings;
+                  FilterUtils::filterByGroup(maximallyMergedMappings, groupFilteredMappings, 
+                      param.numMappingsForSegment - 1, false, *idManager, param, progress);
+                  maximallyMergedMappings = std::move(groupFilteredMappings);
+              }
+
+              if (param.filterLengthMismatches) {
+                  FilterUtils::filterFalseHighIdentity(maximallyMergedMappings, param);
+              }
+              
+              FilterUtils::sparsifyMappings(maximallyMergedMappings, param);
+              FilterUtils::filterByScaffolds(maximallyMergedMappings, rawMappings, param, *idManager, progress);
           } else {
-              filterNonMergedMappings(mappings, param, progress);
-              filterByScaffolds(mappings, rawMappings, param, progress);
+              // Filter non-merged mappings
+              if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {
+                  MappingResultsVector_t filteredMappings;
+                  FilterUtils::filterByGroup(mappings, filteredMappings, 
+                      param.numMappingsForSegment - 1, false, *idManager, param, progress);
+                  mappings = std::move(filteredMappings);
+              }
+              FilterUtils::filterByScaffolds(mappings, rawMappings, param, *idManager, progress);
           }
 
           // Build dense chain ID mapping
           std::unordered_map<offset_t, offset_t> id_map;
           offset_t next_id = 0;
           
-          // First pass - build the mapping from both sets
           for (const auto& mapping : mappings) {
               if (id_map.count(mapping.splitMappingId) == 0) {
                   id_map[mapping.splitMappingId] = next_id++;
@@ -2976,10 +976,8 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
               }
           }
 
-          // Get atomic offset for this batch of chain IDs
           offset_t base_id = maxChainIdSeen.fetch_add(id_map.size(), std::memory_order_relaxed);
           
-          // Apply compacted IDs with offset
           for (auto& mapping : mappings) {
               mapping.splitMappingId = id_map[mapping.splitMappingId] + base_id;
           }
@@ -2990,202 +988,15 @@ VecIn mergeMappingsInRange(VecIn &readMappings,
           return {std::move(mappings), std::move(maximallyMergedMappings)};
       }
 
-      /**
-       * @brief Update chain IDs to prevent conflicts between subsets
-       * @param mappings Mappings whose chain IDs need updating
-       * @param maxId Current maximum chain ID seen
-       */
-
-      void computeChainStatistics(std::vector<MappingResult>::iterator begin, std::vector<MappingResult>::iterator end) {
-          if (begin == end) return;
-
-          offset_t chain_start_query = std::numeric_limits<offset_t>::max();
-          offset_t chain_end_query = std::numeric_limits<offset_t>::min();
-          offset_t chain_start_ref = std::numeric_limits<offset_t>::max();
-          offset_t chain_end_ref = std::numeric_limits<offset_t>::min();
-          double accumulate_nuc_identity = 0.0;
-          double accumulate_kmer_complexity = 0.0;
-          int total_conserved_sketches = 0;
-          int total_sketch_size = 0;
-          int n_in_full_chain = std::distance(begin, end);
-
-          for (auto it = begin; it != end; ++it) {
-              chain_start_query = std::min(chain_start_query, it->queryStartPos);
-              chain_end_query = std::max(chain_end_query, it->queryEndPos);
-              chain_start_ref = std::min(chain_start_ref, it->refStartPos);
-              chain_end_ref = std::max(chain_end_ref, it->refEndPos);
-              accumulate_nuc_identity += it->nucIdentity;
-              accumulate_kmer_complexity += it->kmerComplexity;
-              total_conserved_sketches += it->conservedSketches;
-              total_sketch_size += it->sketchSize;
-          }
-
-          auto chain_nuc_identity = accumulate_nuc_identity / n_in_full_chain;
-          auto chain_kmer_complexity = accumulate_kmer_complexity / n_in_full_chain;
-          auto block_length = std::max(chain_end_query - chain_start_query, chain_end_ref - chain_start_ref);
-
-          for (auto it = begin; it != end; ++it) {
-              it->n_merged = n_in_full_chain;
-              it->blockLength = block_length;
-              it->blockNucIdentity = chain_nuc_identity;
-              it->kmerComplexity = chain_kmer_complexity;
-              it->conservedSketches = total_conserved_sketches;
-              it->sketchSize = total_sketch_size;
-              it->approxMatches = std::round(chain_nuc_identity * block_length / 100.0);
-          }
-      }
-
-     /**
-       * @brief                       This routine is to make sure that all mapping boundaries
-       *                              on query and reference are not outside total
-       *                              length of sequeunces involved
-       * @param[in]     input         input read details
-       * @param[in/out] readMappings  Mappings computed by Mashmap (L2 stage) for a read
-       */
-      template <typename VecIn>
-        void mappingBoundarySanityCheck(InputSeqProgContainer* input, VecIn &readMappings)
-        {
-          for(auto &e : readMappings)
-          {
-            //reference start pos
-            {
-              if(e.refStartPos < 0)
-                e.refStartPos = 0;
-              if(e.refStartPos >= this->idManager->getSequenceLength(e.refSeqId))
-                e.refStartPos = this->idManager->getSequenceLength(e.refSeqId) - 1;
-            }
-
-            //reference end pos
-            {
-              if(e.refEndPos < e.refStartPos)
-                e.refEndPos = e.refStartPos;
-              if(e.refEndPos >= this->idManager->getSequenceLength(e.refSeqId))
-                e.refEndPos = this->idManager->getSequenceLength(e.refSeqId) - 1;
-            }
-
-            //query start pos
-            {
-              if(e.queryStartPos < 0)
-                e.queryStartPos = 0;
-              if(e.queryStartPos >= input->len)
-                e.queryStartPos = input->len;
-            }
-
-            //query end pos
-            {
-              if(e.queryEndPos < e.queryStartPos)
-                e.queryEndPos = e.queryStartPos;
-              if(e.queryEndPos >= input->len)
-                e.queryEndPos = input->len;
-            }
-          }
-        }
-
-      /**
-       * @brief                         Report the final read mappings to output stream
-       * @param[in]   readMappings      mapping results for single or multiple reads
-       * @param[in]   queryName         input required if reporting one read at a time
-       * @param[in]   outstrm           file output stream object
-       */
-      void reportReadMappings(MappingResultsVector_t &readMappings, const std::string &queryName,
-          std::ostream &outstrm)
-      {
-        // Sort mappings by chain ID and query position
-        std::sort(readMappings.begin(), readMappings.end(),
-            [](const MappingResult &a, const MappingResult &b) {
-                return std::tie(a.splitMappingId, a.queryStartPos)
-                    < std::tie(b.splitMappingId, b.queryStartPos);
-            });
-
-        // Assign chain positions within each chain
-        int current_chain = -1;
-        int chain_pos = 0;
-        int chain_length = 0;
-        
-        // First pass - count chain lengths
-        for (size_t i = 0; i < readMappings.size(); ++i) {
-            if (readMappings[i].splitMappingId != current_chain) {
-                current_chain = readMappings[i].splitMappingId;
-                chain_length = 1;
-                // Count forward to find chain length
-                for (size_t j = i + 1; j < readMappings.size(); ++j) {
-                    if (readMappings[j].splitMappingId == current_chain) {
-                        chain_length++;
-                    } else {
-                        break;
-                    }
-                }
-                // Assign length to all mappings in this chain
-                readMappings[i].chain_length = chain_length;
-                chain_pos = 1;
-            } else {
-                readMappings[i].chain_length = chain_length;
-                chain_pos++;
-            }
-            readMappings[i].chain_pos = chain_pos;
-        }
-
-        //Print the results
-        for(auto &e : readMappings)
-        {
-          float fakeMapQ = e.nucIdentity == 1 ? 255 : std::round(-10.0 * std::log10(1-(e.nucIdentity)));
-          std::string sep = param.legacy_output ? " " : "\t";
-
-          outstrm  << (param.filterMode == filter::ONETOONE ? idManager->getSequenceName(e.querySeqId) : queryName)
-                   << sep << e.queryLen
-                   << sep << e.queryStartPos
-                   << sep << e.queryEndPos - (param.legacy_output ? 1 : 0)
-                   << sep << (e.strand == strnd::FWD ? "+" : "-")
-                   << sep << idManager->getSequenceName(e.refSeqId)
-                   << sep << this->idManager->getSequenceLength(e.refSeqId)
-                   << sep << e.refStartPos
-                   << sep << e.refEndPos - (param.legacy_output ? 1 : 0);
-
-          if (!param.legacy_output) 
-          {
-            outstrm  << sep << e.conservedSketches
-                     << sep << e.blockLength
-                     << sep << fakeMapQ
-                     << sep << "id:f:" << e.nucIdentity
-                     << sep << "kc:f:" << e.kmerComplexity;
-            if (!param.mergeMappings) 
-            {
-              outstrm << sep << "jc:f:" << float(e.conservedSketches) / e.sketchSize;
-            } else {
-              outstrm << sep << "ch:Z:" << e.splitMappingId << "." << e.chain_pos << "." << e.chain_length;
-            }
-          } else
-          {
-            outstrm << sep << e.nucIdentity * 100.0;
-          }
-
-#ifdef DEBUG
-          outstrm << std::endl;
-#else
-          outstrm << "\n";
-#endif
-
-          //User defined processing of the results
-          if(processMappingResults != nullptr)
-            processMappingResults(e);
-        }
-      }
-
-    private:
-
     public:
-
       /**
-       * @brief     An optional utility function to save the
-       *            reported results by the L2 stage into a vector
+       * @brief Utility function to save L2 results to vector
        */
       static void insertL2ResultsToVec(MappingResultsVector_t &v, const MappingResult &reportedL2Result)
       {
-        v.push_back(reportedL2Result);
+        OutputHandler::insertL2ResultsToVec(v, reportedL2Result);
       }
-
   };
-
 }
 
-#endif
+#endif // SKETCH_MAP_HPP

--- a/src/map/include/fragmentManager.hpp
+++ b/src/map/include/fragmentManager.hpp
@@ -1,0 +1,86 @@
+/**
+ * @file    fragmentManager.hpp
+ * @brief   Fragment data structures and management for sequence mapping
+ * @author  Chirag Jain <cjain7@gatech.edu>
+ */
+
+#ifndef FRAGMENT_MANAGER_HPP
+#define FRAGMENT_MANAGER_HPP
+
+#include <memory>
+#include <vector>
+#include <mutex>
+#include <atomic>
+#include <string>
+#include "map/include/base_types.hpp"
+#include "common/progress.hpp"
+
+namespace skch
+{
+  // Forward declaration
+  struct QueryMappingOutput;
+
+  /**
+   * @brief Fragment data structure for processing sequence fragments
+   */
+  struct FragmentData {
+      const char* seq;
+      int len;
+      int fullLen; 
+      seqno_t seqId;
+      std::string seqName;
+      int refGroup;
+      int fragmentIndex;
+      std::shared_ptr<QueryMappingOutput> output;
+      std::shared_ptr<std::atomic<int>> processedCounter;
+
+      // Constructor
+      FragmentData(const char* s, int l, int fl, seqno_t sid, 
+                   const std::string& sn, int rg, int idx,
+                   std::shared_ptr<QueryMappingOutput> out,
+                   std::shared_ptr<std::atomic<int>> counter = nullptr)
+          : seq(s), len(l), fullLen(fl), seqId(sid), seqName(sn),
+            refGroup(rg), fragmentIndex(idx), output(out), processedCounter(counter) {}
+  };
+
+  /**
+   * @brief Output structure for query mapping results
+   */
+  struct QueryMappingOutput {
+      std::string queryName;
+      std::vector<MappingResult> results;        // Non-merged mappings
+      std::vector<MappingResult> mergedResults;  // Maximally merged mappings  
+      std::mutex mutex;
+      progress_meter::ProgressMeter& progress;
+      
+      QueryMappingOutput(const std::string& name, const std::vector<MappingResult>& r, 
+                        const std::vector<MappingResult>& mr, progress_meter::ProgressMeter& p)
+          : queryName(name), results(r), mergedResults(mr), progress(p) {}
+  };
+
+  /**
+   * @brief Manages fragment lifetime and processing
+   */
+  class FragmentManager {
+  private:
+      std::vector<std::shared_ptr<FragmentData>> fragments;
+      std::mutex fragments_mutex;
+
+  public:
+      void add_fragment(std::shared_ptr<FragmentData> fragment) {
+          std::lock_guard<std::mutex> lock(fragments_mutex);
+          fragments.push_back(fragment);
+      }
+
+      void clear() {
+          std::lock_guard<std::mutex> lock(fragments_mutex);
+          fragments.clear();
+      }
+
+      const std::vector<std::shared_ptr<FragmentData>>& get_fragments() const {
+          return fragments;
+      }
+  };
+}
+
+#endif // FRAGMENT_MANAGER_HPP

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -85,6 +85,7 @@ struct Parameters
     int64_t scaffold_max_deviation;                  // max diagonal deviation from scaffold chains
     int64_t scaffold_gap;                           // gap threshold for scaffold chaining
     int64_t scaffold_min_length = 50000;            // minimum scaffold block length
+    std::string scaffold_output_file;               // optional file to output scaffold mappings
     
     bool legacy_output;
     //std::unordered_set<std::string> high_freq_kmers;  //

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -32,8 +32,7 @@ struct ales_params {
 struct Parameters
 {
     int kmerSize;                                     //kmer size for sketching
-    offset_t segLength;                                //For split mapping case, this represents the fragment length
-                                                      //for noSplit, it represents minimum read length to multimap
+    offset_t windowLength;                             //window size for sketching
     offset_t block_length;                             // minimum (potentially merged) block to keep if we aren't split
     offset_t chain_gap;                                // max distance for 2d range union-find mapping chaining
     uint64_t max_mapping_length;                      // maximum length of a mapping

--- a/src/map/include/mappingCore.hpp
+++ b/src/map/include/mappingCore.hpp
@@ -148,10 +148,10 @@ namespace skch
       int bestIntersectionSize = 0;
       std::vector<L1_candidateLocus_t> localOpts;
 
-      int windowLen = std::max<offset_t>(0, Q.len - param.segLength);
+      int windowLen = std::max<offset_t>(0, Q.len - param.windowLength);
       auto trailingIt = ip_begin;
       auto leadingIt = ip_begin;
-      int clusterLen = param.segLength;
+      int clusterLen = param.windowLength;
 
       std::unordered_map<hash_t, int> hash_to_freq;
 
@@ -311,7 +311,7 @@ namespace skch
         const Parameters& param)
     {
       auto& minmerIndex = refSketch->minmerIndex;
-      const MinmerInfo first_minmer = MinmerInfo {0, candidateLocus.rangeStartPos - param.segLength - 1, 0, candidateLocus.seqId, 0};
+      const MinmerInfo first_minmer = MinmerInfo {0, candidateLocus.rangeStartPos - param.windowLength - 1, 0, candidateLocus.seqId, 0};
       auto firstOpenIt = std::lower_bound(minmerIndex.begin(), minmerIndex.end(), first_minmer); 
 
       std::vector<skch::MinmerInfo> slidingWindow;
@@ -319,7 +319,7 @@ namespace skch
       constexpr auto heap_cmp = [](const skch::MinmerInfo& l, const skch::MinmerInfo& r) {return l.wpos_end > r.wpos_end;};
 
       auto windowIt = firstOpenIt;
-      int windowLen = std::max<offset_t>(0, Q.len - param.segLength);
+      int windowLen = std::max<offset_t>(0, Q.len - param.windowLength);
       std::unordered_map<hash_t, int> hash_to_freq;
       
       SlideMapper<Q_Info> slideMap(Q);
@@ -406,7 +406,7 @@ namespace skch
             l2_out.seqId = windowIt->seqId;
             l2_out.strand = prev_strand_votes >= 0 ? strnd::FWD : strnd::REV;
             if (l2_vec_out.empty() 
-                || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
+                || l2_vec_out.back().optimalEnd + param.windowLength < l2_out.optimalStart)
             {
               l2_vec_out.push_back(l2_out);
             }
@@ -429,7 +429,7 @@ namespace skch
         l2_out.seqId = std::prev(windowIt)->seqId;
         l2_out.strand = slideMap.strand_votes >= 0 ? strnd::FWD : strnd::REV;
         if (l2_vec_out.empty() 
-            || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
+            || l2_vec_out.back().optimalEnd + param.windowLength < l2_out.optimalStart)
         {
           l2_vec_out.push_back(l2_out);
         }

--- a/src/map/include/mappingCore.hpp
+++ b/src/map/include/mappingCore.hpp
@@ -1,0 +1,446 @@
+/**
+ * @file    mappingCore.hpp
+ * @brief   Core L1/L2 mapping algorithms
+ * @author  Chirag Jain <cjain7@gatech.edu>
+ */
+
+#ifndef MAPPING_CORE_HPP
+#define MAPPING_CORE_HPP
+
+#include <vector>
+#include <algorithm>
+#include <queue>
+#include <unordered_map>
+#include "map/include/base_types.hpp"
+#include "map/include/commonFunc.hpp"
+#include "map/include/winSketch.hpp"
+#include "map/include/slidingMap.hpp"
+#include "map/include/MIIteratorL2.hpp"
+#include "map/include/map_stats.hpp"
+
+namespace skch
+{
+  //Type for Stage L1's predicted candidate location
+  struct L1_candidateLocus_t
+  {
+    seqno_t seqId;                    //sequence id where read is mapped
+    offset_t rangeStartPos;
+    offset_t rangeEndPos;
+    int intersectionSize;
+  };
+
+  //Type for Stage L2's predicted mapping coordinate
+  struct L2_mapLocus_t
+  {
+    seqno_t seqId;                    //sequence id where read is mapped
+    offset_t meanOptimalPos;          //Among multiple consecutive optimal positions, save the avg.
+    offset_t optimalStart;            //optimal start mapping position
+    offset_t optimalEnd;              //optimal end mapping position
+    int sharedSketchSize;             //count of shared sketch elements
+    strand_t strand;
+  };
+
+  //Comparator for L1 candidate locations
+  static constexpr auto L1_locus_intersection_cmp = [](L1_candidateLocus_t& a, L1_candidateLocus_t& b)
+  {
+    return a.intersectionSize < b.intersectionSize;
+  };
+
+  /**
+   * @brief Template class containing core mapping algorithms
+   */
+  template<typename SketchType, typename IdManagerType>
+  class MappingCore {
+  public:
+    using MI_Type = typename SketchType::MI_Type;
+    using MIIter_t = typename SketchType::MIIter_t;
+
+    /**
+     * @brief Compute seed hits for a query sequence
+     */
+    template <typename Q_Info>
+    static void getSeedHits(Q_Info &Q, const Parameters& param)
+    {
+      Q.minmerTableQuery.reserve(param.sketchSize + 1);
+      CommonFunc::sketchSequence(Q.minmerTableQuery, Q.seq, Q.len, param.kmerSize, 
+                                param.alphabetSize, param.sketchSize, Q.seqId);
+      if(Q.minmerTableQuery.size() == 0) {
+        Q.sketchSize = 0;
+        return;
+      }
+
+      const double max_hash_01 = (long double)(Q.minmerTableQuery.back().hash) / std::numeric_limits<hash_t>::max();
+      Q.kmerComplexity = (double(Q.minmerTableQuery.size()) / max_hash_01) / 
+                         ((Q.len - param.kmerSize + 1)*2);
+      Q.sketchSize = Q.minmerTableQuery.size();
+    }
+
+    /**
+     * @brief Find seed interval points using reference sketch
+     */
+    template <typename Q_Info, typename Vec>
+    static void getSeedIntervalPoints(Q_Info &Q, Vec& intervalPoints, 
+                                     const SketchType* refSketch,
+                                     const IdManagerType& idManager,
+                                     const Parameters& param)
+    {
+      if(Q.minmerTableQuery.size() == 0)
+        return;
+
+      // Priority queue for sorting interval points
+      using IP_const_iterator = typename std::vector<IntervalPoint>::const_iterator;
+      std::vector<boundPtr<IP_const_iterator>> pq;
+      pq.reserve(Q.sketchSize);
+      constexpr auto heap_cmp = [](const auto& a, const auto& b) {return b < a;};
+
+      for(auto it = Q.minmerTableQuery.begin(); it != Q.minmerTableQuery.end(); it++)
+      {
+        const auto seedFind = refSketch->minmerPosLookupIndex.find(it->hash);
+        if(seedFind != refSketch->minmerPosLookupIndex.end())
+        {
+          pq.emplace_back(boundPtr<IP_const_iterator> {seedFind->second.cbegin(), seedFind->second.cend()});
+        }
+      }
+      std::make_heap(pq.begin(), pq.end(), heap_cmp);
+
+      while(!pq.empty())
+      {
+        const IP_const_iterator ip_it = pq.front().it;
+        bool skip_mapping = false;
+        int queryGroup = idManager.getRefGroup(Q.seqId);
+        int targetGroup = idManager.getRefGroup(ip_it->seqId);
+
+        if (param.skip_self && queryGroup == targetGroup) skip_mapping = true;
+        if (param.skip_prefix && queryGroup == targetGroup) skip_mapping = true;
+        if (param.lower_triangular && Q.seqId <= ip_it->seqId) skip_mapping = true;
+
+        if (!skip_mapping) {
+          intervalPoints.push_back(*ip_it);
+        }
+        std::pop_heap(pq.begin(), pq.end(), heap_cmp);
+        pq.back().it++;
+        if (pq.back().it >= pq.back().end) 
+        {
+          pq.pop_back();
+        }
+        else
+        {
+          std::push_heap(pq.begin(), pq.end(), heap_cmp);
+        }
+      }
+    }
+
+    /**
+     * @brief Compute L1 candidate regions from interval points
+     */
+    template <typename Q_Info, typename IP_iter, typename Vec2>
+    static void computeL1CandidateRegions(
+        Q_Info &Q, 
+        IP_iter ip_begin, 
+        IP_iter ip_end, 
+        int minimumHits,
+        const Parameters& param,
+        const std::vector<int>& sketchCutoffs,
+        Vec2 &l1Mappings)
+    {
+      int overlapCount = 0;
+      int strandCount = 0;
+      int bestIntersectionSize = 0;
+      std::vector<L1_candidateLocus_t> localOpts;
+
+      int windowLen = std::max<offset_t>(0, Q.len - param.segLength);
+      auto trailingIt = ip_begin;
+      auto leadingIt = ip_begin;
+      int clusterLen = param.segLength;
+
+      std::unordered_map<hash_t, int> hash_to_freq;
+
+      // First pass to find best intersection size
+      if (param.stage1_topANI_filter) {
+        while (leadingIt != ip_end)
+        {
+          while (trailingIt != ip_end 
+              && ((trailingIt->seqId == leadingIt->seqId && trailingIt->pos <= leadingIt->pos - windowLen)
+                || trailingIt->seqId < leadingIt->seqId))
+          {
+            if (trailingIt->side == side::CLOSE) {
+              if (windowLen != 0)
+                hash_to_freq[trailingIt->hash]--;
+              if (windowLen == 0 || hash_to_freq[trailingIt->hash] == 0) {
+                overlapCount--;
+              }
+            }
+            trailingIt++;
+          }
+          auto currentPos = leadingIt->pos;
+          while (leadingIt != ip_end && leadingIt->pos == currentPos) {
+            if (leadingIt->side == side::OPEN) {
+              if (windowLen == 0 || hash_to_freq[leadingIt->hash] == 0) {
+                overlapCount++;
+              }
+              if (windowLen != 0)
+                hash_to_freq[leadingIt->hash]++;
+            }
+            leadingIt++;
+          }
+          bestIntersectionSize = std::max(bestIntersectionSize, overlapCount);
+        }
+
+        // Adjust minimum hits based on best intersection
+        if (bestIntersectionSize < minimumHits) {
+          return;
+        } else {
+          minimumHits = std::max(
+              sketchCutoffs[
+                int(std::min(bestIntersectionSize, Q.sketchSize) 
+                  / std::max<double>(1, param.sketchSize / skch::fixed::ss_table_max))
+              ],
+              minimumHits);
+        }
+      }
+
+      // Second pass to find candidate regions
+      hash_to_freq.clear();
+      bestIntersectionSize = std::min(bestIntersectionSize, Q.sketchSize);
+
+      bool in_candidate = false;
+      L1_candidateLocus_t l1_out = {};
+      trailingIt = ip_begin;
+      leadingIt = ip_begin;
+      overlapCount = 0;
+      int prevOverlap = 0;
+      int prevPrevOverlap = 0;
+      SeqCoord prevPos;
+      SeqCoord currentPos{leadingIt->seqId, leadingIt->pos};
+
+      while (leadingIt != ip_end)
+      {
+        prevPrevOverlap = prevOverlap;
+        prevOverlap = overlapCount;
+
+        while (trailingIt != ip_end 
+            && ((trailingIt->seqId == leadingIt->seqId && trailingIt->pos <= leadingIt->pos - windowLen)
+              || trailingIt->seqId < leadingIt->seqId))
+        {
+          if (trailingIt->side == side::CLOSE) {
+            if (windowLen != 0)
+              hash_to_freq[trailingIt->hash]--;
+            if (windowLen == 0 || hash_to_freq[trailingIt->hash] == 0) {
+              overlapCount--;
+            }
+          }
+          trailingIt++;
+        }
+        if (leadingIt->pos != currentPos.pos) {
+          prevPos = currentPos;
+          currentPos = SeqCoord{leadingIt->seqId, leadingIt->pos};
+        }
+        while (leadingIt != ip_end && leadingIt->pos == currentPos.pos) 
+        {
+          if (leadingIt->side == side::OPEN) {
+            if (windowLen == 0 || hash_to_freq[leadingIt->hash] == 0) {
+              overlapCount++;
+            }
+            if (windowLen != 0)
+              hash_to_freq[leadingIt->hash]++;
+          }
+          leadingIt++;
+        }
+        if (prevOverlap >= minimumHits)
+        {
+          if (l1_out.seqId != prevPos.seqId && in_candidate) {
+            localOpts.push_back(l1_out);
+            l1_out = {};
+            in_candidate = false;
+          }
+          if (!in_candidate) {
+            l1_out.rangeStartPos = prevPos.pos - windowLen;
+            l1_out.rangeEndPos = prevPos.pos - windowLen;
+            l1_out.seqId = prevPos.seqId;
+            l1_out.intersectionSize = prevOverlap;
+            in_candidate = true;
+          } else {
+            if (param.stage2_full_scan) {
+              l1_out.intersectionSize = std::max(l1_out.intersectionSize, prevOverlap);
+              l1_out.rangeEndPos = prevPos.pos - windowLen;
+            }
+            else if (l1_out.intersectionSize < prevOverlap) {
+              l1_out.intersectionSize = prevOverlap;
+              l1_out.rangeStartPos = prevPos.pos - windowLen;
+              l1_out.rangeEndPos = prevPos.pos - windowLen;
+            }
+          }
+        } 
+        else {
+          if (in_candidate) {
+            localOpts.push_back(l1_out);
+            l1_out = {};
+          }
+          in_candidate = false;
+        }
+      }
+      if (in_candidate) {
+        localOpts.push_back(l1_out);
+      }
+
+      // Join proximal local opts
+      for (auto& l1_out : localOpts) 
+      {
+        if (l1Mappings.empty() 
+            || l1_out.seqId != l1Mappings.back().seqId 
+            || l1_out.rangeStartPos > l1Mappings.back().rangeEndPos + clusterLen) 
+        {
+          l1Mappings.push_back(l1_out); 
+        } 
+        else 
+        {
+          l1Mappings.back().rangeEndPos = l1_out.rangeEndPos;
+          l1Mappings.back().intersectionSize = std::max(l1_out.intersectionSize, l1Mappings.back().intersectionSize);
+        }
+      }
+    }
+
+    /**
+     * @brief Compute L2 mapped regions within an L1 candidate
+     */
+    template <typename Q_Info, typename Vec>
+    static void computeL2MappedRegions(Q_Info &Q,
+        L1_candidateLocus_t &candidateLocus,
+        Vec &l2_vec_out,
+        const SketchType* refSketch,
+        const Parameters& param)
+    {
+      auto& minmerIndex = refSketch->minmerIndex;
+      const MinmerInfo first_minmer = MinmerInfo {0, candidateLocus.rangeStartPos - param.segLength - 1, 0, candidateLocus.seqId, 0};
+      auto firstOpenIt = std::lower_bound(minmerIndex.begin(), minmerIndex.end(), first_minmer); 
+
+      std::vector<skch::MinmerInfo> slidingWindow;
+      slidingWindow.reserve(Q.sketchSize);
+      constexpr auto heap_cmp = [](const skch::MinmerInfo& l, const skch::MinmerInfo& r) {return l.wpos_end > r.wpos_end;};
+
+      auto windowIt = firstOpenIt;
+      int windowLen = std::max<offset_t>(0, Q.len - param.segLength);
+      std::unordered_map<hash_t, int> hash_to_freq;
+      
+      SlideMapper<Q_Info> slideMap(Q);
+
+      offset_t beginOptimalPos = 0;
+      offset_t lastOptimalPos = 0;
+      int bestSketchSize = 1;
+      int bestIntersectionSize = 0;
+      bool in_candidate = false;
+      L2_mapLocus_t l2_out = {};
+
+      // Set up the window
+      while (windowIt != minmerIndex.end() && windowIt->seqId == candidateLocus.seqId && windowIt->wpos < candidateLocus.rangeStartPos) 
+      {
+        if (windowIt->wpos_end > candidateLocus.rangeStartPos) 
+        {
+          if (windowLen > 0) 
+          {
+            hash_to_freq[windowIt->hash]++;
+          }
+          if (windowLen == 0 || hash_to_freq[windowIt->hash] == 1) {
+            slidingWindow.push_back(*windowIt);
+            std::push_heap(slidingWindow.begin(), slidingWindow.end(), heap_cmp);
+            slideMap.insert_minmer(*windowIt);
+          }
+        }
+        windowIt++;
+      }
+
+      // Process the window
+      while (windowIt != minmerIndex.end() && windowIt->seqId == candidateLocus.seqId && windowIt->wpos <= candidateLocus.rangeEndPos + windowLen) 
+      {
+        int prev_strand_votes = slideMap.strand_votes;
+        bool inserted = false;
+        
+        while (!slidingWindow.empty() && slidingWindow.front().wpos_end <= windowIt->wpos - windowLen) {
+          if (windowLen > 0) 
+          {
+            hash_to_freq[slidingWindow.front().hash]--;
+          }
+          if (windowLen == 0 || hash_to_freq[slidingWindow.front().hash] == 0) {
+            slideMap.delete_minmer(slidingWindow.front());
+            std::pop_heap(slidingWindow.begin(), slidingWindow.end(), heap_cmp);
+            slidingWindow.pop_back();
+          }
+        }
+        
+        inserted = true;
+        if (windowLen > 0) 
+        {
+          hash_to_freq[windowIt->hash]++;
+        }
+        if (windowLen == 0 || hash_to_freq[windowIt->hash] == 1) {
+          slideMap.insert_minmer(*windowIt);
+          slidingWindow.push_back(*windowIt);
+          std::push_heap(slidingWindow.begin(), slidingWindow.end(), heap_cmp);
+        } else {
+          windowIt++;
+          continue;
+        }
+
+        bestIntersectionSize = std::max(bestIntersectionSize, slideMap.intersectionSize);
+
+        if (slideMap.sharedSketchElements > bestSketchSize)
+        {
+          l2_vec_out.clear();
+          in_candidate = true;
+          bestSketchSize = slideMap.sharedSketchElements;
+          l2_out.sharedSketchSize = slideMap.sharedSketchElements;
+          l2_out.optimalStart = windowIt->wpos - windowLen;
+          l2_out.optimalEnd = windowIt->wpos - windowLen;
+        }
+        else if(slideMap.sharedSketchElements == bestSketchSize)
+        {
+          if (!in_candidate) {
+            l2_out.sharedSketchSize = slideMap.sharedSketchElements;
+            l2_out.optimalStart = windowIt->wpos - windowLen;
+          }
+          in_candidate = true;
+          l2_out.optimalEnd = windowIt->wpos - windowLen;
+        } else {
+          if (in_candidate) {
+            l2_out.meanOptimalPos = (l2_out.optimalStart + l2_out.optimalEnd) / 2;
+            l2_out.seqId = windowIt->seqId;
+            l2_out.strand = prev_strand_votes >= 0 ? strnd::FWD : strnd::REV;
+            if (l2_vec_out.empty() 
+                || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
+            {
+              l2_vec_out.push_back(l2_out);
+            }
+            else 
+            {
+              l2_vec_out.back().optimalEnd = l2_out.optimalEnd;
+              l2_vec_out.back().meanOptimalPos = (l2_vec_out.back().optimalStart + l2_vec_out.back().optimalEnd) / 2;
+            }
+            l2_out = L2_mapLocus_t();
+          }
+          in_candidate = false;
+        }
+        if (inserted) {
+          windowIt++;
+        }
+      }
+      
+      if (in_candidate) {
+        l2_out.meanOptimalPos = (l2_out.optimalStart + l2_out.optimalEnd) / 2;
+        l2_out.seqId = std::prev(windowIt)->seqId;
+        l2_out.strand = slideMap.strand_votes >= 0 ? strnd::FWD : strnd::REV;
+        if (l2_vec_out.empty() 
+            || l2_vec_out.back().optimalEnd + param.segLength < l2_out.optimalStart)
+        {
+          l2_vec_out.push_back(l2_out);
+        }
+        else 
+        {
+          l2_vec_out.back().optimalEnd = l2_out.optimalEnd;
+          l2_vec_out.back().meanOptimalPos = (l2_vec_out.back().optimalStart + l2_vec_out.back().optimalEnd) / 2;
+        }
+      }
+    }
+  };
+}
+
+#endif // MAPPING_CORE_HPP

--- a/src/map/include/mappingFilter.hpp
+++ b/src/map/include/mappingFilter.hpp
@@ -162,10 +162,10 @@ namespace skch
                        readMappings.end(),
                        [&](MappingResult &e){
                            bool is_boundary_mapping = 
-                               e.queryStartPos < param.segLength ||
-                               e.queryEndPos() > queryLen - param.segLength || // Use passed-in queryLen
-                               e.refStartPos < param.segLength ||
-                               e.refEndPos() > idManager.getSequenceLength(e.refSeqId) - param.segLength;
+                               e.queryStartPos < param.windowLength ||
+                               e.queryEndPos() > queryLen - param.windowLength || // Use passed-in queryLen
+                               e.refStartPos < param.windowLength ||
+                               e.refEndPos() > idManager.getSequenceLength(e.refSeqId) - param.windowLength;
                            
                            if (is_boundary_mapping) {
                                return e.blockLength < param.block_length / 2 || 
@@ -444,7 +444,7 @@ namespace skch
                                      (readMappings[j].refStartPos - readMappings[i].refEndPos()) : 
                                      (readMappings[i].refStartPos - readMappings[j].refEndPos());
                     
-                    if (q_dist <= max_dist && r_dist >= -param.segLength/5 && r_dist <= max_dist) {
+                    if (q_dist <= max_dist && r_dist >= -param.windowLength/5 && r_dist <= max_dist) {
                         double dist_sq = (double)q_dist * q_dist + (double)r_dist * r_dist;
                         if (dist_sq < best_score && dist_sq < aux_data[j].chainPairScore) {
                             best_score = dist_sq;
@@ -547,14 +547,14 @@ namespace skch
       // Mark positions that are not cuttable
       for (auto it = std::next(begin); it != end; ++it) {
           auto prev = std::prev(it);
-          if (it->queryStartPos - prev->queryEndPos() > param.segLength / 5 ||
-              it->refStartPos - prev->refEndPos() > param.segLength / 5) {
+          if (it->queryStartPos - prev->queryEndPos() > param.windowLength / 5 ||
+              it->refStartPos - prev->refEndPos() > param.windowLength / 5) {
               is_cuttable[std::distance(begin, prev)] = false;
               is_cuttable[std::distance(begin, it)] = false;
           }
       }
 
-      adjustConsecutiveMappings(begin, end, param.segLength);
+      adjustConsecutiveMappings(begin, end, param.windowLength);
 
       auto fragment_start = begin;
       offset_t accumulate_length = 0;

--- a/src/map/include/mappingFilter.hpp
+++ b/src/map/include/mappingFilter.hpp
@@ -662,6 +662,14 @@ namespace skch
                 [&](const MappingResult& m) { return m.blockLength < param.scaffold_min_length; }),
             anchors.end());
         
+        // Apply plane sweep filter to scaffold mappings to remove spurious anchors
+        if (!anchors.empty() && (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE)) {
+            MappingResultsVector_t filteredAnchors;
+            filterByGroup(anchors, filteredAnchors, param.numMappingsForSegment - 1, 
+                         false, idManager, param, progress);
+            anchors = std::move(filteredAnchors);
+        }
+        
         if (readMappings.empty()) return;
         if (anchors.empty()) {
             // No anchors, filter out everything

--- a/src/map/include/mappingFilter.hpp
+++ b/src/map/include/mappingFilter.hpp
@@ -1,0 +1,798 @@
+/**
+ * @file    mappingFilter.hpp
+ * @brief   Filtering and merging logic for mappings
+ * @author  Chirag Jain <cjain7@gatech.edu>
+ */
+
+#ifndef MAPPING_FILTER_HPP
+#define MAPPING_FILTER_HPP
+
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <cmath>
+#include <numeric>
+#include <set>
+#include "map/include/base_types.hpp"
+#include "map/include/filter.hpp"
+#include "map/include/sequenceIds.hpp"
+#include "common/dset64.hpp"
+#include "common/progress.hpp"
+
+namespace skch
+{
+  /**
+   * @brief Class containing filtering and merging algorithms for mappings
+   */
+  class MappingFilterUtils {
+  public:
+    /**
+     * @brief Filter mappings with fewer than target merged base mappings
+     */
+    static void filterWeakMappings(MappingResultsVector_t &readMappings, 
+                                  int64_t min_count,
+                                  const Parameters& param,
+                                  const SequenceIdManager& idManager)
+    {
+      readMappings.erase(
+          std::remove_if(readMappings.begin(),
+                       readMappings.end(),
+                       [&](MappingResult &e){
+                           bool is_boundary_mapping = 
+                               e.queryStartPos < param.segLength ||
+                               e.queryEndPos > e.queryLen - param.segLength ||
+                               e.refStartPos < param.segLength ||
+                               e.refEndPos > idManager.getSequenceLength(e.refSeqId) - param.segLength;
+                           
+                           if (is_boundary_mapping) {
+                               return e.blockLength < param.block_length / 2 || 
+                                      e.n_merged < min_count / 2;
+                           } else {
+                               return e.blockLength < param.block_length || 
+                                      e.n_merged < min_count;
+                           }
+                       }),
+          readMappings.end());
+    }
+
+    /**
+     * @brief Filter mappings whose identity and query/ref length don't agree
+     */
+    static void filterFalseHighIdentity(MappingResultsVector_t &readMappings,
+                                       const Parameters& param)
+    {
+      readMappings.erase(
+          std::remove_if(readMappings.begin(),
+                         readMappings.end(),
+                         [&](MappingResult &e){
+                             int64_t q_l = (int64_t)e.queryEndPos - (int64_t)e.queryStartPos;
+                             int64_t r_l = (int64_t)e.refEndPos - (int64_t)e.refStartPos;
+                             uint64_t delta = std::abs(r_l - q_l);
+                             double len_id_bound = (1.0 - (double)delta/(((double)q_l+r_l)/2));
+                             return len_id_bound < std::min(0.7, std::pow(param.percentageIdentity,3));
+                         }),
+          readMappings.end());
+    }
+
+    /**
+     * @brief Filter mappings by hash value for sparsification
+     */
+    static void sparsifyMappings(MappingResultsVector_t &readMappings,
+                                const Parameters& param)
+    {
+      if (param.sparsity_hash_threshold < std::numeric_limits<uint64_t>::max()) {
+          readMappings.erase(
+              std::remove_if(readMappings.begin(),
+                             readMappings.end(),
+                             [&](MappingResult &e){
+                                 return e.hash() > param.sparsity_hash_threshold;
+                             }),
+              readMappings.end());
+      }
+    }
+
+    /**
+     * @brief Filter mappings by group
+     */
+    static void filterByGroup(
+        MappingResultsVector_t &unfilteredMappings,
+        MappingResultsVector_t &filteredMappings,
+        int n_mappings,
+        bool filter_ref,
+        const SequenceIdManager& idManager,
+        const Parameters& param,
+        progress_meter::ProgressMeter& progress)
+    {
+      filteredMappings.reserve(unfilteredMappings.size());
+
+      std::sort(unfilteredMappings.begin(), unfilteredMappings.end(), 
+          [](const auto& a, const auto& b) { 
+              return std::tie(a.refSeqId, a.refStartPos) < std::tie(b.refSeqId, b.refStartPos); 
+          });
+          
+      auto subrange_begin = unfilteredMappings.begin();
+      auto subrange_end = unfilteredMappings.begin();
+      
+      if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) 
+      {
+        std::vector<skch::MappingResult> tmpMappings;
+        while (subrange_end != unfilteredMappings.end())
+        {
+          if (param.skip_prefix)
+          {
+            int currGroup = idManager.getRefGroup(subrange_begin->refSeqId);
+            subrange_end = std::find_if_not(subrange_begin, unfilteredMappings.end(), 
+                [&currGroup, &idManager] (const auto& candidate) {
+                    return currGroup == idManager.getRefGroup(candidate.refSeqId);
+            });
+          }
+          else
+          {
+            subrange_end = unfilteredMappings.end();
+          }
+          
+          tmpMappings.insert(
+              tmpMappings.end(), 
+              std::make_move_iterator(subrange_begin), 
+              std::make_move_iterator(subrange_end));
+              
+          std::sort(tmpMappings.begin(), tmpMappings.end(), 
+              [](const auto& a, const auto& b) { 
+                  return std::tie(a.queryStartPos, a.refSeqId, a.refStartPos) < 
+                         std::tie(b.queryStartPos, b.refSeqId, b.refStartPos); 
+              });
+              
+          if (filter_ref)
+          {
+              skch::Filter::ref::filterMappings(tmpMappings, idManager, n_mappings, 
+                                               param.dropRand, param.overlap_threshold);
+          }
+          else
+          {
+              skch::Filter::query::filterMappings(tmpMappings, n_mappings, 
+                                                 param.dropRand, param.overlap_threshold, progress);
+          }
+          
+          filteredMappings.insert(
+              filteredMappings.end(), 
+              std::make_move_iterator(tmpMappings.begin()), 
+              std::make_move_iterator(tmpMappings.end()));
+          tmpMappings.clear();
+          subrange_begin = subrange_end;
+        }
+      }
+      
+      std::sort(
+          filteredMappings.begin(), filteredMappings.end(),
+          [](const MappingResult &a, const MappingResult &b) {
+              return std::tie(a.queryStartPos, a.refSeqId, a.refStartPos, a.strand) 
+                  < std::tie(b.queryStartPos, b.refSeqId, b.refStartPos, b.strand);
+          });
+    }
+
+    /**
+     * @brief Adjust consecutive mappings to close small gaps
+     */
+    static void adjustConsecutiveMappings(std::vector<MappingResult>::iterator begin_maping,
+                                         std::vector<MappingResult>::iterator end_mapping,
+                                         const int threshold)
+    {
+      if (std::distance(begin_maping, end_mapping) < 2) return;
+
+      for (auto it = std::next(begin_maping); it != end_mapping; ++it) {
+          auto& prev = *std::prev(it);
+          auto& curr = *it;
+
+          if (prev.refSeqId != curr.refSeqId || prev.strand != curr.strand) continue;
+
+          int query_gap = curr.queryStartPos - prev.queryEndPos;
+          int ref_gap = curr.refStartPos - prev.refEndPos;
+
+          if (query_gap > 0 && ref_gap > 0 && query_gap <= threshold && ref_gap <= threshold) {
+              int query_mid = (prev.queryEndPos + curr.queryStartPos) / 2;
+              int ref_mid = (prev.refEndPos + curr.refStartPos) / 2;
+
+              prev.queryEndPos = query_mid;
+              prev.refEndPos = ref_mid;
+              curr.queryStartPos = query_mid;
+              curr.refStartPos = ref_mid;
+
+              prev.blockLength = std::max(prev.refEndPos - prev.refStartPos, 
+                                          prev.queryEndPos - prev.queryStartPos);
+              curr.blockLength = std::max(curr.refEndPos - curr.refStartPos, 
+                                          curr.queryEndPos - curr.queryStartPos);
+
+              prev.approxMatches = std::round(prev.nucIdentity * prev.blockLength / 100.0);
+              curr.approxMatches = std::round(curr.nucIdentity * curr.blockLength / 100.0);
+          }
+      }
+    }
+
+    /**
+     * @brief Process a fragment of mappings
+     */
+    static void processMappingFragment(std::vector<MappingResult>::iterator start, 
+                                      std::vector<MappingResult>::iterator end)
+    {
+      auto& fragment = *start;
+
+      for (auto it = start; it != end; ++it) {
+          fragment.queryStartPos = std::min(fragment.queryStartPos, it->queryStartPos);
+          fragment.refStartPos = std::min(fragment.refStartPos, it->refStartPos);
+          fragment.queryEndPos = std::max(fragment.queryEndPos, it->queryEndPos);
+          fragment.refEndPos = std::max(fragment.refEndPos, it->refEndPos);
+      }
+
+      fragment.blockLength = std::max(fragment.refEndPos - fragment.refStartPos, 
+                                     fragment.queryEndPos - fragment.queryStartPos);
+      fragment.approxMatches = std::round(fragment.nucIdentity * fragment.blockLength / 100.0);
+      fragment.n_merged = std::distance(start, end);
+
+      fragment.nucIdentity = std::accumulate(start, end, 0.0,
+          [](double sum, const MappingResult& e) { return sum + e.nucIdentity; }
+      ) / fragment.n_merged;
+
+      fragment.kmerComplexity = std::accumulate(start, end, 0.0,
+          [](double sum, const MappingResult& e) { return sum + e.kmerComplexity; }
+      ) / fragment.n_merged;
+
+      std::for_each(std::next(start), end, [](MappingResult& e) { e.discard = 1; });
+    }
+
+    /**
+     * @brief Merge mappings within specified range
+     */
+    template <typename VecIn>
+    static VecIn mergeMappingsInRange(VecIn &readMappings,
+                                     int max_dist,
+                                     const Parameters& param,
+                                     progress_meter::ProgressMeter& progress)
+    {
+      if (!param.split || readMappings.size() < 2) return readMappings;
+
+      // Sort and assign unique IDs
+      std::sort(readMappings.begin(), readMappings.end(),
+          [](const MappingResult &a, const MappingResult &b) {
+              return std::tie(a.refSeqId, a.strand, a.queryStartPos, a.refStartPos)
+                   < std::tie(b.refSeqId, b.strand, b.queryStartPos, b.refStartPos);
+          });
+
+      for (auto it = readMappings.begin(); it != readMappings.end(); ++it) {
+          it->splitMappingId = std::distance(readMappings.begin(), it);
+          it->discard = 0;
+          it->chainPairScore = std::numeric_limits<double>::max();
+          it->chainPairId = std::numeric_limits<int64_t>::min();
+      }
+
+      // Set up union-find for merging
+      std::vector<dsets::DisjointSets::Aint> ufv(readMappings.size());
+      auto disjoint_sets = dsets::DisjointSets(ufv.data(), ufv.size());
+
+      // Process each group
+      auto group_begin = readMappings.begin();
+      while (group_begin != readMappings.end()) {
+          auto group_end = std::find_if_not(group_begin, readMappings.end(),
+              [refSeqId = group_begin->refSeqId, strand = group_begin->strand](const MappingResult &m) {
+                  return m.refSeqId == refSeqId && m.strand == strand;
+              });
+
+          // Find best pairs within group
+          for (auto it = group_begin; it != group_end; ++it) {
+              if (it->chainPairScore != std::numeric_limits<double>::max()) {
+                  disjoint_sets.unite(it->splitMappingId, it->chainPairId);
+              }
+              double best_score = std::numeric_limits<double>::max();
+              auto best_it2 = group_end;
+
+              auto end_it2 = std::upper_bound(it + 1, group_end, it->queryEndPos + max_dist,
+                  [](offset_t val, const MappingResult &m) {
+                      return val < m.queryStartPos;
+                  });
+
+              for (auto it2 = it + 1; it2 != end_it2; ++it2) {
+                  if (it2->queryStartPos == it->queryStartPos) continue;
+                  int64_t query_dist = it2->queryStartPos - it->queryEndPos;
+                  int64_t ref_dist = (it->strand == strnd::FWD) ? 
+                                     it2->refStartPos - it->refEndPos : 
+                                     it->refStartPos - it2->refEndPos;
+                                     
+                  if (query_dist <= max_dist && ref_dist >= -param.segLength/5 && ref_dist <= max_dist) {
+                      double dist_sq = static_cast<double>(query_dist) * query_dist + 
+                                       static_cast<double>(ref_dist) * ref_dist;
+                      double max_dist_sq = static_cast<double>(max_dist) * max_dist;
+                      if (dist_sq < max_dist_sq && dist_sq < best_score && dist_sq < it2->chainPairScore) {
+                          best_it2 = it2;
+                          best_score = dist_sq;
+                      }
+                  }
+              }
+              if (best_it2 != group_end) {
+                  best_it2->chainPairScore = best_score;
+                  best_it2->chainPairId = it->splitMappingId;
+              }
+          }
+          group_begin = group_end;
+      }
+
+      // Assign merged IDs
+      for (auto &mapping : readMappings) {
+          mapping.splitMappingId = disjoint_sets.find(mapping.splitMappingId);
+      }
+
+      // Sort by merged ID
+      std::sort(readMappings.begin(), readMappings.end(),
+          [](const MappingResult &a, const MappingResult &b) {
+              return std::tie(a.splitMappingId, a.queryStartPos, a.refStartPos)
+                   < std::tie(b.splitMappingId, b.queryStartPos, b.refStartPos);
+          });
+
+      // Create maximally merged mappings
+      MappingResultsVector_t maximallyMergedMappings;
+      for (auto it = readMappings.begin(); it != readMappings.end();) {
+          auto it_end = std::find_if(it, readMappings.end(), 
+              [splitId = it->splitMappingId](const MappingResult &e) {
+                  return e.splitMappingId != splitId;
+              });
+
+          // Process chain into fragments
+          auto fragment_start = it;
+          while (fragment_start != it_end) {
+              MappingResult mergedMapping = *fragment_start;
+              auto fragment_end = fragment_start;
+              auto next = std::next(fragment_end);
+             
+              offset_t current_length = fragment_start->queryEndPos - fragment_start->queryStartPos;
+              
+              while (next != it_end) {
+                  offset_t potential_length = next->queryEndPos - fragment_start->queryStartPos;
+                  if (potential_length > param.max_mapping_length) break;
+                  fragment_end = next;
+                  current_length = potential_length;
+                  next = std::next(next);
+              }
+
+              // Set merged mapping properties
+              mergedMapping.queryStartPos = fragment_start->queryStartPos;
+              mergedMapping.queryEndPos = fragment_end->queryEndPos;
+
+              if (mergedMapping.strand == strnd::FWD) {
+                  mergedMapping.refStartPos = fragment_start->refStartPos;
+                  mergedMapping.refEndPos = fragment_end->refEndPos;
+              } else {
+                  mergedMapping.refStartPos = fragment_end->refStartPos;
+                  mergedMapping.refEndPos = fragment_start->refEndPos;
+              }
+              
+              mergedMapping.blockLength = std::max(
+                  mergedMapping.refEndPos - mergedMapping.refStartPos,
+                  mergedMapping.queryEndPos - mergedMapping.queryStartPos
+              );
+
+              // Calculate averages
+              double totalNucIdentity = 0.0;
+              double totalKmerComplexity = 0.0;
+              int totalConservedSketches = 0;
+              int totalSketchSize = 0;
+              int fragment_size = 0;
+              
+              for (auto subIt = fragment_start; subIt != std::next(fragment_end); ++subIt) {
+                  totalNucIdentity += subIt->nucIdentity;
+                  totalKmerComplexity += subIt->kmerComplexity;
+                  totalConservedSketches += subIt->conservedSketches;
+                  totalSketchSize += subIt->sketchSize;
+                  fragment_size++;
+              }
+              
+              mergedMapping.n_merged = fragment_size;
+              mergedMapping.nucIdentity = totalNucIdentity / fragment_size;
+              mergedMapping.kmerComplexity = totalKmerComplexity / fragment_size;
+              mergedMapping.conservedSketches = totalConservedSketches;
+              mergedMapping.sketchSize = totalSketchSize;
+              mergedMapping.blockNucIdentity = mergedMapping.nucIdentity;
+              mergedMapping.approxMatches = std::round(mergedMapping.nucIdentity * mergedMapping.blockLength / 100.0);
+              mergedMapping.discard = 0;
+              mergedMapping.overlapped = false;
+              mergedMapping.chainPairScore = std::numeric_limits<double>::max();
+              mergedMapping.chainPairId = std::numeric_limits<int64_t>::min();
+
+              maximallyMergedMappings.push_back(mergedMapping);
+              fragment_start = std::next(fragment_end);
+          }
+
+          // Process chain with splits
+          processChainWithSplits(it, it_end, param);
+          it = it_end;
+      }
+
+      // Remove discarded mappings
+      readMappings.erase(
+          std::remove_if(readMappings.begin(), readMappings.end(), 
+                         [](const MappingResult& e) { return e.discard == 1; }),
+          readMappings.end()
+      );
+
+      return maximallyMergedMappings;
+    }
+
+    /**
+     * @brief Process a chain of mappings with splits
+     */
+    static void processChainWithSplits(std::vector<MappingResult>::iterator begin, 
+                                      std::vector<MappingResult>::iterator end,
+                                      const Parameters& param)
+    {
+      if (begin == end) return;
+
+      std::vector<bool> is_cuttable(std::distance(begin, end), true);
+      
+      // Mark positions that are not cuttable
+      for (auto it = std::next(begin); it != end; ++it) {
+          auto prev = std::prev(it);
+          if (it->queryStartPos - prev->queryEndPos > param.segLength / 5 ||
+              it->refStartPos - prev->refEndPos > param.segLength / 5) {
+              is_cuttable[std::distance(begin, prev)] = false;
+              is_cuttable[std::distance(begin, it)] = false;
+          }
+      }
+
+      adjustConsecutiveMappings(begin, end, param.segLength);
+
+      auto fragment_start = begin;
+      offset_t accumulate_length = 0;
+
+      for (auto it = begin; it != end; ++it) {
+          accumulate_length += it->queryEndPos - it->queryStartPos;
+          
+          if (accumulate_length >= param.max_mapping_length && is_cuttable[std::distance(begin, it)]) {
+              processMappingFragment(fragment_start, std::next(it));
+              fragment_start = std::next(it);
+              accumulate_length = 0;
+          }
+      }
+
+      if (fragment_start != end) {
+          processMappingFragment(fragment_start, end);
+      }
+
+      computeChainStatistics(begin, end);
+    }
+
+    /**
+     * @brief Compute chain statistics
+     */
+    static void computeChainStatistics(std::vector<MappingResult>::iterator begin, 
+                                      std::vector<MappingResult>::iterator end)
+    {
+      if (begin == end) return;
+
+      offset_t chain_start_query = std::numeric_limits<offset_t>::max();
+      offset_t chain_end_query = std::numeric_limits<offset_t>::min();
+      offset_t chain_start_ref = std::numeric_limits<offset_t>::max();
+      offset_t chain_end_ref = std::numeric_limits<offset_t>::min();
+      double accumulate_nuc_identity = 0.0;
+      double accumulate_kmer_complexity = 0.0;
+      int total_conserved_sketches = 0;
+      int total_sketch_size = 0;
+      int n_in_full_chain = std::distance(begin, end);
+
+      for (auto it = begin; it != end; ++it) {
+          chain_start_query = std::min(chain_start_query, it->queryStartPos);
+          chain_end_query = std::max(chain_end_query, it->queryEndPos);
+          chain_start_ref = std::min(chain_start_ref, it->refStartPos);
+          chain_end_ref = std::max(chain_end_ref, it->refEndPos);
+          accumulate_nuc_identity += it->nucIdentity;
+          accumulate_kmer_complexity += it->kmerComplexity;
+          total_conserved_sketches += it->conservedSketches;
+          total_sketch_size += it->sketchSize;
+      }
+
+      auto chain_nuc_identity = accumulate_nuc_identity / n_in_full_chain;
+      auto chain_kmer_complexity = accumulate_kmer_complexity / n_in_full_chain;
+      auto block_length = std::max(chain_end_query - chain_start_query, chain_end_ref - chain_start_ref);
+
+      for (auto it = begin; it != end; ++it) {
+          it->n_merged = n_in_full_chain;
+          it->blockLength = block_length;
+          it->blockNucIdentity = chain_nuc_identity;
+          it->kmerComplexity = chain_kmer_complexity;
+          it->conservedSketches = total_conserved_sketches;
+          it->sketchSize = total_sketch_size;
+          it->approxMatches = std::round(chain_nuc_identity * block_length / 100.0);
+      }
+    }
+
+    // Scaffold filtering structures and methods
+    struct RotatedEnvelope {
+        double u_start;
+        double u_end;
+        double v_min;
+        double v_max;
+        bool antidiagonal;
+    };
+
+    // Event types for sweep line algorithm
+    enum EventType { START, END };
+    enum MappingType { SCAFFOLD, RAW };
+
+    struct Event {
+        double u;
+        EventType type;
+        MappingType mappingType;
+        double v_min, v_max;
+        size_t id;
+        
+        bool operator<(const Event& other) const {
+            if (u != other.u) return u < other.u;
+            if (type != other.type) return type < other.type;
+            return mappingType < other.mappingType;
+        }
+    };
+
+    // Interval tree for v-coordinate ranges
+    struct Interval {
+        double low, high;
+        size_t id;
+        
+        bool operator<(const Interval& other) const {
+            return low < other.low;
+        }
+    };
+
+    class IntervalTree {
+        std::set<Interval> intervals;
+
+    public:
+        void insert(double low, double high, size_t id) {
+            intervals.insert({low, high, id});
+        }
+
+        void remove(double low, double high, size_t id) {
+            intervals.erase({low, high, id});
+        }
+
+        std::vector<size_t> findOverlapping(double low, double high) const {
+            std::vector<size_t> result;
+            auto it = intervals.upper_bound({low, 0, 0});
+            if (it != intervals.begin()) --it;
+            
+            while (it != intervals.end() && it->low <= high) {
+                if (!(it->high < low || it->low > high)) {
+                    result.push_back(it->id);
+                }
+                ++it;
+            }
+            return result;
+        }
+
+        bool hasOverlap(double low, double high) const {
+            auto it = intervals.upper_bound({low, 0, 0});
+            if (it != intervals.begin()) --it;
+            
+            while (it != intervals.end() && it->low <= high) {
+                if (!(it->high < low || it->low > high)) {
+                    return true;
+                }
+                ++it;
+            }
+            return false;
+        }
+    };
+
+    /**
+     * @brief Compute orientation score for a mapping
+     */
+    static double computeOrientationScore(const MappingResult& m) {
+        int64_t q_span = m.queryEndPos - m.queryStartPos;
+        int64_t r_span = m.refEndPos - m.refStartPos;
+        double diag_proj = (r_span + q_span) / std::sqrt(2.0);
+        double anti_proj = (r_span - q_span) / std::sqrt(2.0);
+        return std::abs(anti_proj / diag_proj);
+    }
+
+    /**
+     * @brief Determine if group should use antidiagonal projection
+     */
+    static bool shouldUseAntidiagonal(const std::vector<MappingResult>& mappings) {
+        double total_weight = 0.0;
+        double weighted_score = 0.0;
+        for (const auto& m : mappings) {
+            double weight = m.queryEndPos - m.queryStartPos;
+            total_weight += weight;
+            weighted_score += weight * computeOrientationScore(m);
+        }
+        return (weighted_score / total_weight) > 1.0;
+    }
+
+    /**
+     * @brief Compute rotated envelope for a mapping
+     */
+    static RotatedEnvelope computeRotatedEnvelope(const MappingResult& m, 
+                                                  bool use_antidiagonal,
+                                                  const Parameters& param) {
+        const double invSqrt2 = 1.0 / std::sqrt(2.0);
+        double u_start, u_end, v1, v2;
+             
+        if (!use_antidiagonal) {
+            u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
+            u_end   = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
+            v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
+            v2 = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
+        } else {
+            u_start = (m.refStartPos - m.queryStartPos) * invSqrt2;
+            u_end   = (m.refEndPos   - m.queryEndPos)   * invSqrt2;
+            v1 = (m.queryStartPos + m.refStartPos) * invSqrt2;
+            v2 = (m.queryEndPos   + m.refEndPos)   * invSqrt2;
+        }
+             
+        double u_min = std::min(u_start, u_end);
+        double u_max = std::max(u_start, u_end);
+        double v_min = std::min(v1, v2) - param.scaffold_max_deviation;
+        double v_max = std::max(v1, v2) + param.scaffold_max_deviation;
+        return { u_min, u_max, v_min, v_max, use_antidiagonal };
+    }
+
+    /**
+     * @brief Filter mappings by scaffolds
+     */
+    static void filterByScaffolds(MappingResultsVector_t& readMappings,
+                                 const MappingResultsVector_t& mergedMappings,
+                                 const Parameters& param,
+                                 const SequenceIdManager& idManager,
+                                 progress_meter::ProgressMeter& progress)
+    {
+        if (param.scaffold_gap == 0 && param.scaffold_min_length == 0 && param.scaffold_max_deviation == 0) {
+            return;
+        }
+
+        // Build scaffold mappings
+        MappingResultsVector_t scaffoldMappings = mergedMappings;
+        Parameters scaffoldParam = param;
+        scaffoldParam.chain_gap *= 2;
+        auto superChains = mergeMappingsInRange(scaffoldMappings, scaffoldParam.chain_gap, scaffoldParam, progress);
+        
+        // Filter and expand scaffolds
+        filterWeakMappings(superChains, std::floor(param.scaffold_min_length / param.segLength), param, idManager);
+        
+        for (auto& mapping : superChains) {
+            int64_t expansion = param.scaffold_max_deviation / 2;
+            mapping.refStartPos = std::max<int64_t>(0, mapping.refStartPos - expansion);
+            mapping.refEndPos = std::min<int64_t>(idManager.getSequenceLength(mapping.refSeqId),
+                                                 mapping.refEndPos + expansion);
+            mapping.queryStartPos = std::max<int64_t>(0, mapping.queryStartPos - expansion);
+            mapping.queryEndPos = std::min<int64_t>(mapping.queryLen, mapping.queryEndPos + expansion);
+            mapping.blockLength = std::max(mapping.refEndPos - mapping.refStartPos,
+                                         mapping.queryEndPos - mapping.queryStartPos);
+        }
+
+        // Group mappings
+        struct GroupKey {
+            seqno_t querySeqId;
+            seqno_t refSeqId;
+            bool operator==(const GroupKey &other) const {
+                return querySeqId == other.querySeqId && refSeqId == other.refSeqId;
+            }
+        };
+        
+        struct GroupKeyHash {
+            std::size_t operator()(const GroupKey &k) const {
+                auto h1 = std::hash<seqno_t>()(k.querySeqId);
+                auto h2 = std::hash<seqno_t>()(k.refSeqId);
+                return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+            }
+        };
+
+        std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> rawGroups;
+        std::unordered_map<GroupKey, std::vector<MappingResult>, GroupKeyHash> scafGroups;
+        
+        for (const auto& m : readMappings) {
+            GroupKey key { m.querySeqId, m.refSeqId };
+            rawGroups[key].push_back(m);
+        }
+        for (const auto& m : superChains) {
+            GroupKey key { m.querySeqId, m.refSeqId };
+            scafGroups[key].push_back(m);
+        }
+
+        // Process each group with 2D sweep
+        MappingResultsVector_t filteredMappings;
+        for (const auto& kv : rawGroups) {
+            const GroupKey& key = kv.first;
+            const auto& groupRaw = kv.second;
+            
+            if (scafGroups.find(key) == scafGroups.end()) {
+                continue;
+            }
+            const auto& groupScaf = scafGroups[key];
+
+            bool use_antidiagonal = shouldUseAntidiagonal(groupScaf);
+
+            // Generate events
+            std::vector<Event> events;
+            std::vector<bool> keep(groupRaw.size(), false);
+
+            // Helper to compute rotated coordinates
+            auto computeRotatedCoords = [use_antidiagonal](const MappingResult& m) {
+                const double invSqrt2 = 1.0 / std::sqrt(2.0);
+                double u_start, u_end, v1, v2;
+                
+                if (!use_antidiagonal) {
+                    u_start = (m.queryStartPos + m.refStartPos) * invSqrt2;
+                    u_end = (m.queryEndPos + m.refEndPos) * invSqrt2;
+                    v1 = (m.refStartPos - m.queryStartPos) * invSqrt2;
+                    v2 = (m.refEndPos - m.queryEndPos) * invSqrt2;
+                } else {
+                    u_start = (m.refStartPos - m.queryStartPos) * invSqrt2;
+                    u_end = (m.refEndPos - m.queryEndPos) * invSqrt2;
+                    v1 = (m.queryStartPos + m.refStartPos) * invSqrt2;
+                    v2 = (m.queryEndPos + m.refEndPos) * invSqrt2;
+                }
+                
+                return std::make_tuple(
+                    std::min(u_start, u_end),
+                    std::max(u_start, u_end),
+                    std::min(v1, v2),
+                    std::max(v1, v2)
+                );
+            };
+
+            // Generate events for scaffolds
+            for (size_t i = 0; i < groupScaf.size(); i++) {
+                auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(groupScaf[i]);
+                v_min -= param.scaffold_max_deviation;
+                v_max += param.scaffold_max_deviation;
+                events.push_back(Event{u_min, START, SCAFFOLD, v_min, v_max, i});
+                events.push_back(Event{u_max, END, SCAFFOLD, v_min, v_max, i});
+            }
+
+            // Generate events for raw mappings
+            for (size_t i = 0; i < groupRaw.size(); i++) {
+                auto [u_min, u_max, v_min, v_max] = computeRotatedCoords(groupRaw[i]);
+                events.push_back(Event{u_min, START, RAW, v_min, v_max, i});
+                events.push_back(Event{u_max, END, RAW, v_min, v_max, i});
+            }
+
+            std::sort(events.begin(), events.end());
+
+            // Process events
+            IntervalTree activeScaffolds;
+            IntervalTree activeRaws;
+
+            for (const auto& event : events) {
+                if (event.type == START && event.mappingType == SCAFFOLD) {
+                    activeScaffolds.insert(event.v_min, event.v_max, event.id);
+                    auto overlapping = activeRaws.findOverlapping(event.v_min, event.v_max);
+                    for (auto raw_id : overlapping) {
+                        keep[raw_id] = true;
+                    }
+                } else if (event.type == END && event.mappingType == SCAFFOLD) {
+                    activeScaffolds.remove(event.v_min, event.v_max, event.id);
+                } else if (event.type == START && event.mappingType == RAW) {
+                    if (!keep[event.id]) {
+                        if (activeScaffolds.hasOverlap(event.v_min, event.v_max)) {
+                            keep[event.id] = true;
+                        } else {
+                            activeRaws.insert(event.v_min, event.v_max, event.id);
+                        }
+                    }
+                } else if (event.type == END && event.mappingType == RAW) {
+                    if (!keep[event.id]) {
+                        activeRaws.remove(event.v_min, event.v_max, event.id);
+                    }
+                }
+            }
+
+            // Collect kept mappings
+            for (size_t i = 0; i < groupRaw.size(); i++) {
+                if (keep[i]) {
+                    filteredMappings.push_back(groupRaw[i]);
+                }
+            }
+        }
+
+        readMappings = std::move(filteredMappings);
+    }
+  };
+}
+
+#endif // MAPPING_FILTER_HPP

--- a/src/map/include/mappingOutput.hpp
+++ b/src/map/include/mappingOutput.hpp
@@ -1,0 +1,172 @@
+/**
+ * @file    mappingOutput.hpp
+ * @brief   Result processing and output for mappings
+ * @author  Chirag Jain <cjain7@gatech.edu>
+ */
+
+#ifndef MAPPING_OUTPUT_HPP
+#define MAPPING_OUTPUT_HPP
+
+#include <vector>
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <cmath>
+#include <functional>
+#include "map/include/base_types.hpp"
+#include "map/include/sequenceIds.hpp"
+#include "map/include/map_parameters.hpp"
+
+namespace skch
+{
+  /**
+   * @brief Class for handling mapping output and reporting
+   */
+  class MappingOutput {
+  public:
+    /**
+     * @brief Check mapping boundaries and fix if needed
+     */
+    template <typename VecIn>
+    static void mappingBoundarySanityCheck(InputSeqProgContainer* input, 
+                                          VecIn &readMappings,
+                                          const SequenceIdManager& idManager)
+    {
+      for(auto &e : readMappings)
+      {
+        //reference start pos
+        {
+          if(e.refStartPos < 0)
+            e.refStartPos = 0;
+          if(e.refStartPos >= idManager.getSequenceLength(e.refSeqId))
+            e.refStartPos = idManager.getSequenceLength(e.refSeqId) - 1;
+        }
+
+        //reference end pos
+        {
+          if(e.refEndPos < e.refStartPos)
+            e.refEndPos = e.refStartPos;
+          if(e.refEndPos >= idManager.getSequenceLength(e.refSeqId))
+            e.refEndPos = idManager.getSequenceLength(e.refSeqId) - 1;
+        }
+
+        //query start pos
+        {
+          if(e.queryStartPos < 0)
+            e.queryStartPos = 0;
+          if(e.queryStartPos >= input->len)
+            e.queryStartPos = input->len;
+        }
+
+        //query end pos
+        {
+          if(e.queryEndPos < e.queryStartPos)
+            e.queryEndPos = e.queryStartPos;
+          if(e.queryEndPos >= input->len)
+            e.queryEndPos = input->len;
+        }
+      }
+    }
+
+    /**
+     * @brief Report final read mappings to output stream
+     */
+    static void reportReadMappings(MappingResultsVector_t &readMappings, 
+                                  const std::string &queryName,
+                                  std::ostream &outstrm,
+                                  const SequenceIdManager& idManager,
+                                  const Parameters& param,
+                                  std::function<void(const MappingResult&)> processMappingResults = nullptr)
+    {
+      // Sort mappings by chain ID and query position
+      std::sort(readMappings.begin(), readMappings.end(),
+          [](const MappingResult &a, const MappingResult &b) {
+              return std::tie(a.splitMappingId, a.queryStartPos)
+                  < std::tie(b.splitMappingId, b.queryStartPos);
+          });
+
+      // Assign chain positions within each chain
+      int current_chain = -1;
+      int chain_pos = 0;
+      int chain_length = 0;
+      
+      // First pass - count chain lengths
+      for (size_t i = 0; i < readMappings.size(); ++i) {
+          if (readMappings[i].splitMappingId != current_chain) {
+              current_chain = readMappings[i].splitMappingId;
+              chain_length = 1;
+              // Count forward to find chain length
+              for (size_t j = i + 1; j < readMappings.size(); ++j) {
+                  if (readMappings[j].splitMappingId == current_chain) {
+                      chain_length++;
+                  } else {
+                      break;
+                  }
+              }
+              // Assign length to all mappings in this chain
+              readMappings[i].chain_length = chain_length;
+              chain_pos = 1;
+          } else {
+              readMappings[i].chain_length = chain_length;
+              chain_pos++;
+          }
+          readMappings[i].chain_pos = chain_pos;
+      }
+
+      //Print the results
+      for(auto &e : readMappings)
+      {
+        float fakeMapQ = e.nucIdentity == 1 ? 255 : std::round(-10.0 * std::log10(1-(e.nucIdentity)));
+        std::string sep = param.legacy_output ? " " : "\t";
+
+        outstrm  << (param.filterMode == filter::ONETOONE ? idManager.getSequenceName(e.querySeqId) : queryName)
+                 << sep << e.queryLen
+                 << sep << e.queryStartPos
+                 << sep << e.queryEndPos - (param.legacy_output ? 1 : 0)
+                 << sep << (e.strand == strnd::FWD ? "+" : "-")
+                 << sep << idManager.getSequenceName(e.refSeqId)
+                 << sep << idManager.getSequenceLength(e.refSeqId)
+                 << sep << e.refStartPos
+                 << sep << e.refEndPos - (param.legacy_output ? 1 : 0);
+
+        if (!param.legacy_output) 
+        {
+          outstrm  << sep << e.conservedSketches
+                   << sep << e.blockLength
+                   << sep << fakeMapQ
+                   << sep << "id:f:" << e.nucIdentity
+                   << sep << "kc:f:" << e.kmerComplexity;
+          if (!param.mergeMappings) 
+          {
+            outstrm << sep << "jc:f:" << float(e.conservedSketches) / e.sketchSize;
+          } else {
+            outstrm << sep << "ch:Z:" << e.splitMappingId << "." << e.chain_pos << "." << e.chain_length;
+          }
+        } else
+        {
+          outstrm << sep << e.nucIdentity * 100.0;
+        }
+
+#ifdef DEBUG
+        outstrm << std::endl;
+#else
+        outstrm << "\n";
+#endif
+
+        //User defined processing of the results
+        if(processMappingResults != nullptr)
+          processMappingResults(e);
+      }
+    }
+
+    /**
+     * @brief Utility function to save L2 results to vector
+     */
+    static void insertL2ResultsToVec(MappingResultsVector_t &v, const MappingResult &reportedL2Result)
+    {
+      v.push_back(reportedL2Result);
+    }
+  };
+}
+
+#endif // MAPPING_OUTPUT_HPP

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -53,9 +53,9 @@ $ mashmap --rl reference_files_list.txt -q seq.fq [OPTIONS]");
     cmd.defineOption("queryList", "a file containing list of query files, one per line", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("queryList","ql");
 
-    cmd.defineOption("segLength", "mapping segment length [default : 5,000]\n\
+    cmd.defineOption("windowLength", "mapping window length [default : 5,000]\n\
 sequences shorter than segment length will be ignored", ArgvParser::OptionRequiresValue);
-    cmd.defineOptionAlternative("segLength","s");
+    cmd.defineOptionAlternative("windowLength","s");
 
     cmd.defineOption("sketchSize", "Number of sketch elements", ArgvParser::OptionRequiresValue);
     cmd.defineOptionAlternative("sketchSize","J");
@@ -400,13 +400,13 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     }
     str.clear();
 
-    if(cmd.foundOption("segLength"))
+    if(cmd.foundOption("windowLength"))
     {
-      str << cmd.optionValue("segLength");
-      str >> parameters.segLength;
+      str << cmd.optionValue("windowLength");
+      str >> parameters.windowLength;
       str.clear();
 
-      if(parameters.segLength < 100)
+      if(parameters.windowLength < 100)
       {
         std::cerr << "ERROR, skch::parseandSave, minimum segment length is required to be >= 100 bp.\n\
           This is because Mashmap is not designed for computing short local alignments.\n" << std::endl;
@@ -414,7 +414,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
       }
     }
     else
-      parameters.segLength = 5000;
+      parameters.windowLength = 5000;
 
     if(cmd.foundOption("blockLength"))
     {
@@ -427,7 +427,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
     } else {
         // n.b. we map-merge across gaps up to 3x segment length
         // and then filter for things that are at least block_length long
-        parameters.block_length = parameters.segLength;
+        parameters.block_length = parameters.windowLength;
     }
     str.clear();
 
@@ -441,7 +441,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
       }
       parameters.chain_gap = l;
     } else {
-      parameters.chain_gap = parameters.segLength;
+      parameters.chain_gap = parameters.windowLength;
     }
     str.clear();
 
@@ -575,7 +575,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
       {
         const double md = 1 - parameters.percentageIdentity;
         double dens = 0.02 * (1 + (md / 0.05));
-        parameters.sketchSize = dens * (parameters.segLength - parameters.kmerSize);
+        parameters.sketchSize = dens * (parameters.windowLength - parameters.kmerSize);
       }
       else 
       {
@@ -584,7 +584,7 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
             skch::fixed::pval_cutoff, skch::fixed::confidence_interval,
             parameters.kmerSize, parameters.alphabetSize,
             parameters.percentageIdentity,
-            parameters.segLength, parameters.referenceSize);
+            parameters.windowLength, parameters.referenceSize);
       }
     }
 

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -215,7 +215,7 @@ namespace skch
                   fileName,
                   target_names,
                   [&](const std::string& seq_name, const std::string& seq) {
-                      if (seq.length() >= param.segLength) {
+                      if (seq.length() >= param.windowLength) {
                           seqno_t seqId = idManager.getSequenceId(seq_name);
                           threadPool.runWhenThreadAvailable(new InputSeqContainer(seq, seq_name, seqId));
                           totalSeqProcessed++;
@@ -440,7 +440,7 @@ namespace skch
                 &(input->seq[0u]), 
                 input->len, 
                 param.kmerSize, 
-                param.segLength, 
+                param.windowLength, 
                 param.alphabetSize, 
                 param.sketchSize,
                 input->seqId,
@@ -555,7 +555,7 @@ namespace skch
       void writeParameters(std::ofstream& outStream)
       {
         // Write segment length, sketch size, and kmer size
-        outStream.write((char*) &param.segLength, sizeof(param.segLength));
+        outStream.write((char*) &param.windowLength, sizeof(param.windowLength));
         outStream.write((char*) &param.sketchSize, sizeof(param.sketchSize));
         outStream.write((char*) &param.kmerSize, sizeof(param.kmerSize));
       }
@@ -665,22 +665,22 @@ namespace skch
        */
       void readParameters(std::ifstream& inStream)
       {
-        decltype(param.segLength) index_segLength;
+        decltype(param.windowLength) index_windowLength;
         decltype(param.sketchSize) index_sketchSize;
         decltype(param.kmerSize) index_kmerSize;
 
-        inStream.read((char*) &index_segLength, sizeof(index_segLength));
+        inStream.read((char*) &index_windowLength, sizeof(index_windowLength));
         inStream.read((char*) &index_sketchSize, sizeof(index_sketchSize));
         inStream.read((char*) &index_kmerSize, sizeof(index_kmerSize));
 
-        if (param.segLength != index_segLength 
+        if (param.windowLength != index_windowLength 
             || param.sketchSize != index_sketchSize
             || param.kmerSize != index_kmerSize)
         {
           std::cerr << "[wfmash::mashmap] ERROR: Parameters of indexed sketch differ from current parameters" << std::endl;
-          std::cerr << "[wfmash::mashmap] Index --> segLength=" << index_segLength
+          std::cerr << "[wfmash::mashmap] Index --> windowLength=" << index_windowLength
                     << " sketchSize=" << index_sketchSize << " kmerSize=" << index_kmerSize << std::endl;
-          std::cerr << "[wfmash::mashmap] Current --> segLength=" << param.segLength
+          std::cerr << "[wfmash::mashmap] Current --> windowLength=" << param.windowLength
                     << " sketchSize=" << param.sketchSize << " kmerSize=" << param.kmerSize << std::endl;
           exit(1);
         }
@@ -755,10 +755,10 @@ namespace skch
         }
         
         // Skip parameters
-        decltype(param.segLength) segLength;
+        decltype(param.windowLength) windowLength;
         decltype(param.sketchSize) sketchSize;
         decltype(param.kmerSize) kmerSize;
-        inStream.read(reinterpret_cast<char*>(&segLength), sizeof(segLength));
+        inStream.read(reinterpret_cast<char*>(&windowLength), sizeof(windowLength));
         inStream.read(reinterpret_cast<char*>(&sketchSize), sizeof(sketchSize));
         inStream.read(reinterpret_cast<char*>(&kmerSize), sizeof(kmerSize));
         


### PR DESCRIPTION
This dramatically reduces the memory and time required by the mapping module. The computeMap.hpp functionality has been refactored into smaller files. Then, lightweight mapping record objects (32 bytes) replaced the 178-byte monster objects that had developed ad-hoc. Local auxiliary data structures provide additional annotations as needed. Improvement in correctness of mapping merging. Scaffold mapping algorithm for distance finding is now dramatically simpler, and involves traversing a proximity K-D tree that links the mappings together across the 2D plane. The result is a dramatically more sensitive, yet not dramatically slower mapping process.