### PR TITLE
fix: drop std::filesystem so pre-10.15 macOS still builds

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -35,9 +35,9 @@ jobs:
           bedtools
           cargo
       - name: Install wgatools
-        run: cargo install --git https://github.com/wjwei-handsome/wgatools.git
+        run: cargo install --locked --git https://github.com/wjwei-handsome/wgatools.git
       - name: Install pafcheck
-        run: cargo install --git https://github.com/ekg/pafcheck.git
+        run: cargo install --locked --git https://github.com/ekg/pafcheck.git
       - name: Init and update submodules
         run: git submodule update --init --recursive
       - name: Build wfmash
@@ -58,9 +58,9 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install wgatools
-        run: cargo install --git https://github.com/wjwei-handsome/wgatools.git
+        run: cargo install --locked --git https://github.com/wjwei-handsome/wgatools.git
       - name: Install pafcheck
-        run: cargo install --git https://github.com/ekg/pafcheck.git
+        run: cargo install --locked --git https://github.com/ekg/pafcheck.git
       - name: Init and update submodules
         run: git submodule update --init --recursive
       - name: Build wfmash

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -17,9 +17,7 @@
 #include <cassert>
 #include <numeric>
 #include <iostream>
-#include <filesystem>
 #include <map>
-namespace fs = std::filesystem;
 #include <queue>
 #include <algorithm>
 #include <unordered_set>
@@ -347,7 +345,7 @@ namespace skch
           }
 
           if (!param.indexFilename.empty() && !param.create_index_only) {
-              std::ifstream indexStream(param.indexFilename.string(), std::ios::binary);
+              std::ifstream indexStream(param.indexFilename, std::ios::binary);
               if (!indexStream) {
                   std::cerr << "Error: Unable to open index file for reading: " << param.indexFilename << std::endl;
                   exit(1);
@@ -400,7 +398,7 @@ namespace skch
               std::cerr << "[wfmash::mashmap] Processing subset " << (subset_idx + 1) 
                         << "/" << target_subsets.size() << " (mapping)" << std::endl;
               
-              std::string indexFilename = param.indexFilename.string();
+              std::string indexFilename = param.indexFilename;
               
               if (param.create_index_only) {
                   std::cerr << "[wfmash::mashmap] Processing subset " << (subset_idx + 1) 
@@ -430,7 +428,7 @@ namespace skch
 
               auto buildIndex_task = subset_flow->emplace([this, target_subset=target_subset, subset_idx, total_subsets=target_subsets.size()]() {
                   if (!param.indexFilename.empty()) {
-                      std::string indexFilename = param.indexFilename.string();
+                      std::string indexFilename = param.indexFilename;
                       static std::ifstream indexStream;
                       static bool index_opened = false;
                       static size_t file_subset_count = 0;

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -8,8 +8,6 @@
 
 #include <vector>
 #include <unordered_set>
-#include <filesystem>
-namespace stdfs = std::filesystem;
 
 #include "common/ALeS.hpp"
 #include "base_types.hpp"
@@ -52,7 +50,7 @@ struct Parameters
     std::vector<std::string> refSequences;            //reference sequence(s)
     std::vector<std::string> querySequences;          //query sequence(s)
     std::string outFileName;                          //output file name
-    stdfs::path indexFilename;                        //output file name of index
+    std::string indexFilename;                        //output file name of index
     bool overwrite_index = false;                     //overwrite index if it exists
     bool create_index_only = false;                   //only create index and exit
     bool split = false;                               //Split read mapping (done if this is true)

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -13,8 +13,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <filesystem>
-namespace fs = std::filesystem;
 
 //#include <zlib.h>
 
@@ -554,7 +552,7 @@ namespace skch
       void writeSketchTSV() 
       {
         std::ofstream outStream;
-        outStream.open(std::string(param.indexFilename) + ".tsv");
+        outStream.open(param.indexFilename + ".tsv");
         outStream << "seqId" << "\t" << "strand" << "\t" << "start" << "\t" << "end" << "\t" << "hash\n";
         for (auto& mi : this->minmerIndex) {
           outStream << mi.seqId << "\t" << std::to_string(mi.strand) << "\t" << mi.wpos << "\t" << mi.wpos_end << "\t" << mi.hash << "\n";
@@ -615,7 +613,7 @@ namespace skch
        */
       void writeIndex(const std::vector<std::string>& target_subset, const std::string& filename = "", bool append = false, size_t batch_idx = 0, size_t total_batches = 1) 
       {
-        fs::path indexFilename = filename.empty() ? fs::path(param.indexFilename) : fs::path(filename);
+        std::string indexFilename = filename.empty() ? param.indexFilename : filename;
         std::ofstream outStream;
         if (append) {
             outStream.open(indexFilename, std::ios::binary | std::ios::app);
@@ -664,7 +662,7 @@ namespace skch
        */
       void readSketchTSV() 
       {
-        io::CSVReader<5, io::trim_chars<' '>, io::no_quote_escape<'\t'>> inReader(std::string(param.indexFilename) + ".tsv");
+        io::CSVReader<5, io::trim_chars<' '>, io::no_quote_escape<'\t'>> inReader(param.indexFilename + ".tsv");
         inReader.read_header(io::ignore_missing_column, "seqId", "strand", "start", "end", "hash");
         hash_t hash;
         offset_t start, end;


### PR DESCRIPTION
Building wfmash under conda for osx-64 fails:

```
map_parameters.hpp:55: error: 'path' is unavailable: introduced in macOS 10.15
    stdfs::path indexFilename;
```

Apple marks `std::filesystem` available only from macOS 10.15, and the conda osx-64 toolchain targets an older deployment target. The alternative is pinning every downstream packager to 10.15+.

`indexFilename` is only ever concatenated with a suffix, tested with `empty()`, or handed to an `ofstream`. `std::string` covers all three, so the three `<filesystem>` includes and the two namespace aliases go away.

7 insertions, 13 deletions. The same change is applied to the vendored copy in pangenome/wfmash-rs, where wfmash builds and maps correctly afterwards: 7 reads and 4.5 Mbp aligned on yeast chrV.