### PR TITLE
Fix deadlock by using a dedicated executor for fragment batches

### DIFF
--- a/BUILD_VENDOR.md
+++ b/BUILD_VENDOR.md
@@ -1,0 +1,51 @@
+# Vendor Everything Build
+
+This branch adds a `VENDOR_EVERYTHING` option to build wfmash with all dependencies downloaded and compiled from source.
+
+## Quick Start
+
+```bash
+./build-vendor-everything.sh [jobs]
+```
+
+This script will:
+1. Download and build all dependencies (zlib, bzip2, xz, htslib, gsl, libdeflate)
+2. Build wfmash statically linked against these dependencies
+3. Copy the final binary to `./wfmash-<version>`
+
+## Manual Build
+
+```bash
+rm -rf build
+cmake -H. -Bbuild -DVENDOR_EVERYTHING=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -- -j 16
+```
+
+## What VENDOR_EVERYTHING Does
+
+When `VENDOR_EVERYTHING=ON`, CMake automatically enables:
+- `BUILD_STATIC=ON` - Build static binary
+- `VENDOR_HTSLIB=ON` - Download and build htslib from source
+- `BUILD_DEPS=ON` - Download and build all dependencies from source
+
+Additional dependencies downloaded and built:
+- zlib 1.3.1
+- bzip2 1.0.8
+- xz 5.4.6
+- GSL 2.8
+- libdeflate 1.20
+- htslib 1.20
+
+## Benefits
+
+- No system dependency requirements beyond basic build tools
+- Reproducible builds across different systems
+- Static linking for easier deployment
+- Known working versions of all dependencies
+
+## Build Requirements
+
+- CMake 3.9+
+- GCC/Clang with C++17 support
+- Basic build tools (make, autotools)
+- Internet connection for downloading dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ enable_testing()
 include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_STANDARD 17)
-# set(CMAKE_CXX_STANDARD 20) # because of sequenceIds.hpp:101:23: warning: captured structured bindings are a C++20 extension [-Wc++20-extensions]
+#set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20) # because of sequenceIds.hpp:101:23: warning: captured structured bindings are a C++20 extension [-Wc++20-extensions]
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard is not allowed.
 set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are used.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,15 @@ option(ASAN "Use address sanitiser (Debug build only)" OFF)
 option(DISABLE_LTO "Disable IPO/LTO" OFF)
 option(STOP_ON_ERROR "Stop compiling on first error" OFF)
 option(VENDOR_HTSLIB "Download and build htslib instead of using system version" OFF)
+option(VENDOR_EVERYTHING "Download and build all dependencies (enables BUILD_STATIC and VENDOR_HTSLIB)" OFF)
+
+# Enable static build and htslib vendoring when VENDOR_EVERYTHING is ON
+if (VENDOR_EVERYTHING)
+  set(BUILD_STATIC ON CACHE BOOL "Build static binary" FORCE)
+  set(VENDOR_HTSLIB ON CACHE BOOL "Download and build htslib instead of using system version" FORCE)
+  set(BUILD_DEPS ON CACHE BOOL "Build external dependencies" FORCE)
+  message(STATUS "VENDOR_EVERYTHING enabled - forcing BUILD_STATIC=ON, VENDOR_HTSLIB=ON, BUILD_DEPS=ON")
+endif()
 
 if (NOT DISABLE_LTO)
   include(CheckIPOSupported) # adds lto
@@ -49,7 +58,12 @@ endif()
 if (BUILD_STATIC)
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   set(BUILD_SHARED_LIBS OFF)
-  set(CMAKE_EXE_LINKER_FLAGS "-static")
+  # Use -static-libgcc -static-libstdc++ instead of full -static for better compatibility
+  if (VENDOR_EVERYTHING)
+    set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+  else()
+    set(CMAKE_EXE_LINKER_FLAGS "-static")
+  endif()
   set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
 else ()
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -57,9 +71,14 @@ endif ()
 
 find_package(PkgConfig REQUIRED)
 # include(FindCURL) # for htslib?
-find_package(ZLIB REQUIRED)
-find_package(BZip2 REQUIRED)
-find_package(LibLZMA REQUIRED)
+
+# When vendoring everything, we'll build these ourselves
+if (NOT VENDOR_EVERYTHING)
+  find_package(ZLIB REQUIRED)
+  find_package(BZip2 REQUIRED)
+  find_package(LibLZMA REQUIRED)
+endif()
+
 find_package(Threads REQUIRED)
 find_package(OpenMP REQUIRED)
 
