### PR TITLE
Accept AGC archives as sequence input

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -45,3 +45,29 @@ jobs:
         run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/reference.fa.gz data/reads.500bps.fa.gz -s 0.5k -N -a > reads.500bps.sam && samtools view reads.500bps.sam -bS | samtools sort > reads.500bps.bam && samtools index reads.500bps.bam && samtools view reads.500bps.bam | head
       - name: Test mapping+alignment with short reads (255bps) (PAF output)
         run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/reads.255bps.fa.gz -w 16 -s 100 -L > reads.255bps.paf && head reads.255bps.paf
+
+  agc_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install required packages
+        run: sudo apt-get update && sudo apt-get install -y
+          git
+          bash
+          cmake
+          make
+          g++
+          python3-dev
+          libgsl-dev
+          zlib1g-dev
+          libhts-dev
+          samtools
+          libjemalloc-dev
+      - name: Init and update submodules
+        run: git submodule update --init --recursive
+      - name: Build AGC (produces bin/agc and bin/libagc.a)
+        run: git clone --depth 1 --branch v3.2.1 --recurse-submodules https://github.com/refresh-bio/agc /tmp/agc && make -C /tmp/agc -j 2
+      - name: Build wfmash with AGC support
+        run: cmake -H. -Bbuild-agc -D CMAKE_BUILD_TYPE=Release -DAGC_ROOT=/tmp/agc && cmake --build build-agc -- -j 2
+      - name: AGC input produces identical output to FASTA
+        run: WFMASH=build-agc/bin/wfmash PATH="/tmp/agc/bin:$PATH" scripts/test_agc.sh data/LPA.subset.fa.gz -n 10 -L

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -12,7 +12,7 @@ name: build and test
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install required packages
@@ -47,7 +47,7 @@ jobs:
         run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/reads.255bps.fa.gz -w 16 -s 100 -L > reads.255bps.paf && head reads.255bps.paf
 
   agc_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install required packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,26 @@ if (NOT APPLE)
   target_link_libraries(wfmash rt)
 endif()
 
