### PR TITLE
fix: support building with GCC on macOS ARM64

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -70,7 +70,7 @@ jobs:
           export CC=gcc-${GCC_VERSION}
           export CXX=g++-${GCC_VERSION}
           echo "Using CC=$CC CXX=$CXX"
-          cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DVENDOR_EVERYTHING=ON
+          cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DVENDOR_EVERYTHING=ON
           cmake --build build -- -j 3
       - name: Run cmake tests
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -11,7 +11,7 @@ on:
 name: build and test
 
 jobs:
-  build_and_test:
+  build_and_test_linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -36,12 +36,42 @@ jobs:
           cargo
       - name: Install wgatools
         run: cargo install --git https://github.com/wjwei-handsome/wgatools.git
-      - name: Install pafcheck  
+      - name: Install pafcheck
         run: cargo install --git https://github.com/ekg/pafcheck.git
       - name: Init and update submodules
         run: git submodule update --init --recursive
       - name: Build wfmash
         run: cmake -H. -Bbuild -D CMAKE_BUILD_TYPE=Debug -DWFA_PNG_AND_TSV=ON && cmake --build build -- -j 2
+      - name: Run cmake tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
+  build_and_test_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install required packages
+        run: |
+          brew install cmake gcc gsl zlib samtools bedtools
+          # Install Rust toolchain
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install wgatools
+        run: cargo install --git https://github.com/wjwei-handsome/wgatools.git
+      - name: Install pafcheck
+        run: cargo install --git https://github.com/ekg/pafcheck.git
+      - name: Init and update submodules
+        run: git submodule update --init --recursive
+      - name: Build wfmash
+        run: |
+          # Use Homebrew GCC for OpenMP support (Apple clang doesn't support -fopenmp)
+          GCC_VERSION=$(ls /opt/homebrew/bin/gcc-* 2>/dev/null | grep -o '[0-9]*$' | sort -rn | head -1)
+          export CC=gcc-${GCC_VERSION}
+          export CXX=g++-${GCC_VERSION}
+          echo "Using CC=$CC CXX=$CXX"
+          cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DVENDOR_EVERYTHING=ON
+          cmake --build build -- -j 3
       - name: Run cmake tests
         run: |
           cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ if (BUILD_DEPS)
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libdeflate
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libdeflate
+      -DCMAKE_INSTALL_LIBDIR=lib
       -DCMAKE_BUILD_TYPE=Release
       -DLIBDEFLATE_BUILD_STATIC_LIB=ON
       -DLIBDEFLATE_BUILD_SHARED_LIB=OFF
@@ -317,7 +318,7 @@ if (BUILD_DEPS)
       ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgsl.a
       ${CMAKE_CURRENT_BINARY_DIR}/gsl/lib/libgslcblas.a
       ${CMAKE_CURRENT_BINARY_DIR}/htslib/lib/libhts.a
