### PR TITLE
Add scaffold overlap threshold parameter (default 0.5)

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -89,6 +89,7 @@ void parse_args(int argc,
     args::ValueFlag<int> scaffold_mass(scaffold_opts, "INT", "scaffold mass (min segments) [5]", {'S', "scaffold-mass"});
     args::ValueFlag<std::string> scaffold_dist(scaffold_opts, "INT", "max scaffold distance [100k]", {'D', "scaffold-dist"});
     args::ValueFlag<std::string> scaffold_jump(scaffold_opts, "INT", "scaffold jump (gap) [100k]", {'j', "scaffold-jump"});
+    args::ValueFlag<double> scaffold_overlap_thresh(scaffold_opts, "FLOAT", "scaffold chain overlap threshold [0.5]", {"scaffold-overlap"});
     args::ValueFlag<std::string> scaffold_output(scaffold_opts, "FILE", "output scaffold mappings to FILE", {"scaffold-out"});
 
     // SELECTION
@@ -448,6 +449,10 @@ void parse_args(int argc,
 
     if (scaffold_output) {
         map_parameters.scaffold_output_file = args::get(scaffold_output);
+    }
+
+    if (scaffold_overlap_thresh) {
+        map_parameters.scaffold_overlap_threshold = args::get(scaffold_overlap_thresh);
     }
 
     if (max_mapping_length) {

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -81,6 +81,7 @@ struct Parameters
     bool world_minimizers = false;
     uint64_t sparsity_hash_threshold;                 // keep mappings that hash to <= this value
     double overlap_threshold;                         // minimum overlap for a mapping to be considered
+    double scaffold_overlap_threshold = 0.5;          // overlap threshold for scaffold chain filtering
     int64_t scaffold_max_deviation;                  // max diagonal deviation from scaffold chains
     int64_t scaffold_gap;                           // gap threshold for scaffold chaining
     int64_t scaffold_min_length = 50000;            // minimum scaffold block length

--- a/src/map/include/mappingFilter.hpp
+++ b/src/map/include/mappingFilter.hpp
@@ -874,8 +874,11 @@ namespace skch
         // Step 4: Apply plane sweep filter to the merged chains to remove off-diagonal/weaker scaffold chains
         if (!mergedChains.empty() && (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE)) {
             MappingResultsVector_t filteredChains;
+            // Use scaffold-specific overlap threshold for more aggressive filtering
+            Parameters scaffoldFilterParam = param;
+            scaffoldFilterParam.overlap_threshold = param.scaffold_overlap_threshold;
             filterByGroup(mergedChains, filteredChains, param.numMappingsForSegment - 1, 
-                         false, idManager, param, progress);
+                         false, idManager, scaffoldFilterParam, progress);
             mergedChains = std::move(filteredChains);
         }
 


### PR DESCRIPTION
- Add scaffold_overlap_threshold parameter to map_parameters.hpp with default 0.5
- Add --scaffold-overlap command-line flag to parse_args.hpp
- Modify filterByScaffolds to use scaffold-specific overlap threshold for more aggressive filtering of off-diagonal chains