+# --- AGC (Assembled Genomes Compressor) support: read .agc archives directly ---
+# Defaults to a sibling checkout of https://github.com/refresh-bio/agc built with
+# `make` (which produces bin/libagc.a and 3rd_party/zstd/lib/libzstd.a). If it is
+# not found, wfmash still builds but will not accept .agc input.
+set(AGC_ROOT "${CMAKE_SOURCE_DIR}/../agc" CACHE PATH
+    "Path to an AGC source tree with bin/libagc.a and src/lib-cxx/agc-api.h")
+if (EXISTS "${AGC_ROOT}/bin/libagc.a" AND EXISTS "${AGC_ROOT}/src/lib-cxx/agc-api.h")
+    message(STATUS "AGC support: ENABLED (AGC_ROOT=${AGC_ROOT})")
+    target_compile_definitions(wfmash PRIVATE WFMASH_HAVE_AGC)
+    target_include_directories(wfmash PRIVATE ${AGC_ROOT}/src/lib-cxx)
+    # libagc.a must precede libzstd.a on the link line (it references ZSTD_*).
+    target_link_libraries(wfmash
+        ${AGC_ROOT}/bin/libagc.a
+        ${AGC_ROOT}/3rd_party/zstd/lib/libzstd.a
+    )
+else()
+    message(WARNING "AGC support: DISABLED (no libagc.a / agc-api.h under AGC_ROOT=${AGC_ROOT}); "
+        ".agc input will not be accepted. Set -DAGC_ROOT=/path/to/agc to enable.")
+endif()
+
 install(TARGETS wfmash DESTINATION bin)
 
 install(TARGETS wfa2cpp

--- a/scripts/test_agc.sh
+++ b/scripts/test_agc.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Verify that wfmash produces identical output from a FASTA and from the same sequences
+# stored in an AGC archive.
+#
+# Requires: agc and samtools on PATH, and a wfmash built with AGC support
+# (point WFMASH at it; defaults to build/bin/wfmash).
+#
+# Usage: scripts/test_agc.sh <fasta[.gz]> [extra wfmash args...]
+set -euo pipefail
+
+fasta="${1:?usage: test_agc.sh <fasta[.gz]> [wfmash args...]}"
+shift || true
+wfmash="${WFMASH:-build/bin/wfmash}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Plain FASTA (+ .fai) for the FASTA run and as the source for the AGC archive.
+zcat -f "$fasta" > "$tmp/seq.fa"
+samtools faidx "$tmp/seq.fa"
+agc create -o "$tmp/seq.agc" "$tmp/seq.fa" > /dev/null 2>&1
+
+# -t 1 makes wfmash deterministic, so the sorted PAFs are directly comparable.
+"$wfmash" "$tmp/seq.fa"  -t 1 "$@" 2>/dev/null | sort > "$tmp/fa.paf"
+"$wfmash" "$tmp/seq.agc" -t 1 "$@" 2>/dev/null | sort > "$tmp/agc.paf"
+
+if diff -q "$tmp/fa.paf" "$tmp/agc.paf" > /dev/null; then
+    echo "[test_agc] OK: FASTA and AGC produce identical output ($(wc -l < "$tmp/fa.paf") mappings) for $fasta"
+else
+    echo "[test_agc] FAIL: FASTA and AGC output differ for $fasta"
+    diff "$tmp/fa.paf" "$tmp/agc.paf" | head
+    exit 1
+fi

--- a/scripts/test_agc.sh
+++ b/scripts/test_agc.sh
@@ -31,3 +31,26 @@ else
     diff "$tmp/fa.paf" "$tmp/agc.paf" | head
     exit 1
 fi
+
+# A multi-sample archive built the canonical AGC way (one sample per file, plain contig
+# names) repeats contig names across samples. Those records must stay distinct: each is
+# named contig@sample and must carry its own sample's bases. If they collapsed onto one
+# name/sequence, the two copies would look identical and be dropped as self-mappings.
+name="$(head -n 1 "$tmp/seq.fa" | sed 's/^>//' | cut -f1 -d' ')"
+samtools faidx "$tmp/seq.fa" "$name" | tail -n +2 | tr -d '\n' > "$tmp/one.seq"
+{ echo ">shared_ctg"; cat "$tmp/one.seq"; echo; } > "$tmp/sampleX.fa"
+# sampleY: the same sequence with every 50th base flipped, so the two still align
+{ echo ">shared_ctg"
+  awk '{ for (i = 1; i <= length($0); i++) { c = substr($0, i, 1);
+         printf "%s", (i % 50 == 0 ? (c == "A" ? "T" : "A") : c) } print "" }' "$tmp/one.seq"
+} > "$tmp/sampleY.fa"
+agc create -o "$tmp/multi.agc" "$tmp/sampleX.fa" "$tmp/sampleY.fa" > /dev/null 2>&1
+
+"$wfmash" "$tmp/multi.agc" -t 1 "$@" 2>/dev/null > "$tmp/multi.paf" || true
+if grep -q 'shared_ctg@sampleX' "$tmp/multi.paf" && grep -q 'shared_ctg@sampleY' "$tmp/multi.paf"; then
+    echo "[test_agc] OK: duplicate contig names across samples stay distinct (from $name)"
+else
+    echo "[test_agc] FAIL: expected shared_ctg@sampleX and shared_ctg@sampleY in the output"
+    head "$tmp/multi.paf"
+    exit 1
+fi

--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -28,6 +28,7 @@
 #include "common/wflign/src/wflign.hpp"
 #include "common/atomic_queue/atomic_queue.h"
 #include "common/seqiter.hpp"
+#include "common/agc_index.hpp"
 #include "common/progress.hpp"
 #include "common/utils.hpp"
 
@@ -73,16 +74,27 @@ namespace align
 
       refSequenceMap_t refSequences;
       std::vector<faidx_t*> faidxs;