@@ -180,6 +199,43 @@ if (VENDOR_HTSLIB)
 endif()
 
 if (BUILD_DEPS)
+  # Build core system libraries when vendoring everything
+  if (VENDOR_EVERYTHING)
+    ExternalProject_Add(zlib_vendor
+      URL https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/zlib
+      CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/zlib
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      BUILD_COMMAND cmake --build . --config Release
+      INSTALL_COMMAND cmake --install . --config Release
+    )
+
+    ExternalProject_Add(bzip2_vendor
+      URL https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/bzip2
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND $(MAKE) -f Makefile libbz2.a CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC
+      INSTALL_COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/bzip2/lib ${CMAKE_CURRENT_BINARY_DIR}/bzip2/include && 
+                      cp libbz2.a ${CMAKE_CURRENT_BINARY_DIR}/bzip2/lib/ && 
+                      cp bzlib.h ${CMAKE_CURRENT_BINARY_DIR}/bzip2/include/
+      BUILD_IN_SOURCE 1
+    )
+
+    ExternalProject_Add(xz_vendor
+      URL https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/xz
+      CONFIGURE_COMMAND ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/xz --enable-static --disable-shared --disable-doc
+      BUILD_COMMAND $(MAKE)
+      INSTALL_COMMAND $(MAKE) install
+      BUILD_IN_SOURCE 1
+    )
+  endif()
+
   ExternalProject_Add(htslib
     URL https://github.com/samtools/htslib/releases/download/1.20/htslib-1.20.tar.bz2
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
@@ -194,7 +250,7 @@ if (BUILD_DEPS)
     URL https://mirror.ibcp.fr/pub/gnu/gsl/gsl-2.8.tar.gz
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gsl
-    CONFIGURE_COMMAND ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/gsl
+    CONFIGURE_COMMAND ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/gsl --enable-static --disable-shared
     BUILD_COMMAND $(MAKE)
     INSTALL_COMMAND $(MAKE) install
     BUILD_IN_SOURCE 1
@@ -207,17 +263,27 @@ if (BUILD_DEPS)
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libdeflate
       -DCMAKE_BUILD_TYPE=Release
+      -DLIBDEFLATE_BUILD_STATIC_LIB=ON
+      -DLIBDEFLATE_BUILD_SHARED_LIB=OFF
     BUILD_COMMAND cmake --build . --config Release
     INSTALL_COMMAND cmake --install . --config Release
     BUILD_IN_SOURCE 1
   )
 
-  add_dependencies(wfmash htslib gsl libdeflate)
 endif()
 
 add_executable(wfmash
   src/common/utils.cpp
   src/interface/main.cpp)
+
+# Add dependencies after target creation
+if (BUILD_DEPS)
+  if (VENDOR_EVERYTHING)
+    add_dependencies(wfmash zlib_vendor bzip2_vendor xz_vendor htslib gsl libdeflate)
+  else()
+    add_dependencies(wfmash htslib gsl libdeflate)
+  endif()
+endif()
 
 # Add dependency on vendored htslib if using it
 if (VENDOR_HTSLIB)
@@ -225,18 +291,39 @@ if (VENDOR_HTSLIB)
 endif()
 
 if (BUILD_DEPS)
-  target_include_directories(wfmash PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/htslib/include
-    ${CMAKE_CURRENT_BINARY_DIR}/gsl/include
-    ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/include
-  )
+  if (VENDOR_EVERYTHING)
+    target_include_directories(wfmash PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/htslib/include
+      ${CMAKE_CURRENT_BINARY_DIR}/gsl/include
+      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/include
+      ${CMAKE_CURRENT_BINARY_DIR}/zlib/include
+      ${CMAKE_CURRENT_BINARY_DIR}/bzip2/include
+      ${CMAKE_CURRENT_BINARY_DIR}/xz/include
+    )
 
-  target_link_libraries(wfmash
-    ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgsl.a
-    ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgslcblas.a
-    ${CMAKE_CURRENT_BINARY_DIR}/htslib/lib/libhts.a
-    ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/lib/libdeflate.a
-  )
+    target_link_libraries(wfmash
+      ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgsl.a
+      ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgslcblas.a
+      ${CMAKE_CURRENT_BINARY_DIR}/htslib/lib/libhts.a
+      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/lib64/libdeflate.a
+      ${CMAKE_CURRENT_BINARY_DIR}/zlib/lib/libz.a
+      ${CMAKE_CURRENT_BINARY_DIR}/bzip2/lib/libbz2.a
+      ${CMAKE_CURRENT_BINARY_DIR}/xz/lib/liblzma.a
+    )
+  else()
+    target_include_directories(wfmash PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/htslib/include
+      ${CMAKE_CURRENT_BINARY_DIR}/gsl/include
+      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/include
+    )
+
+    target_link_libraries(wfmash
+      ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgsl.a
+      ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgslcblas.a
+      ${CMAKE_CURRENT_BINARY_DIR}/htslib/lib/libhts.a
+      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/lib/libdeflate.a
+    )
+  endif()
 else()
   #find_package(HTSLIB REQUIRED)
   #find_package(GSL REQUIRED)
