### PR TITLE
Avoid filtering all k-mers (rebased from #366)

### DIFF
--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -295,6 +295,48 @@ namespace skch
               }
           }
 
+          // Calculate count_threshold ONCE before parallel section
+          uint64_t min_occ = 10;
+          uint64_t max_occ = std::numeric_limits<uint64_t>::max();
+          uint64_t count_threshold;
+
+          if (param.max_kmer_freq <= 1.0) {
+              count_threshold = std::min(max_occ,
+                                      std::max(min_occ,
+                                              (uint64_t)(total_windows * param.max_kmer_freq)));
+          } else {
+              count_threshold = std::min(max_occ,
+                                      std::max(min_occ,
+                                              (uint64_t)param.max_kmer_freq));
+          }
+
+          // Safety check to prevent filtering all k-mers
+          size_t would_filter = 0;
+          for (const auto& [hash, freq] : kmer_freqs) {
+              if (freq > count_threshold && freq > min_occ) {
+                  would_filter++;
+              }
+          }
+
+          // If we would filter too many k-mers (>70%), adjust threshold
+          if (would_filter > kmer_freqs.size() * 0.7) {
+              std::vector<uint64_t> all_freqs;
+              all_freqs.reserve(kmer_freqs.size());
+              for (const auto& [hash, freq] : kmer_freqs) {
+                  all_freqs.push_back(freq);
+              }
+              std::sort(all_freqs.begin(), all_freqs.end());
+
+              // Find threshold that keeps at least 10% of k-mers
+              size_t keep_index = kmer_freqs.size() - (kmer_freqs.size() / 10);
+              count_threshold = all_freqs[keep_index];
+
+              std::cerr << "[wfmash::mashmap] WARNING: Adjusted k-mer frequency threshold from "
+                      << (uint64_t)(total_windows * param.max_kmer_freq)
+                      << " to " << count_threshold
+                      << " to prevent filtering all k-mers" << std::endl;
+          }
+
           // Parallel index building
           std::vector<MI_Map_t> thread_pos_indexes(param.threads);
           std::vector<MI_Type> thread_minmer_indexes(param.threads);
@@ -303,33 +345,20 @@ namespace skch
           std::vector<std::thread> index_threads;
 
           for (size_t t = 0; t < param.threads; ++t) {
-              index_threads.emplace_back([&, t]() {
+              index_threads.emplace_back([&, t, count_threshold]() {
                   size_t start = t * chunk_size;
                   size_t end = std::min(start + chunk_size, threadOutputs.size());
 
                   for (size_t i = start; i < end; ++i) {
                       for (const MinmerInfo& mi : *threadOutputs[i]) {
                           thread_total_kmers[t]++;
-                          
+
                           auto freq_it = kmer_freqs.find(mi.hash);
                           if (freq_it == kmer_freqs.end()) {
                               continue;  // Should never happen
                           }
 
                           uint64_t freq = freq_it->second;
-                          uint64_t min_occ = 10;
-                          uint64_t max_occ = std::numeric_limits<uint64_t>::max();
-                          uint64_t count_threshold;
-                          
-                          if (param.max_kmer_freq <= 1.0) {
-                              count_threshold = std::min(max_occ, 
-                                                       std::max(min_occ, 
-                                                              (uint64_t)(total_windows * param.max_kmer_freq)));
-                          } else {
-                              count_threshold = std::min(max_occ,
-                                                       std::max(min_occ,
-                                                              (uint64_t)param.max_kmer_freq));
-                          }
 
                           if (freq > count_threshold && freq > min_occ) {
                               thread_filtered_kmers[t]++;
@@ -391,16 +420,10 @@ namespace skch
           // Always finish the index progress meter
           index_progress->finish();
 
-          uint64_t freq_cutoff;
-          if (param.max_kmer_freq <= 1.0) {
-              freq_cutoff = std::max(static_cast<uint64_t>(1), static_cast<uint64_t>(total_windows * param.max_kmer_freq));
-          } else {
-              freq_cutoff = (uint64_t)param.max_kmer_freq;
-          }
-          std::cerr << "[wfmash::mashmap] Processed " << totalSeqProcessed << " sequences (" << totalSeqSkipped << " skipped, " << total_seq_length << " total bp), " 
+          std::cerr << "[wfmash::mashmap] Processed " << totalSeqProcessed << " sequences (" << totalSeqSkipped << " skipped, " << total_seq_length << " total bp), "
                     << minmerPosLookupIndex.size() << " unique hashes, " << minmerIndex.size() << " windows" << std::endl
-                    << "[wfmash::mashmap] Filtered " << filtered_kmers << "/" << total_kmers 
-                    << " k-mers occurring > " << freq_cutoff << " times"
+                    << "[wfmash::mashmap] Filtered " << filtered_kmers << "/" << total_kmers
+                    << " k-mers occurring > " << count_threshold << " times"
                     << " (target: " << (param.max_kmer_freq <= 1.0 ? 
                                       ([&]() { 
                                           std::stringstream ss;


### PR DESCRIPTION
## Summary

Rebases the core logic from #366 onto current main, which had diverged significantly (struct redesign, code refactoring into separate files).

- Compute `count_threshold` once before the parallel index-building section instead of redundantly per-kmer in each thread
- Add safety check: if >70% of k-mers would be filtered, automatically adjust threshold to keep at least 10%
- Log the actual threshold used (which may differ from the configured one if adjustment was triggered)

The `int32→int64` chain field changes from #366 are no longer needed since main redesigned `MappingResult` into a compact 32-byte struct with a separate `ChainInfo` type.

Supersedes #366.

## Test plan

- [x] Builds cleanly