+      // When the reference is an AGC archive we keep one AgcIndex per thread
+      // instead of a faidx_t, mirroring the per-thread faidx model below.
+      bool use_agc = false;
+#ifdef WFMASH_HAVE_AGC
+      std::vector<agcidx::AgcIndex*> agc_readers;
+#endif
 
     public:
       /**
-       * @brief                 destructor, cleans up faidx index
+       * @brief                 destructor, cleans up faidx / AGC indices
        */
       ~Aligner()
       {
           for (auto& faid : this->faidxs) {
               fai_destroy(faid);
           }
+#ifdef WFMASH_HAVE_AGC
+          for (auto* reader : this->agc_readers) {
+              delete reader;
+          }
+#endif
       }
 
       /**
@@ -148,6 +160,22 @@ namespace align
           auto& nthreads = param.threads;
           assert(param.refSequences.size() == 1);
           auto& filename = param.refSequences.front();
+#ifdef WFMASH_HAVE_AGC
+          if (agcidx::is_agc_file(filename)) {
+              use_agc = true;
+              // One decompressor per thread: AGC's per-query state is not shared
+              // across threads, exactly like the per-thread faidx_t below.
+              for (int i = 0; i < nthreads; ++i) {
+                  auto* reader = new agcidx::AgcIndex();
+                  if (!reader->open(filename)) {
+                      std::cerr << "[wfmash::align] ERROR: could not open AGC archive " << filename << std::endl;
+                      exit(1);
+                  }
+                  agc_readers.push_back(reader);
+              }
+              return;
+          }
+#endif
           for (int i = 0; i < nthreads; ++i) {
               auto faid = fai_load(filename.c_str());
               faidxs.push_back(faid);
@@ -467,20 +495,44 @@ namespace align
 
         //Obtain reference substring for this mapping
         // htslib caches are not threadsafe! so we use a thread-specific faidx_t
+        // (or, for AGC input, a thread-specific AgcIndex).
+#ifdef WFMASH_HAVE_AGC
+        agcidx::AgcIndex* agc_reader = use_agc ? agc_readers[tid] : nullptr;
+        faidx_t* faid = use_agc ? nullptr : faidxs[tid];
+        const int64_t ref_size = use_agc
+            ? agc_reader->length(currentRecord.refId)
+            : faidx_seq_len(faid, currentRecord.refId.c_str());
+#else
         faidx_t* faid = faidxs[tid];
         const int64_t ref_size = faidx_seq_len(faid, currentRecord.refId.c_str());
+#endif
 
         // Take flanking sequences to support head/tail patching due to noisy (inaccurate) mapping boundaries
         const uint64_t head_padding = currentRecord.rStartPos >= param.wflign_max_len_minor ? param.wflign_max_len_minor : currentRecord.rStartPos;
         const uint64_t tail_padding = ref_size - currentRecord.rEndPos >= param.wflign_max_len_minor ? param.wflign_max_len_minor : ref_size - currentRecord.rEndPos;
 
         int64_t got_seq_len = 0;
-        char * ref_seq = faidx_fetch_seq64(
-                faid, currentRecord.refId.c_str(),
-                currentRecord.rStartPos - head_padding,
-                currentRecord.rEndPos + tail_padding,
-                &got_seq_len
-                );
+        char * ref_seq;
+#ifdef WFMASH_HAVE_AGC
+        if (use_agc) {
+            // fetch_malloc returns a malloc()-ed, 0-terminated buffer with the same
+            // [start,end] inclusive convention as faidx_fetch_seq64, so the cleanup
+            // (free of ref_seq - head_padding) below is unchanged.
+            ref_seq = agc_reader->fetch_malloc(
+                    currentRecord.refId,
+                    (int64_t)currentRecord.rStartPos - (int64_t)head_padding,
+                    (int64_t)currentRecord.rEndPos + (int64_t)tail_padding,
+                    got_seq_len);
+        } else
+#endif
+        {
+            ref_seq = faidx_fetch_seq64(
+                    faid, currentRecord.refId.c_str(),
+                    currentRecord.rStartPos - head_padding,
+                    currentRecord.rEndPos + tail_padding,
+                    &got_seq_len
+                    );
+        }
 
         // hack to make it 0-terminated as expected by WFA
         ref_seq[got_seq_len] = '\0';

--- a/src/common/agc_index.hpp
+++ b/src/common/agc_index.hpp
@@ -43,16 +43,32 @@ inline bool is_agc_file(const std::string& filename) {
 namespace agcidx {
 
 /*
- * Reads one AGC archive. AGC's native identity is (sample, contig); wfmash only
- * ever knows a flat sequence name (the PAF query/target id, which for a PanSN
- * archive equals the contig name). We build an ordered (sample, contig) list and
- * a contig->sample map at open time so every flat name resolves to its sample.
+ * Reads one AGC archive. AGC's native identity is (sample, contig), while wfmash
+ * only ever knows a flat sequence name (the PAF query/target id). The mapping
+ * between the two must be one-to-one, so every record gets an external name:
+ *
+ *   - contig name unique across all samples -> the contig name itself (the usual
+ *     case for a PanSN archive, where names are already sample#hap#contig);
+ *   - contig name shared by several samples -> "contig@sample", which is AGC's own
+ *     query syntax, so the name still round-trips through `agc getctg`.
+ *
+ * Without this, an archive built the canonical AGC way (`agc create ref.fa in1.fa
+ * in2.fa`, one sample per file, plain chr names) would expose several records under
+ * the same name and every one of them would resolve to whichever sample was listed
+ * first, silently returning the wrong sequence.
  *
  * One AgcIndex owns one CAGCFile and is NOT shared between threads (the alignment
  * stage keeps one per thread, exactly like the per-thread faidx_t it replaces).
  */
 class AgcIndex {
 public:
+    // One archive record: the flat name wfmash sees, plus its AGC coordinates.
+    struct Record {
+        std::string name;
+        std::string sample;
+        std::string contig;
+    };
+
     AgcIndex() = default;
 
     AgcIndex(const AgcIndex&) = delete;
@@ -68,29 +84,47 @@ public:
 
         std::vector<std::string> samples;
         agc.ListSample(samples);
+
+        // Pass 1: collect (sample, contig) in archive order and count each contig name.
+        std::vector<std::pair<std::string, std::string>> raw;
+        std::unordered_map<std::string, size_t> contig_count;
         for (const auto& sample : samples) {
             std::vector<std::string> contigs;
             agc.ListCtg(sample, contigs);
             for (const auto& contig : contigs) {
-                ordered.emplace_back(sample, contig);
-                // First occurrence of a contig name wins (mirrors impg). For a
-                // PanSN archive every contig name is unique.
-                contig_to_sample.emplace(contig, sample);
+                raw.emplace_back(sample, contig);
+                ++contig_count[contig];
             }
+        }
+
+        // Pass 2: assign a unique external name to every record.
+        ordered.reserve(raw.size());
+        for (const auto& sc : raw) {
+            const std::string& sample = sc.first;
+            const std::string& contig = sc.second;
+            std::string name = contig_count[contig] > 1 ? contig + "@" + sample : contig;
+            if (!name_to_index.emplace(name, ordered.size()).second) {
+                // Only reachable if the archive itself holds a contig literally named
+                // "x@y" that collides with a disambiguated name; bail out rather than
+                // serve the wrong sequence.
+                std::cerr << "[wfmash::agc] ERROR: duplicate sequence name '" << name
+                          << "' in " << filename << std::endl;
+                return false;
+            }
+            ordered.push_back(Record{std::move(name), sample, contig});
         }
         return true;
     }
 
     bool is_open() const { return opened; }
 