@@ -248,7 +335,9 @@ else()
   #  ${LIBDEFLATE_INCLUDE_DIR}
   #)
 
-  if (VENDOR_HTSLIB)
+  if (VENDOR_EVERYTHING)
+    # All libraries are built from source, don't use system libs
+  elseif (VENDOR_HTSLIB)
     target_include_directories(wfmash PRIVATE ${HTSLIB_INCLUDE_DIR})
     target_link_libraries(wfmash
       gsl
@@ -278,11 +367,17 @@ target_link_libraries(wfmash
   m
   pthread
   rt
-  lzma
-  bz2
-  z
   Threads::Threads
 )
+
+# Only link system compression libraries if not vendoring everything
+if (NOT VENDOR_EVERYTHING)
+  target_link_libraries(wfmash
+    lzma
+    bz2
+    z
+  )
+endif()
 
 if (PROFILER)
   target_link_libraries(wfmash profiler)

--- a/scripts/build-vendor-everything.sh
+++ b/scripts/build-vendor-everything.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Build script that vendors all dependencies and builds wfmash statically
+# Usage: ./build-vendor-everything.sh [jobs]
+
+set -e
+
+JOBS=${1:-16}
+BUILD_DIR="build"
+
+echo "Building wfmash with all vendored dependencies..."
+echo "Using $JOBS parallel jobs"
+
+# Clean build directory
+if [ -d "$BUILD_DIR" ]; then
+    echo "Removing existing build directory..."
+    rm -rf "$BUILD_DIR"
+fi
+
+# Configure with vendored everything
+echo "Configuring build with VENDOR_EVERYTHING=ON..."
+cmake -H. -B"$BUILD_DIR" \
+    -DVENDOR_EVERYTHING=ON \
+    -DCMAKE_BUILD_TYPE=Release
+
+# Build
+echo "Building wfmash..."
+cmake --build "$BUILD_DIR" -- -j "$JOBS"
+
+# Get version and copy binary
+if [ -f "$BUILD_DIR/bin/wfmash" ]; then
+    VERSION=$("$BUILD_DIR/bin/wfmash" --version 2>&1 | head -n1 | awk '{print $NF}')
+    OUTPUT_NAME="wfmash-$VERSION"
+    
+    echo "Build successful! Copying binary to ./$OUTPUT_NAME"
+    cp "$BUILD_DIR/bin/wfmash" "./$OUTPUT_NAME"
+    
+    echo "Done! Binary available at: ./$OUTPUT_NAME"
+    echo "File info:"
+    ls -lh "./$OUTPUT_NAME"
+    
+    echo "Testing basic functionality:"
+    "./$OUTPUT_NAME" --help | head -5
+else
+    echo "Error: wfmash binary not found in $BUILD_DIR/bin/"
+    exit 1
+fi

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -875,8 +875,10 @@ namespace skch
               });
           }
           
-          executor.run(batchTaskflow).wait();
-          
+          size_t fragThreads = std::max<size_t>(1, param.threads);
+	  tf::Executor fragmentExecutor(fragThreads);
+	  fragmentExecutor.run(batchTaskflow).wait();
+
           // Post-process and output results
           finalizeQueryResults(queryData, allMappings, progress, subsetMappings, subsetMappings_mutex, outstream);
       }

--- a/src/map/include/mappingOutput.hpp
+++ b/src/map/include/mappingOutput.hpp
@@ -130,6 +130,8 @@ namespace skch
 #else
         outstrm << "\n";
 #endif
+	
+	outstrm.flush();
 
         // User defined processing of the results
         if(processMappingResults != nullptr)


### PR DESCRIPTION
In processQueryParallel, replace the call to executor.run(batchTaskflow).wait() (which reused the outer tf::Executor and could exhaust its threads) with a scoped block that:
	•	Creates a new tf::Executor fragmentExecutor (using param.threads threads)
	•	Runs batchTaskflow on this separate executor
	•	Waits on fragmentExecutor to complete

This ensures inner fragment-batch tasks do not deadlock waiting for threads held by the outer executor.