-      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/lib64/libdeflate.a
+      ${CMAKE_CURRENT_BINARY_DIR}/libdeflate/lib/libdeflate.a
       ${CMAKE_CURRENT_BINARY_DIR}/zlib/lib/libz.a
       ${CMAKE_CURRENT_BINARY_DIR}/bzip2/lib/libbz2.a
       ${CMAKE_CURRENT_BINARY_DIR}/xz/lib/liblzma.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,9 +378,13 @@ target_include_directories(wfmash PRIVATE
 target_link_libraries(wfmash
   m
   pthread
-  rt
   Threads::Threads
 )
+
+# librt is needed on Linux but not on macOS (where it doesn't exist)
+if (NOT APPLE)
+  target_link_libraries(wfmash rt)
+endif()
 
 # Only link system compression libraries if not vendoring everything
 if (NOT VENDOR_EVERYTHING)

--- a/src/common/wflign/src/wflign_patch.cpp
+++ b/src/common/wflign/src/wflign_patch.cpp
@@ -785,16 +785,16 @@ AlignmentBounds find_alignment_bounds(const alignment_t& aln, const int& erode_k
         bounds.target_start_offset = 0;
     } else {
         // heuristic: subtract erode_k
-        bounds.query_start_offset = std::max((int64_t)0, bounds.query_start_offset - erode_k);
-        bounds.target_start_offset = std::max((int64_t)0, bounds.target_start_offset - erode_k);
+        bounds.query_start_offset = std::max(static_cast<int64_t>(0), bounds.query_start_offset - static_cast<int64_t>(erode_k));
+        bounds.target_start_offset = std::max(static_cast<int64_t>(0), bounds.target_start_offset - static_cast<int64_t>(erode_k));
     }
     if (!found_end) {
         bounds.query_end_offset = aln.query_length;
         bounds.target_end_offset = aln.target_length;
     } else {
         // heuristic: add erode_k
-        bounds.query_end_offset = std::min((int64_t)aln.query_length, bounds.query_end_offset + erode_k);
-        bounds.target_end_offset = std::min((int64_t)aln.target_length, bounds.target_end_offset + erode_k);
+        bounds.query_end_offset = std::min(static_cast<int64_t>(aln.query_length), bounds.query_end_offset + static_cast<int64_t>(erode_k));
+        bounds.target_end_offset = std::min(static_cast<int64_t>(aln.target_length), bounds.target_end_offset + static_cast<int64_t>(erode_k));
     }
 
     // Adjust bounds for reverse complement alignments
@@ -1262,7 +1262,7 @@ void write_merged_alignment(
             // Head patching
             if (query_start > 0 || target_start > 0) {
                 // Calculate how far we need to shift to cover the query, and how far we can safely shift
-                int64_t needed_shift = std::max(0L, static_cast<int64_t>(query_start) - static_cast<int64_t>(target_start));
+                int64_t needed_shift = std::max(static_cast<int64_t>(0), static_cast<int64_t>(query_start) - static_cast<int64_t>(target_start));
                 int64_t max_safe_shift = std::min(
                     static_cast<int64_t>(wflign_max_len_minor),
                     static_cast<int64_t>(target_offset)
@@ -1652,7 +1652,7 @@ void write_merged_alignment(
             // Tail patching
             if (query_pos < query_length || target_pos < target_length) {
                 // Calculate how much additional target sequence we need
-                int64_t needed_extension = std::max(0L, static_cast<int64_t>(query_length - query_pos) - static_cast<int64_t>(target_length - target_pos));
+                int64_t needed_extension = std::max(static_cast<int64_t>(0), static_cast<int64_t>(query_length - query_pos) - static_cast<int64_t>(target_length - target_pos));
     
                 // Calculate how much we can safely extend
                 int64_t max_safe_extension = std::min(

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -393,7 +393,7 @@ namespace skch
 
           uint64_t freq_cutoff;
           if (param.max_kmer_freq <= 1.0) {
-              freq_cutoff = std::max(1UL, (uint64_t)(total_windows * param.max_kmer_freq));
+              freq_cutoff = std::max(static_cast<uint64_t>(1), static_cast<uint64_t>(total_windows * param.max_kmer_freq));
           } else {
               freq_cutoff = (uint64_t)param.max_kmer_freq;
           }


### PR DESCRIPTION
## Summary

- Skip linking `-lrt` on macOS (librt doesn't exist on Darwin; clock/timer functions are in libSystem)
- Fix `std::max`/`std::min` type mismatches in `wflign_patch.cpp` and `winSketch.hpp`

On macOS ARM64, `long` and `long long` are both 64-bit but **different types**. GCC's strict template deduction for `std::max`/`std::min` requires both arguments to be the same type, while Apple clang is permissive about this. This causes build failures when using GCC (e.g., from Homebrew) on macOS ARM64.

### Changes
| File | Issue |
|------|-------|
| `CMakeLists.txt` | Guard `-lrt` with `if (NOT APPLE)` |
| `wflign_patch.cpp:788-797` | `std::max((int64_t)0, int64_t - int)` → explicit `static_cast<int64_t>` on both args |
| `wflign_patch.cpp:1265,1655` | `std::max(0L, int64_t)` → `std::max(static_cast<int64_t>(0), ...)` |
| `winSketch.hpp:396` | `std::max(1UL, uint64_t)` → `std::max(static_cast<uint64_t>(1), ...)` |

## Test plan
- [x] Verified fixes compile with GCC-15 on macOS ARM64 via CI (wfmash-rs)
- [x] Verify no regression on Linux builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)