-    // (sample, contig) pairs in the archive's stored order.
-    const std::vector<std::pair<std::string, std::string>>& sample_contigs() const {
-        return ordered;
-    }
+    // Every record, in the archive's stored order.
+    const std::vector<Record>& records() const { return ordered; }
 
-    // Length of a contig by flat name; <0 if not found.
+    // Length of a sequence by its external name; <0 if unknown.
     int64_t length(const std::string& name) const {
-        return agc.GetCtgLen(sample_of(name), name);
+        const Record* rec = find(name);
+        return rec ? agc.GetCtgLen(rec->sample, rec->contig) : -1;
     }
 
     /*
@@ -100,14 +134,19 @@ public:
      * len_out receives the number of bases returned.
      */
     char* fetch_malloc(const std::string& name, int64_t start, int64_t end, int64_t& len_out) const {
-        const std::string& sample = sample_of(name);
-        const int64_t ctg_len = agc.GetCtgLen(sample, name);
+        const Record* rec = find(name);
+        if (rec == nullptr) {
+            std::cerr << "[wfmash::agc] ERROR: unknown sequence '" << name << "'" << std::endl;
+            std::exit(1);
+        }
+        const int64_t ctg_len = agc.GetCtgLen(rec->sample, rec->contig);
         if (start < 0) start = 0;
         if (ctg_len > 0 && end > ctg_len - 1) end = ctg_len - 1;
 
         std::string buffer;
         if (end >= start) {
-            agc.GetCtgSeq(sample, name, static_cast<int>(start), static_cast<int>(end), buffer);
+            agc.GetCtgSeq(rec->sample, rec->contig, static_cast<int>(start), static_cast<int>(end),
+                          buffer);
         }
 
         len_out = static_cast<int64_t>(buffer.size());
@@ -124,40 +163,43 @@ public:
         return out;
     }
 
