### PR TITLE
Add simple OOM handler that aborts cleanly with helpful message

### DIFF
--- a/src/interface/main.cpp
+++ b/src/interface/main.cpp
@@ -30,6 +30,8 @@
 #include "align/include/parseCmdArgs.hpp"
 #include "align/include/computeAlignments.hpp"
 
+// Memory handler
+#include "interface/memory_handler.hpp"
 
 // External includes
 #include "common/args.hxx"
@@ -47,6 +49,9 @@ int main(int argc, char** argv) {
     align::Parameters align_parameters;
     yeet::Parameters yeet_parameters;
     yeet::parse_args(argc, argv, map_parameters, align_parameters, yeet_parameters);
+    
+    // Install memory handler for clean abort on OOM
+    wfmash::memory::install_memory_handler();
 
     //parameters.refSequences.push_back(ref);
 

--- a/src/interface/memory_handler.hpp
+++ b/src/interface/memory_handler.hpp
@@ -1,0 +1,72 @@
+#ifndef WFMASH_MEMORY_HANDLER_HPP
+#define WFMASH_MEMORY_HANDLER_HPP
+
+#include <new>
+#include <iostream>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <sstream>
+
+namespace wfmash {
+namespace memory {
+
+// Track allocation failures for informative messages
+inline std::atomic<int> allocation_failures(0);
+inline std::atomic<bool> handler_installed(false);
+inline std::chrono::steady_clock::time_point last_failure_time;
+
+inline void memory_exhausted_handler() {
+    allocation_failures.fetch_add(1);
+    auto now = std::chrono::steady_clock::now();
+    
+    // Only print message once per second to avoid spam
+    static std::chrono::steady_clock::time_point last_print = std::chrono::steady_clock::time_point::min();
+    if (std::chrono::duration_cast<std::chrono::seconds>(now - last_print).count() >= 1) {
+        std::cerr << "\n========================================\n";
+        std::cerr << "[wfmash] ERROR: Memory allocation failed!\n";
+        std::cerr << "========================================\n\n";
+        
+        std::cerr << "The system has run out of available memory.\n";
+        std::cerr << "This typically happens when:\n";
+        std::cerr << "  - The batch size (-b) is too large for available RAM\n";
+        std::cerr << "  - Too many threads are trying to allocate memory simultaneously\n";
+        std::cerr << "  - The input sequences are very large\n\n";
+        
+        std::cerr << "SUGGESTIONS TO FIX THIS:\n";
+        std::cerr << "  1. Reduce batch size: Try -b 500m or -b 100m instead of -b 1g\n";
+        std::cerr << "  2. Use fewer threads: Try -t 24 or -t 48 instead of -t 112\n";
+        std::cerr << "  3. Run on a node with more memory\n";
+        std::cerr << "  4. Split your input into smaller chunks\n\n";
+        
+        std::cerr << "The program will now exit to prevent system instability.\n";
+        std::cerr << "Please adjust parameters and try again.\n";
+        std::cerr << "========================================\n\n";
+        
+        last_print = now;
+    }
+    
+    // Give a moment for the message to be written
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    
+    // Exit cleanly with error code
+    std::abort();
+}
+
+inline void install_memory_handler() {
+    if (!handler_installed.exchange(true)) {
+        std::set_new_handler(memory_exhausted_handler);
+        std::cerr << "[wfmash] Memory handler installed - will abort cleanly on allocation failure\n";
+    }
+}
+
+inline void uninstall_memory_handler() {
+    if (handler_installed.exchange(false)) {
+        std::set_new_handler(nullptr);
+    }
+}
+
+} // namespace memory
+} // namespace wfmash
+
+#endif // WFMASH_MEMORY_HANDLER_HPP


### PR DESCRIPTION
- Installs custom new_handler to catch memory allocation failures
- Provides clear error message explaining the issue
- Suggests concrete solutions (reduce batch size, use fewer threads, etc.)
- Exits cleanly instead of undefined behavior
- Helps users understand and fix memory issues