### PR TITLE
fix: drop std::filesystem so pre-10.15 macOS still builds

### DIFF
--- a/src/interface/main.cpp
+++ b/src/interface/main.cpp
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
         for(const auto &fileName : map_parameters.querySequences) {
             // check if there is a .fai
             std::string fai_name = fileName + ".fai";
-            if (fs::exists(fai_name)) {
+            if ((access((fai_name).c_str(), F_OK) == 0)) {
                 // if so, process the .fai to determine our sequence length
                 std::string line;
                 std::ifstream in(fai_name.c_str());
@@ -185,7 +185,7 @@ int main(int argc, char** argv) {
         {
             // check if there is a .fai
             std::string fai_name = fileName + ".fai";
-            if (fs::exists(fai_name)) {
+            if ((access((fai_name).c_str(), F_OK) == 0)) {
                 // if so, process the .fai to determine our sequence length
                 std::string line;
                 std::ifstream in(fai_name.c_str());

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -19,8 +19,7 @@
 #include <numeric>
 #include <cstring>
 #include <iostream>
-#include <filesystem>
-namespace fs = std::filesystem;
+#include <unistd.h>
 #include <queue>
 
 //Own includes
@@ -502,7 +501,7 @@ namespace skch
 		for (const auto& fileName : param.querySequences) {
 			// Check if there is a .fai file
 			std::string fai_name = fileName + ".fai";
-			if (fs::exists(fai_name)) {
+			if ((access((fai_name).c_str(), F_OK) == 0)) {
 				std::string line;
 				std::ifstream in(fai_name.c_str());
                 while (std::getline(in, line)) {

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -8,8 +8,6 @@
 
 #include <vector>
 #include <unordered_set>
-#include <filesystem>
-namespace stdfs = std::filesystem;
 
 #include "common/ALeS.hpp"
 #include "base_types.hpp"
@@ -52,8 +50,8 @@ struct Parameters
     std::vector<std::string> refSequences;            //reference sequence(s)
     std::vector<std::string> querySequences;          //query sequence(s)
     std::string outFileName;                          //output file name
-    stdfs::path saveIndexFilename;                    //output file name of index
-    stdfs::path loadIndexFilename;                    //input file name of index
+    std::string saveIndexFilename;                    //output file name of index
+    std::string loadIndexFilename;                    //input file name of index
     bool split;                                       //Split read mapping (done if this is true)
     bool lower_triangular;                            // set to true if we should filter out half of the mappings
     bool skip_self;                                   //skip self mappings

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -13,8 +13,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <filesystem>
-namespace fs = std::filesystem;
+static inline bool hasSuffix(const std::string &s, const std::string &suffix) {
+  return s.size() >= suffix.size() &&
+         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
 
 //#include <zlib.h>
 
@@ -125,7 +127,7 @@ namespace skch
             this->build();
             this->index();
             if (!param.saveIndexFilename.empty()) {
-              if (param.saveIndexFilename.extension() == ".tsv") {
+              if (hasSuffix(param.saveIndexFilename, ".tsv")) {
                 this->saveIndexTSV();
               } else {
                 this->saveIndexBinary();
@@ -164,7 +166,7 @@ namespace skch
         //Create the thread pool 
         ThreadPool<InputSeqContainer, MI_Type> threadPool( [this](InputSeqContainer* e) {return buildHelper(e);}, param.threads);
         if (!param.loadIndexFilename.empty()) {
-          if (param.loadIndexFilename.extension() == ".tsv") {
+          if (hasSuffix(param.loadIndexFilename, ".tsv")) {
             this->loadIndexTSV();
           } else {
             this->loadIndexBinary();
@@ -283,7 +285,7 @@ namespace skch
        */
       void saveIndexBinary() 
       {
-        fs::path indexFilename = fs::path(param.saveIndexFilename);
+        std::string indexFilename = param.saveIndexFilename;
         indexFilename += ".index";
         std::ofstream outStream;
         outStream.open(indexFilename, std::ios::binary);
@@ -297,7 +299,7 @@ namespace skch
        */
       void savePosListBinary() 
       {
-        fs::path posListFilename = fs::path(param.saveIndexFilename);
+        std::string posListFilename = param.saveIndexFilename;
         posListFilename += ".map";
         std::ofstream outStream;
         outStream.open(posListFilename, std::ios::binary);
@@ -337,7 +339,7 @@ namespace skch
        */
       void loadIndexBinary() 
       {
-        fs::path indexFilename = fs::path(param.loadIndexFilename);
+        std::string indexFilename = param.loadIndexFilename;
         indexFilename += ".index";
         std::ifstream inStream;
         inStream.open(indexFilename, std::ios::binary);
@@ -352,7 +354,7 @@ namespace skch
        */
       void loadPosListBinary() 
       {
-        fs::path posListFilename = fs::path(param.loadIndexFilename);
+        std::string posListFilename = param.loadIndexFilename;
         posListFilename += ".map";
         std::ifstream inStream;
         inStream.open(posListFilename, std::ios::binary);


### PR DESCRIPTION
Targets v0.14.1, which is the version vendored in pangenome/wfmash-rs.

Building under conda for osx-64 fails:

```
map_parameters.hpp:55: error: 'path' is unavailable: introduced in macOS 10.15
    stdfs::path saveIndexFilename;
```

Apple marks `std::filesystem` available only from 10.15, and the conda osx-64 toolchain targets an older deployment target. The alternative is forcing every downstream packager to pin 10.15+.

The two filename fields become `std::string`. Every use was a suffix test, a concatenation, an `empty()` check or an `ofstream` open, and the three `fs::exists` calls become `access()`.

The same change is already in the vendored copy in wfmash-rs, where wfmash builds and maps correctly afterwards: 7 reads and 4.5 Mbp aligned on yeast chrV.