-    // (contig name, length) for every contig, in archive order, using AGC metadata
+    // (external name, length) for every record, in archive order, using AGC metadata
     // only (GetCtgLen reads segment descriptors; it does NOT decompress the bases).
     // For the length-only code paths that otherwise decompress the whole archive.
     std::vector<std::pair<std::string, int64_t>> names_and_lengths() const {
         std::vector<std::pair<std::string, int64_t>> out;
         out.reserve(ordered.size());
-        for (const auto& sc : ordered) {
-            out.emplace_back(sc.second, agc.GetCtgLen(sc.first, sc.second));
+        for (const auto& rec : ordered) {
+            out.emplace_back(rec.name, agc.GetCtgLen(rec.sample, rec.contig));
         }
         return out;
     }
 
-    // Whole contig as a std::string (used by the sequence-enumeration callback).
+    // Whole sequence as a std::string (used by the sequence-enumeration callback).
     std::string fetch_string(const std::string& name) const {
-        const std::string& sample = sample_of(name);
-        const int64_t ctg_len = agc.GetCtgLen(sample, name);
+        const Record* rec = find(name);
         std::string buffer;
+        if (rec == nullptr) {
+            std::cerr << "[wfmash::agc] ERROR: unknown sequence '" << name << "'" << std::endl;
+            return buffer;
+        }
+        const int64_t ctg_len = agc.GetCtgLen(rec->sample, rec->contig);
         if (ctg_len > 0) {
-            agc.GetCtgSeq(sample, name, 0, static_cast<int>(ctg_len - 1), buffer);
+            agc.GetCtgSeq(rec->sample, rec->contig, 0, static_cast<int>(ctg_len - 1), buffer);
         }
         return buffer;
     }
 
 private:
-    const std::string& sample_of(const std::string& name) const {
-        auto it = contig_to_sample.find(name);
-        return it != contig_to_sample.end() ? it->second : empty_sample;
+    const Record* find(const std::string& name) const {
+        auto it = name_to_index.find(name);
+        return it != name_to_index.end() ? &ordered[it->second] : nullptr;
     }
 
     CAGCFile agc;
     bool opened = false;
-    std::vector<std::pair<std::string, std::string>> ordered;
-    std::unordered_map<std::string, std::string> contig_to_sample;
-    std::string empty_sample; // AGC resolves an empty sample by unique contig name
+    std::vector<Record> ordered;
+    std::unordered_map<std::string, size_t> name_to_index;
 };
 
 } // namespace agcidx

