### PR TITLE
Fix ANI logging to correctly show ani50-2 offset

### DIFF
--- a/src/interface/parse_args.hpp
+++ b/src/interface/parse_args.hpp
@@ -383,11 +383,11 @@ void parse_args(int argc,
             }
         }
     } else {
-        // No -p flag provided, use ani50 by default (set here, not in Parameters struct)
+        // No -p flag provided, use ani50-2 by default (set here, not in Parameters struct)
         map_parameters.percentageIdentity = skch::fixed::percentage_identity; // Will be overridden
         map_parameters.auto_pct_identity = true;
         map_parameters.ani_percentile = 50;
-        map_parameters.ani_adjustment = 0.0;
+        map_parameters.ani_adjustment = -2.0;
     }
 
     if (block_length) {


### PR DESCRIPTION
The logging was showing 'ani50' instead of 'ani50-2' because ani_adjustment was being reset to 0.0 in the default parameter handling. This fixes the issue by ensuring the default ani_adjustment value of -2.0 is preserved when no -p flag is provided.

- Fix ani_adjustment being reset to 0.0 in default case
- Update comment to reflect ani50-2 default
- Logging now correctly shows 'ani50-2' instead of just 'ani50'