### PR TITLE
fix: drop the template keyword where there is no argument list

### DIFF
--- a/src/common/atomic_queue/atomic_queue.h
+++ b/src/common/atomic_queue/atomic_queue.h
@@ -393,13 +393,13 @@ class AtomicQueue2 : public AtomicQueueCommon<AtomicQueue2<T, SIZE, MINIMIZE_CON
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail % size_);
-        return Base::template do_pop_any(states_[index], elements_[index]);
+        return Base::do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head % size_);
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
 public:
@@ -521,13 +521,13 @@ class AtomicQueueB2 : public AtomicQueueCommon<AtomicQueueB2<T, A, MAXIMIZE_THRO
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail & (size_ - 1));
-        return Base::template do_pop_any(states_[index], elements_[index]);
+        return Base::do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head & (size_ - 1));
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
 public:


### PR DESCRIPTION
clang 19 rejects four uses in `atomic_queue.h`:

```
atomic_queue.h:396: error: a template argument list is expected after a name
prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
    return Base::template do_pop_any(states_[index], elements_[index]);
```

`do_pop_any` and `do_push_any` take no template arguments, so the keyword is wrong there. GCC accepts it, which is why it only appears on clang. It broke the conda osx-arm64 build, where no Homebrew GCC exists and clang is used.

The four sites that do pass arguments, such as `do_pop_atomic<T, NIL>`, are left alone.