### PR TITLE
Use the first header token as the name of an AGC sequence

### DIFF
--- a/scripts/test_agc.sh
+++ b/scripts/test_agc.sh
@@ -32,6 +32,24 @@ else
     exit 1
 fi
 
+# AGC keeps the whole FASTA header line as the contig name, so an archive built from headers
+# that carry a description must still expose the sequences under their first token, the name
+# the FASTA reader and the PAF use.
+sed 's/^\(>[^ ]*\).*/\1 some description here/' "$tmp/seq.fa" > "$tmp/desc.fa"
+samtools faidx "$tmp/desc.fa"
+agc create -o "$tmp/desc.agc" "$tmp/desc.fa" > /dev/null 2>&1
+
+"$wfmash" "$tmp/desc.fa"  -t 1 "$@" 2>/dev/null | sort > "$tmp/desc_fa.paf"
+"$wfmash" "$tmp/desc.agc" -t 1 "$@" 2>/dev/null | sort > "$tmp/desc_agc.paf"
+
+if [ -s "$tmp/desc_fa.paf" ] && diff -q "$tmp/desc_fa.paf" "$tmp/desc_agc.paf" > /dev/null; then
+    echo "[test_agc] OK: headers with descriptions give identical output ($(wc -l < "$tmp/desc_fa.paf") mappings)"
+else
+    echo "[test_agc] FAIL: FASTA and AGC output differ when headers carry a description"
+    diff "$tmp/desc_fa.paf" "$tmp/desc_agc.paf" | head
+    exit 1
+fi
+
 # A multi-sample archive built the canonical AGC way (one sample per file, plain contig
 # names) repeats contig names across samples. Those records must stay distinct: each is
 # named contig@sample and must carry its own sample's bases. If they collapsed onto one

--- a/src/common/agc_index.hpp
+++ b/src/common/agc_index.hpp
@@ -85,15 +85,15 @@ public:
         std::vector<std::string> samples;
         agc.ListSample(samples);
 
-        // Pass 1: collect (sample, contig) in archive order and count each contig name.
+        // Pass 1: collect (sample, contig) in archive order and count each short name.
         std::vector<std::pair<std::string, std::string>> raw;
-        std::unordered_map<std::string, size_t> contig_count;
+        std::unordered_map<std::string, size_t> short_name_count;
         for (const auto& sample : samples) {
             std::vector<std::string> contigs;
             agc.ListCtg(sample, contigs);
             for (const auto& contig : contigs) {
                 raw.emplace_back(sample, contig);
-                ++contig_count[contig];
+                ++short_name_count[short_name(contig)];
             }
         }
 
@@ -102,7 +102,8 @@ public:
         for (const auto& sc : raw) {
             const std::string& sample = sc.first;
             const std::string& contig = sc.second;
-            std::string name = contig_count[contig] > 1 ? contig + "@" + sample : contig;
+            const std::string base = short_name(contig);
+            std::string name = short_name_count[base] > 1 ? base + "@" + sample : base;
             if (!name_to_index.emplace(name, ordered.size()).second) {
                 // Only reachable if the archive itself holds a contig literally named
                 // "x@y" that collides with a disambiguated name; bail out rather than
@@ -191,6 +192,15 @@ public:
     }
 
 private:
+    // AGC stores the whole FASTA header line as the contig name, so ">chr1 some description"
+    // comes back with its description attached. wfmash names a sequence by the first
+    // whitespace-delimited token (as htslib and the FASTA reader do), and its own PAF parser
+    // splits rows on whitespace, so the description must be dropped here too.
+    static std::string short_name(const std::string& contig) {
+        const size_t end = contig.find_first_of(" \t");
+        return end == std::string::npos ? contig : contig.substr(0, end);
+    }
+
     const Record* find(const std::string& name) const {
         auto it = name_to_index.find(name);
         return it != name_to_index.end() ? &ordered[it->second] : nullptr;


### PR DESCRIPTION
Follow-up to #400.

AGC stores the whole FASTA header line as the contig name, so an archive built from a FASTA whose headers carry a description (`>grch38#1#chr6 gi|568815592:32578768-32589835 Homo sapiens ...`, as in pggb's own `data/HLA/DRB1-3123.fa.gz`) exposed its sequences under names containing spaces.

wfmash names a sequence by its first whitespace-delimited token (htslib and the FASTA reader both do this), and `parseMashmapRow` splits its intermediate PAF rows on whitespace. A name with spaces therefore shifted every field: mapping reported hits (`count of mapped reads = 10`) but the alignment stage produced an empty PAF, and on some inputs aborted.

Sequence names now use the first token of the contig name, while AGC lookups keep the full stored contig name, so `GetCtgLen`/`GetCtgSeq` still resolve. Behaviour on headers without a description is unchanged.

`scripts/test_agc.sh` gains a check that builds an archive from headers carrying a description and requires identical output to the FASTA. Against the previous build that check exits 134 (abort); with this change the three checks pass, and the LPA and duplicate-contig-name cases are unaffected.