--- a/src/common/agc_index.hpp
+++ b/src/common/agc_index.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+/*
+ * Minimal wrapper around AGC's (Assembled Genomes Compressor) public C++ API
+ * (CAGCFile in agc-api.h) so wfmash can read sequences directly from a .agc
+ * archive with the same operations it uses on an htslib faidx:
+ *   - enumerate sequence names,
+ *   - query a sequence length by name,
+ *   - fetch a [start,end] (0-based, inclusive) range by name.
+ *
+ * The whole thing is compiled in only when the build links libagc
+ * (WFMASH_HAVE_AGC, set by CMake when the AGC tree is found). When it is not
+ * defined this header degrades to just is_agc_file(), and the callers'
+ * #ifdef WFMASH_HAVE_AGC branches are stripped, so wfmash still builds and
+ * behaves exactly as before on FASTA/FASTQ input.
+ */
+
+#include <string>
+
+namespace agcidx {
+
+// True if the path ends in ".agc". Always available (no AGC dependency).
+inline bool is_agc_file(const std::string& filename) {
+    const std::string suffix = ".agc";
+    return filename.size() >= suffix.size()
+        && filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+} // namespace agcidx
+
+#ifdef WFMASH_HAVE_AGC
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "agc-api.h"
+
+namespace agcidx {
+
+/*
+ * Reads one AGC archive. AGC's native identity is (sample, contig); wfmash only
+ * ever knows a flat sequence name (the PAF query/target id, which for a PanSN
+ * archive equals the contig name). We build an ordered (sample, contig) list and
+ * a contig->sample map at open time so every flat name resolves to its sample.
+ *
+ * One AgcIndex owns one CAGCFile and is NOT shared between threads (the alignment
+ * stage keeps one per thread, exactly like the per-thread faidx_t it replaces).
+ */
+class AgcIndex {
+public:
+    AgcIndex() = default;
+
+    AgcIndex(const AgcIndex&) = delete;
+    AgcIndex& operator=(const AgcIndex&) = delete;
+
+    // prefetch=false keeps memory low (segments decompressed on demand), which is
+    // what we want for both one-shot enumeration and per-thread random access.
+    bool open(const std::string& filename, bool prefetch = false) {
+        if (!agc.Open(filename, prefetch)) {
+            return false;
+        }
+        opened = true;
+
+        std::vector<std::string> samples;
+        agc.ListSample(samples);
+        for (const auto& sample : samples) {
+            std::vector<std::string> contigs;
+            agc.ListCtg(sample, contigs);
+            for (const auto& contig : contigs) {
+                ordered.emplace_back(sample, contig);
+                // First occurrence of a contig name wins (mirrors impg). For a
+                // PanSN archive every contig name is unique.
+                contig_to_sample.emplace(contig, sample);
+            }
+        }
+        return true;
+    }
+
+    bool is_open() const { return opened; }
+
+    // (sample, contig) pairs in the archive's stored order.
+    const std::vector<std::pair<std::string, std::string>>& sample_contigs() const {
+        return ordered;
+    }
+
+    // Length of a contig by flat name; <0 if not found.
+    int64_t length(const std::string& name) const {
+        return agc.GetCtgLen(sample_of(name), name);
+    }
+
+    /*
+     * Fetch bases [start, end], 0-based and INCLUSIVE, matching
+     * faidx_fetch_seq64. end is clamped to the last base and start floored at 0 so
+     * boundary requests behave identically to htslib (which silently clamps).
+     * len_out receives the number of bases returned.
+     */
+    char* fetch_malloc(const std::string& name, int64_t start, int64_t end, int64_t& len_out) const {
+        const std::string& sample = sample_of(name);
+        const int64_t ctg_len = agc.GetCtgLen(sample, name);
+        if (start < 0) start = 0;
+        if (ctg_len > 0 && end > ctg_len - 1) end = ctg_len - 1;
+
+        std::string buffer;
+        if (end >= start) {
+            agc.GetCtgSeq(sample, name, static_cast<int>(start), static_cast<int>(end), buffer);
+        }
+
+        len_out = static_cast<int64_t>(buffer.size());
+        // Match htslib: caller null-terminates at len_out and frees with free().
+        char* out = static_cast<char*>(std::malloc(len_out + 1));
+        if (out == nullptr) {
+            std::cerr << "[wfmash::agc] ERROR: out of memory fetching " << name << std::endl;
+            std::exit(1);
+        }
+        if (len_out > 0) {
+            std::memcpy(out, buffer.data(), static_cast<size_t>(len_out));
+        }
+        out[len_out] = '\0';
+        return out;
+    }
+
+    // (contig name, length) for every contig, in archive order, using AGC metadata
+    // only (GetCtgLen reads segment descriptors; it does NOT decompress the bases).
+    // For the length-only code paths that otherwise decompress the whole archive.
+    std::vector<std::pair<std::string, int64_t>> names_and_lengths() const {
+        std::vector<std::pair<std::string, int64_t>> out;
+        out.reserve(ordered.size());
+        for (const auto& sc : ordered) {
+            out.emplace_back(sc.second, agc.GetCtgLen(sc.first, sc.second));
+        }
+        return out;
+    }
+
+    // Whole contig as a std::string (used by the sequence-enumeration callback).
+    std::string fetch_string(const std::string& name) const {
+        const std::string& sample = sample_of(name);
+        const int64_t ctg_len = agc.GetCtgLen(sample, name);
+        std::string buffer;
+        if (ctg_len > 0) {
+            agc.GetCtgSeq(sample, name, 0, static_cast<int>(ctg_len - 1), buffer);
+        }
+        return buffer;
+    }
+
+private:
+    const std::string& sample_of(const std::string& name) const {
+        auto it = contig_to_sample.find(name);
+        return it != contig_to_sample.end() ? it->second : empty_sample;
+    }
+
+    CAGCFile agc;
+    bool opened = false;
+    std::vector<std::pair<std::string, std::string>> ordered;
+    std::unordered_map<std::string, std::string> contig_to_sample;
+    std::string empty_sample; // AGC resolves an empty sample by unique contig name
+};
+
+} // namespace agcidx
+
+#endif // WFMASH_HAVE_AGC

--- a/src/common/seqiter.hpp
+++ b/src/common/seqiter.hpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include "gzstream.h"
 #include <htslib/faidx.h>
+#include "agc_index.hpp"
 
 namespace seqiter {
 
@@ -20,6 +21,28 @@ void for_each_seq_in_file(
     const std::unordered_set<std::string>& keep_seq,
     const std::string& keep_prefix,
     const std::function<void(const std::string&, const std::string&)>& func) {
+
+#ifdef WFMASH_HAVE_AGC
+    if (agcidx::is_agc_file(filename)) {
+        agcidx::AgcIndex agc;
+        if (!agc.open(filename)) {
+            std::cerr << "[wfmash::for_each_seq_in_file] could not open AGC archive " << filename << std::endl;
+            exit(1);
+        }
+        for (const auto& sc : agc.sample_contigs()) {
+            const std::string& name = sc.second;
+            const bool keep =
+                (keep_prefix.empty() || name.compare(0, keep_prefix.size(), keep_prefix) == 0)
+                && (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
+            if (keep) {
+                func(name, agc.fetch_string(name));
+            } else {
+                func(name, "");
+            }
+        }
+        return;
+    }
+#endif
 
     if ((!keep_seq.empty() || !keep_prefix.empty())
           && fai_index_exists(filename)) {
@@ -125,6 +148,31 @@ void for_each_seq_in_file_filtered(
     const std::vector<std::string>& query_prefix,
     const std::unordered_set<std::string>& query_list,
     const std::function<void(const std::string&, const std::string&)>& func) {
+
+#ifdef WFMASH_HAVE_AGC
+    if (agcidx::is_agc_file(filename)) {
+        agcidx::AgcIndex agc;
+        if (!agc.open(filename)) {
+            std::cerr << "[wfmash::for_each_seq_in_file_filtered] could not open AGC archive " << filename << std::endl;
+            return;
+        }
+        for (const auto& sc : agc.sample_contigs()) {
+            const std::string& name = sc.second;
+            bool prefix_ok = query_prefix.empty();
+            for (const auto& prefix : query_prefix) {
+                if (name.compare(0, prefix.size(), prefix) == 0) {
+                    prefix_ok = true;
+                    break;
+                }
+            }
+            if (!prefix_ok) continue;
+            if (!query_list.empty() && query_list.count(name) == 0) continue;
+            func(name, agc.fetch_string(name));
+        }
+        return;
+    }
+#endif
+
     faidx_t* fai = fai_load(filename.c_str());
     if (fai == nullptr) {
         std::cerr << "Error: Failed to load FASTA index for file " << filename << std::endl;

--- a/src/common/seqiter.hpp
+++ b/src/common/seqiter.hpp
@@ -29,8 +29,8 @@ void for_each_seq_in_file(
             std::cerr << "[wfmash::for_each_seq_in_file] could not open AGC archive " << filename << std::endl;
             exit(1);
         }
-        for (const auto& sc : agc.sample_contigs()) {
-            const std::string& name = sc.second;
+        for (const auto& rec : agc.records()) {
+            const std::string& name = rec.name;
             const bool keep =
                 (keep_prefix.empty() || name.compare(0, keep_prefix.size(), keep_prefix) == 0)
                 && (keep_seq.empty() || keep_seq.find(name) != keep_seq.end());
@@ -156,8 +156,8 @@ void for_each_seq_in_file_filtered(
             std::cerr << "[wfmash::for_each_seq_in_file_filtered] could not open AGC archive " << filename << std::endl;
             return;
         }
-        for (const auto& sc : agc.sample_contigs()) {
-            const std::string& name = sc.second;
+        for (const auto& rec : agc.records()) {
+            const std::string& name = rec.name;
             bool prefix_ok = query_prefix.empty();
             for (const auto& prefix : query_prefix) {
                 if (name.compare(0, prefix.size(), prefix) == 0) {

--- a/src/interface/main.cpp
+++ b/src/interface/main.cpp
@@ -29,6 +29,7 @@
 //External includes
 #include "common/args.hxx"
 #include "common/ALeS.hpp"
+#include "common/agc_index.hpp"
 
 int main(int argc, char** argv) {
     /*
@@ -107,7 +108,21 @@ int main(int argc, char** argv) {
                     const uint64_t seq_len = std::stoull(line_split[1]);
                     seqName_to_seqCounterAndLen[seq_name] = std::make_pair(seqCounter++,  seq_len);
                 }
-            } else {
+            }
+#ifdef WFMASH_HAVE_AGC
+            else if (agcidx::is_agc_file(fileName)) {
+                // AGC: get lengths from archive metadata (GetCtgLen), without decompressing sequences
+                agcidx::AgcIndex agc;
+                if (!agc.open(fileName)) {
+                    std::cerr << "[wfmash::align] ERROR: could not open AGC archive " << fileName << std::endl;
+                    exit(1);
+                }
+                for (const auto& nl : agc.names_and_lengths()) {
+                    seqName_to_seqCounterAndLen[nl.first] = std::make_pair(seqCounter++, (uint64_t)nl.second);
+                }
+            }
+#endif
+            else {
                 // if not, warn that this is expensive
                 std::cerr << "[wfmash::align] WARNING, no .fai index found for " << fileName << ", reading the file to sort the mappings (slow)" << std::endl;
                 for(const auto &fileName : map_parameters.querySequences)
@@ -180,7 +195,21 @@ int main(int argc, char** argv) {
                     const uint64_t seq_len = std::stoull(line_split[1]);
                     outstrm << "@SQ\tSN:" << seq_name << "\tLN:" << seq_len << "\n";
                 }
-            } else {
+            }
+#ifdef WFMASH_HAVE_AGC
+            else if (agcidx::is_agc_file(fileName)) {
+                // AGC: emit @SQ lengths from archive metadata (GetCtgLen), no decompression
+                agcidx::AgcIndex agc;
+                if (!agc.open(fileName)) {
+                    std::cerr << "[wfmash::align] ERROR: could not open AGC archive " << fileName << std::endl;
+                    exit(1);
+                }
+                for (const auto& nl : agc.names_and_lengths()) {
+                    outstrm << "@SQ\tSN:" << nl.first << "\tLN:" << nl.second << "\n";
+                }
+            }
+#endif
+            else {
                 // if not, warn that this is expensive
                 std::cerr << "[wfmash::align] WARNING, no .fai index found for " << fileName << ", reading the file to prepare SAM header (slow)" << std::endl;
                 seqiter::for_each_seq_in_file(

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -527,7 +527,32 @@ namespace skch
 					total_seqs++;
 					total_seq_length += std::stoul(line_split[1]);
 				}
-			} else {
+			}
+#ifdef WFMASH_HAVE_AGC
+			else if (agcidx::is_agc_file(fileName)) {
+				// AGC: count sequences / sum lengths from metadata (GetCtgLen), no decompression
+				agcidx::AgcIndex agc;
+				if (!agc.open(fileName)) {
+					std::cerr << "[mashmap::skch::Map::mapQuery] ERROR: could not open AGC archive " << fileName << std::endl;
+					exit(1);
+				}
+				for (const auto& nl : agc.names_and_lengths()) {
+					const std::string& seq_name = nl.first;
+					if (!param.query_prefix.empty()) {
+						bool prefix_match = false;
+						for (const auto& prefix : param.query_prefix) {
+							if (seq_name.substr(0, prefix.size()) == prefix) { prefix_match = true; break; }
+						}
+						if (!prefix_match) continue;
+					}
+					if (!allowed_query_names.empty()
+						&& allowed_query_names.find(seq_name) == allowed_query_names.end()) continue;
+					++total_seqs;
+					total_seq_length += nl.second;
+				}
+			}
+#endif
+			else {
 				// If .fai file doesn't exist, warn and use the for_each_seq_in_file_filtered function
 				std::cerr << "[mashmap::skch::Map::mapQuery] WARNING, no .fai index found for " << fileName << ", reading the file to filter query sequences (slow)" << std::endl;
 				seqiter::for_each_seq_in_file_filtered(


### PR DESCRIPTION
Adds native support for reading sequences directly from an AGC (`.agc`) archive wherever wfmash takes a FASTA, by linking libagc (the `CAGCFile` C++ API).

- `seqiter` enumerates and loads contigs from the archive (covers the mapping stage's target/query load and the no-`.fai` length fallbacks).
- The alignment stage fetches reference subranges through a per-thread AGC reader in place of htslib faidx. `GetCtgSeq` uses the same 0-based inclusive-end convention as `faidx_fetch_seq64`, so it is coordinate-compatible.
- With no `.fai` (as for `.agc`), sequence lengths come from AGC metadata (`GetCtgLen`) instead of decompressing every contig.

AGC support auto-enables when the AGC source tree is found (`AGC_ROOT`, default sibling `../agc`, providing `bin/libagc.a` and `src/lib-cxx/agc-api.h`). Builds without it compile unchanged and simply do not accept `.agc`.

Verified byte-identical to FASTA: PAF identical on LPA and on yeast8 (96 Mbp, 1243 mappings) at `-t1` and with pggb's exact parameters. Runtime and memory are at parity with FASTA (userCPU and maxRSS match); the only AGC-specific cost is on-demand segment decompression.
